### PR TITLE
feat: Disco Activity stats in admin dashboard

### DIFF
--- a/app/admin/AdminClient.tsx
+++ b/app/admin/AdminClient.tsx
@@ -42,6 +42,27 @@ interface CronJob {
   consecutiveErrors?: number;
 }
 
+interface DiscoActivityData {
+  lastRunAtMs: number | null;
+  lastRunStatus: string | null;
+  lastJobName: string | null;
+  runsToday: number;
+  placesScannedToday: number;
+  discoveriesToday: number;
+  changesDetectedToday: number;
+  errorsToday: number;
+  errorDetails: string[];
+  jobs: Array<{
+    id: string;
+    name: string;
+    enabled: boolean;
+    lastRun: number | null;
+    lastStatus: string | null;
+    consecutiveErrors: number;
+    lastError: string | null;
+  }>;
+}
+
 interface TokenData {
   total24h: number;
   hourly: Array<{ hour: string; tokens: number }>;
@@ -153,17 +174,19 @@ export default function AdminClient() {
   const [crons, setCrons] = useState<CronJob[]>([]);
   const [tokenData, setTokenData] = useState<TokenData | null>(null);
   const [users, setUsers] = useState<UserWithData[]>([]);
+  const [discoActivity, setDiscoActivity] = useState<DiscoActivityData | null>(null);
   const [loading, setLoading] = useState(true);
   const [expandedUsers, setExpandedUsers] = useState<Set<string>>(new Set());
   const [activeTab, setActiveTab] = useState<AdminTab>('overview');
 
   const load = useCallback(async () => {
     try {
-      const [agentsRes, cronsRes, tokensRes, usersRes] = await Promise.all([
+      const [agentsRes, cronsRes, tokensRes, usersRes, discoRes] = await Promise.all([
         fetch('/api/admin/agents'),
         fetch('/api/admin/crons'),
         fetch('/api/admin/tokens'),
         fetch('/api/admin/users'),
+        fetch('/api/admin/disco'),
       ]);
       if (agentsRes.ok) {
         const data = await agentsRes.json();
@@ -173,6 +196,7 @@ export default function AdminClient() {
       if (cronsRes.ok) setCrons((await cronsRes.json()).jobs || []);
       if (tokensRes.ok) setTokenData(await tokensRes.json());
       if (usersRes.ok) setUsers((await usersRes.json()).users || []);
+      if (discoRes.ok) setDiscoActivity(await discoRes.json());
     } catch {
       // silent
     } finally {
@@ -380,6 +404,113 @@ export default function AdminClient() {
             );
           })()}
         </div>
+      </Section>
+
+      {/* ---- Disco Activity ---- */}
+      <Section title="Disco Activity" emoji="🔍">
+        {discoActivity ? (
+          <div>
+            {/* Key metrics row */}
+            <div className="health-stats" style={{ marginBottom: 'var(--space-md)' }}>
+              <div className="health-stat-card">
+                <strong style={{ color: discoActivity.lastRunStatus === 'error' ? '#f44336' : 'var(--text-primary)' }}>
+                  {formatRelativeTime(discoActivity.lastRunAtMs)}
+                </strong>
+                <span>Last Run</span>
+              </div>
+              <div className="health-stat-card">
+                <strong>{discoActivity.runsToday}</strong>
+                <span>Runs Today</span>
+              </div>
+              <div className="health-stat-card">
+                <strong>{discoActivity.placesScannedToday}</strong>
+                <span>Places Found</span>
+              </div>
+              <div className="health-stat-card">
+                <strong style={{ color: discoActivity.discoveriesToday > 0 ? '#22c55e' : 'var(--text-primary)' }}>
+                  {discoActivity.discoveriesToday}
+                </strong>
+                <span>Pushed Today</span>
+              </div>
+              <div className="health-stat-card">
+                <strong>{discoActivity.changesDetectedToday}</strong>
+                <span>Changes</span>
+              </div>
+              <div className="health-stat-card">
+                <strong style={{ color: discoActivity.errorsToday > 0 ? '#f44336' : 'var(--text-muted)' }}>
+                  {discoActivity.errorsToday}
+                </strong>
+                <span>Errors</span>
+              </div>
+            </div>
+
+            {/* Last run detail */}
+            {discoActivity.lastJobName && (
+              <div style={{ fontSize: '0.8rem', color: 'var(--text-muted)', marginBottom: discoActivity.errorDetails.length > 0 ? 'var(--space-sm)' : 0 }}>
+                Last: <span style={{ color: 'var(--text-secondary)' }}>{discoActivity.lastJobName}</span>
+                {discoActivity.lastRunStatus && (
+                  <span style={{
+                    marginLeft: 8,
+                    color: discoActivity.lastRunStatus === 'ok' ? '#22c55e' : '#f44336',
+                    fontWeight: 500,
+                  }}>
+                    {discoActivity.lastRunStatus === 'ok' ? '✓' : '✗'} {discoActivity.lastRunStatus}
+                  </span>
+                )}
+              </div>
+            )}
+
+            {/* Error details */}
+            {discoActivity.errorDetails.length > 0 && (
+              <div style={{
+                marginTop: 'var(--space-sm)',
+                padding: '8px 12px',
+                background: 'rgba(244, 67, 54, 0.08)',
+                borderLeft: '3px solid #f44336',
+                borderRadius: 4,
+                fontSize: '0.78rem',
+                color: '#f44336',
+              }}>
+                {discoActivity.errorDetails.map((e, i) => <div key={i}>{e}</div>)}
+              </div>
+            )}
+
+            {/* Per-job mini table */}
+            {discoActivity.jobs.length > 0 && (
+              <div style={{ marginTop: 'var(--space-md)', overflowX: 'auto' }}>
+                <table className="cron-table">
+                  <thead>
+                    <tr>
+                      <th style={{ width: 20 }}></th>
+                      <th style={{ textAlign: 'left' }}>Job</th>
+                      <th>Last Run</th>
+                      <th>Errs</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {discoActivity.jobs.map(job => {
+                      const statusIcon = !job.lastStatus ? '⚪'
+                        : job.consecutiveErrors > 0 ? '🔴'
+                        : job.lastStatus === 'ok' ? '🟢' : '🟡';
+                      return (
+                        <tr key={job.id}>
+                          <td style={{ textAlign: 'center', fontSize: '0.75rem' }}>{statusIcon}</td>
+                          <td style={{ fontSize: '0.8rem', color: 'var(--text-primary)' }}>{job.name}</td>
+                          <td style={{ fontSize: '0.78rem', color: 'var(--text-muted)' }}>{formatRelativeTime(job.lastRun)}</td>
+                          <td style={{ textAlign: 'center', fontSize: '0.78rem', color: job.consecutiveErrors > 0 ? '#f44336' : 'var(--text-muted)' }}>
+                            {job.consecutiveErrors > 0 ? job.consecutiveErrors : '—'}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        ) : (
+          <p className="text-muted" style={{ fontSize: '0.85rem' }}>Disco data unavailable</p>
+        )}
       </Section>
 
       {/* ---- Token Usage (hourly chart) ---- */}

--- a/app/api/admin/disco/route.ts
+++ b/app/api/admin/disco/route.ts
@@ -1,0 +1,209 @@
+/* ============================================================
+   Admin API — Disco Activity Stats (Issue #91)
+   Returns Disco operational data: last run, scans today,
+   discoveries pushed today, place changes, errors.
+   ============================================================ */
+
+import { NextResponse } from 'next/server';
+import { getCurrentUser, getAllUsers } from '../../../_lib/user';
+import { getUserDiscoveries } from '../../../_lib/user-data';
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+
+export const dynamic = 'force-dynamic';
+
+function homeDir(): string {
+  return process.env.HOME || '/Users/john';
+}
+
+interface CronJob {
+  id: string;
+  name: string;
+  agentId?: string;
+  enabled: boolean;
+  state?: {
+    lastRunAtMs?: number;
+    lastRunStatus?: string;
+    lastStatus?: string;
+    consecutiveErrors?: number;
+    lastError?: string;
+    lastErrorReason?: string;
+  };
+}
+
+interface RunEntry {
+  ts: number;
+  jobId: string;
+  action: string;
+  status: string;
+  summary?: string;
+  runAtMs?: number;
+  durationMs?: number;
+}
+
+/** Disco-related job name patterns */
+const DISCO_JOB_PATTERNS = [
+  'discovery',
+  'disco',
+  'delta monitor',
+  'source scout',
+];
+
+function isDiscoJob(job: CronJob): boolean {
+  const name = job.name.toLowerCase();
+  return DISCO_JOB_PATTERNS.some(p => name.includes(p));
+}
+
+function readRunLog(jobId: string): RunEntry[] {
+  const p = path.join(homeDir(), '.openclaw', 'cron', 'runs', `${jobId}.jsonl`);
+  if (!existsSync(p)) return [];
+  try {
+    return readFileSync(p, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .map(line => JSON.parse(line) as RunEntry);
+  } catch {
+    return [];
+  }
+}
+
+function isTodayET(tsMs: number): boolean {
+  const now = new Date();
+  const entryDate = new Date(tsMs);
+  // Compare in Eastern time
+  const etOpts: Intl.DateTimeFormatOptions = { timeZone: 'America/Toronto', year: 'numeric', month: '2-digit', day: '2-digit' };
+  return (
+    new Intl.DateTimeFormat('en-CA', etOpts).format(now) ===
+    new Intl.DateTimeFormat('en-CA', etOpts).format(entryDate)
+  );
+}
+
+/** Count VERIFIED finds in a summary text (common pattern: "VERIFIED finds\n- X\n- Y") */
+function countVerifiedInSummary(summary: string): number {
+  // Match lines like "- PlaceName" that follow a VERIFIED header
+  const verifiedSection = summary.match(/VERIFIED finds?\s*[:\n]([\s\S]*?)(?:Leads pending|Next actions|$)/i);
+  if (!verifiedSection || !verifiedSection[1]) return 0;
+  const lines = verifiedSection[1].split('\n').filter(l => /^[-•*]\s+\S/.test(l.trim()));
+  // Exclude "None this run" lines
+  return lines.filter(l => !/none\s+this\s+run/i.test(l)).length;
+}
+
+/** Extract place change info from Delta Monitor summaries */
+function extractChangesFromSummary(summary: string): { movers: number; closures: number; openings: number } {
+  let movers = 0, closures = 0, openings = 0;
+  const moverMatch = summary.match(/(\d+)\s+mover/i);
+  if (moverMatch?.[1]) movers = parseInt(moverMatch[1]);
+  const closureMatch = summary.match(/(\d+)\s+closure/i);
+  if (closureMatch?.[1]) closures = parseInt(closureMatch[1]);
+  const openingMatch = summary.match(/(\d+)\s+(?:new\s+)?opening/i);
+  if (openingMatch?.[1]) openings = parseInt(openingMatch[1]);
+  return { movers, closures, openings };
+}
+
+export async function GET() {
+  const currentUser = await getCurrentUser();
+  if (!currentUser || !currentUser.isOwner) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // --- Load cron jobs ---
+  const cronPath = path.join(homeDir(), '.openclaw', 'cron', 'jobs.json');
+  let allJobs: CronJob[] = [];
+  if (existsSync(cronPath)) {
+    try {
+      const cronFile = JSON.parse(readFileSync(cronPath, 'utf-8'));
+      allJobs = cronFile.jobs || [];
+    } catch { /* ignore */ }
+  }
+
+  const discoJobs = allJobs.filter(isDiscoJob);
+
+  // --- Find last cron run across all Disco jobs ---
+  let lastRunAtMs: number | null = null;
+  let lastRunStatus: string | null = null;
+  let lastJobName: string | null = null;
+
+  for (const job of discoJobs) {
+    const ts = job.state?.lastRunAtMs;
+    if (ts && (!lastRunAtMs || ts > lastRunAtMs)) {
+      lastRunAtMs = ts;
+      lastRunStatus = job.state?.lastRunStatus || job.state?.lastStatus || null;
+      lastJobName = job.name;
+    }
+  }
+
+  // --- Scan today's run logs ---
+  let runsToday = 0;
+  let errorsToday = 0;
+  let placesScannedToday = 0;
+  let changesDetectedToday = 0;
+  const errorDetails: string[] = [];
+
+  for (const job of discoJobs) {
+    const runs = readRunLog(job.id);
+    const todayRuns = runs.filter(r => r.ts && isTodayET(r.ts));
+
+    runsToday += todayRuns.length;
+
+    for (const run of todayRuns) {
+      if (run.status === 'error' || run.status === 'timeout') {
+        errorsToday++;
+        const errMsg = `${job.name}: ${run.status}`;
+        if (!errorDetails.includes(errMsg)) errorDetails.push(errMsg);
+      }
+
+      if (run.summary) {
+        // Count verified discoveries from discovery jobs
+        const isDiscoveryJob = job.name.toLowerCase().includes('discovery') ||
+          job.name.toLowerCase().includes('source scout');
+        if (isDiscoveryJob) {
+          placesScannedToday += countVerifiedInSummary(run.summary);
+        }
+        // Count changes from delta monitor
+        if (job.name.toLowerCase().includes('delta monitor') || job.name.toLowerCase().includes('disco places')) {
+          const { movers, closures, openings } = extractChangesFromSummary(run.summary);
+          changesDetectedToday += movers + closures + openings;
+        }
+      }
+    }
+  }
+
+  // --- Count discoveries pushed today (from user Blob) ---
+  let discoveriesToday = 0;
+  try {
+    const users = getAllUsers();
+    const allDiscoveries = await Promise.all(users.map(u => getUserDiscoveries(u.id)));
+    for (const ud of allDiscoveries) {
+      if (!ud?.discoveries) continue;
+      for (const d of ud.discoveries) {
+        if (d.discoveredAt && isTodayET(new Date(d.discoveredAt).getTime())) {
+          discoveriesToday++;
+        }
+      }
+    }
+  } catch { /* Blob unavailable in dev */ }
+
+  // --- Build job summary for UI ---
+  const jobSummary = discoJobs.map(job => ({
+    id: job.id,
+    name: job.name,
+    enabled: job.enabled,
+    lastRun: job.state?.lastRunAtMs || null,
+    lastStatus: job.state?.lastRunStatus || job.state?.lastStatus || null,
+    consecutiveErrors: job.state?.consecutiveErrors || 0,
+    lastError: job.state?.lastError || null,
+  }));
+
+  return NextResponse.json({
+    lastRunAtMs,
+    lastRunStatus,
+    lastJobName,
+    runsToday,
+    placesScannedToday,
+    discoveriesToday,
+    changesDetectedToday,
+    errorsToday,
+    errorDetails,
+    jobs: jobSummary,
+  });
+}


### PR DESCRIPTION
## What

Adds a **Disco Activity** section to the admin Overview tab, surfacing Disco's day-to-day operational data without requiring new external API endpoints.

## Changes

### New: `/api/admin/disco` route
- Reads `~/.openclaw/cron/jobs.json` to find all Disco-related cron jobs (discovery, delta monitor, source scout)
- Parses `~/.openclaw/cron/runs/<jobId>.jsonl` for today's run logs
- Counts verified finds from run summaries (regex on "VERIFIED finds" sections)
- Extracts place changes from Delta Monitor summaries
- Fetches user Blob discoveries and counts those added today

### Updated: `AdminClient.tsx`
- New `DiscoActivityData` interface
- Fetches `/api/admin/disco` alongside existing endpoints
- **Disco Activity** section in Overview tab (below Agent Health):
  - 6 stat cards: Last Run (relative), Runs Today, Places Found, Pushed Today, Changes, Errors
  - Per-job mini table with green/red/yellow status icons
  - Red error detail banner when errors are present

## Acceptance criteria
- [x] Disco last run time visible
- [x] Discovery push count for today
- [x] Shows in admin without requiring new API endpoints (reuses cron/Blob data)
- [x] TypeScript clean
- [x] Next.js build passes

Addresses issue #91