### PR TITLE
feat: break out DevClaw worker tokens in admin usage chart

### DIFF
--- a/app/admin/AdminClient.tsx
+++ b/app/admin/AdminClient.tsx
@@ -116,13 +116,14 @@ function shortModel(model: string | null): string {
   return model.replace(/^(anthropic|openai|google)\//, '');
 }
 
-const AGENT_NAMES: Record<string, string> = { main: 'Charlie', devclaw: 'DevClaw', disco: 'Disco', concierge: 'Concierge' };
+const AGENT_NAMES: Record<string, string> = { main: 'Charlie', devclaw: 'DevClaw', 'devclaw-workers': 'Workers', disco: 'Disco', concierge: 'Concierge' };
 const AGENT_COLORS: Record<string, string> = {
-  main:      '#6366f1',  // indigo — orchestrator
-  charlie:   '#6366f1',
-  devclaw:   '#f59e0b',  // amber — builder
-  disco:     '#22c55e',  // green — discovery
-  concierge: '#e879f9',  // fuchsia — chat
+  main:             '#6366f1',  // indigo — orchestrator
+  charlie:          '#6366f1',
+  devclaw:          '#f59e0b',  // amber — pipeline
+  'devclaw-workers':'#d97706',  // darker amber — worker subagents
+  disco:            '#22c55e',  // green — discovery
+  concierge:        '#e879f9',  // fuchsia — chat
 };
 const AGENT_ROLES: Record<string, string> = { main: 'Orchestrator', devclaw: 'Development', disco: 'Discovery & Research' };
 const AGENT_ORDER: Record<string, number> = { main: 0, devclaw: 1, disco: 2 };
@@ -407,7 +408,7 @@ export default function AdminClient() {
                   const isEmpty = h.tokens === 0;
                   const totalWidth = isEmpty ? 0 : Math.max((h.tokens / maxHourly) * 100, 2);
                   // Build stacked segments in agent order
-                  const agentOrder = ['main', 'devclaw', 'disco', 'concierge'];
+                  const agentOrder = ['main', 'devclaw', 'devclaw-workers', 'disco', 'concierge'];
                   const segments = agentOrder
                     .filter(a => (byAgent[a] ?? 0) > 0)
                     .map(a => ({

--- a/app/api/admin/tokens/route.ts
+++ b/app/api/admin/tokens/route.ts
@@ -15,10 +15,38 @@ interface UsageEntry {
   total: number;
 }
 
+/**
+ * Build a Set of session file UUIDs that belong to DevClaw worker subagents.
+ * We identify these by reading the main agent's sessions.json index and
+ * finding session keys matching /agent:main:subagent:/.
+ * This is fast (single JSON read) and avoids scanning JSONL content.
+ */
+function loadSubagentFileIds(): Set<string> {
+  const sessionsJsonPath = path.join(AGENTS_DIR, 'main', 'sessions', 'sessions.json');
+  const ids = new Set<string>();
+  try {
+    const raw = readFileSync(sessionsJsonPath, 'utf8');
+    const sessionsMap = JSON.parse(raw) as Record<string, { sessionId?: string; sessionFile?: string }>;
+    for (const [key, val] of Object.entries(sessionsMap)) {
+      if (!key.includes(':subagent:')) continue;
+      // sessionId is the UUID, or derive from sessionFile
+      const sessionId = val.sessionId
+        || (val.sessionFile ? path.basename(val.sessionFile, '.jsonl') : null);
+      if (sessionId) ids.add(sessionId);
+    }
+  } catch {
+    // If unavailable, return empty set (graceful degradation)
+  }
+  return ids;
+}
+
 function collectUsage(): UsageEntry[] {
   const entries: UsageEntry[] = [];
   const now = Date.now();
   const h24Ago = now - 24 * 3600000;
+
+  // Pre-load subagent UUID set once for the main agent directory
+  const subagentIds = loadSubagentFileIds();
 
   let agentDirs: string[];
   try {
@@ -41,6 +69,12 @@ function collectUsage(): UsageEntry[] {
     }
 
     for (const file of files) {
+      // Determine effective agent label:
+      // For the 'main' agent dir, re-label subagent session files as 'devclaw-workers'
+      const fileUuid = file.replace(/\.jsonl$/, '');
+      const effectiveAgent =
+        agentName === 'main' && subagentIds.has(fileUuid) ? 'devclaw-workers' : agentName;
+
       let content: string;
       try {
         content = readFileSync(path.join(sessionsDir, file), 'utf8');
@@ -61,7 +95,7 @@ function collectUsage(): UsageEntry[] {
 
           entries.push({
             ts,
-            agent: agentName,
+            agent: effectiveAgent,
             total:
               msg.usage.totalTokens ||
               msg.usage.total_tokens ||


### PR DESCRIPTION
## What

Splits DevClaw worker subagent token usage out of Charlie's bar in the admin token usage chart.

## Changes

### `app/api/admin/tokens/route.ts`
- New `loadSubagentFileIds()` function reads `~/.openclaw/agents/main/sessions/sessions.json` once to build a `Set<string>` of session file UUIDs whose session keys match `:subagent:`
- When iterating JSONL files in the `main` agent directory, re-labels any file whose UUID is in that set as `devclaw-workers` instead of `main`
- Fast: single JSON parse per request, no per-file header scanning
- Graceful: if sessions.json is unavailable, returns empty Set and falls back to existing behaviour

### `app/admin/AdminClient.tsx`
- `AGENT_NAMES`: added `'devclaw-workers': 'Workers'`
- `AGENT_COLORS`: added `'devclaw-workers': '#d97706'` (darker amber, distinct from DevClaw's `#f59e0b`)
- `agentOrder` in hourly bar chart: added `'devclaw-workers'` after `'devclaw'`
- Legend: auto-includes Workers since it iterates `AGENT_COLORS`

## Result
Stacked bar shows: 🔵 Charlie · 🟡 DevClaw · 🟠 Workers · 🟢 Disco · 🟣 Concierge

## Tests
- TypeScript: clean
- Build: passes
- Smoke test: 8/8

Addresses issue #114