### PR TITLE
fix: #100 backfill missing place photos

### DIFF
--- a/scripts/fetch-missing-photos.mjs
+++ b/scripts/fetch-missing-photos.mjs
@@ -24,8 +24,14 @@ if (!GOOGLE_API_KEY) {
 
 // 1. Get list of place_ids that already have blob photos
 console.log('Listing existing Blob photos...');
-const { blobs: existingPhotos } = await list({ prefix: 'place-photos', limit: 2000 });
-const existingPathnames = new Set(existingPhotos.map(b => b.pathname));
+let allBlobs = [];
+let cursor;
+do {
+  const result = await list({ prefix: 'place-photos', limit: 1000, cursor });
+  allBlobs = allBlobs.concat(result.blobs);
+  cursor = result.cursor;
+} while (cursor);
+const existingPathnames = new Set(allBlobs.map(b => b.pathname));
 console.log(`Existing photo blobs: ${existingPathnames.size}`);
 
 // 2. Load discoveries
@@ -103,6 +109,7 @@ for (const d of toProcess) {
       access: 'public',
       addRandomSuffix: false,
       contentType: 'image/jpeg',
+      allowOverwrite: true,
     });
 
     // Update discovery heroImage


### PR DESCRIPTION
## Summary
- Fixed `fetch-missing-photos.mjs` to properly paginate blob listing (was limited to 1000 items)
- Added `allowOverwrite: true` to prevent duplicate key errors when uploading photos
- These fixes enable the script to fetch missing place photos from Google Places API

The script was run and successfully fetched photos for places with valid Google Places IDs. Some places return NOT_FOUND or INVALID_REQUEST errors because their Place IDs are no longer valid or they don't have photos in the Google Places API.

Addresses issue #100

## Test plan
- [ ] Verify the script runs without errors
- [ ] Check that new photos are uploaded to Vercel Blob
- [ ] Verify homepage shows photos instead of gradients for backfilled places

🤖 Generated with [Claude Code](https://claude.com/claude-code)