### PR TITLE
feat: cottage review cards — card separation, shadow, rounded corners (#117)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5035,7 +5035,7 @@ body {
 .accomm-review-list {
   display: flex;
   flex-direction: column;
-  gap: var(--space-md);
+  gap: 0;
   min-width: 0;
 }
 
@@ -5068,17 +5068,19 @@ body {
 .accomm-card {
   display: flex;
   flex-direction: column;           /* VERTICAL now */
-  background: var(--card-bg);
+  background: #ffffff;
   border: 1px solid var(--card-border);
-  border-radius: var(--radius-md);
+  border-radius: 12px;
   overflow: hidden;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.10);
   transition: box-shadow var(--transition-base);
   max-width: 680px;
   width: 100%;
+  margin-bottom: 1.5rem;
 }
 
 .accomm-card:hover {
-  box-shadow: var(--card-shadow-hover);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.15);
 }
 
 .accomm-card-hero-link {


### PR DESCRIPTION
## Summary

Addresses issue #117

### Changes

- **Solid white background** on each card () instead of semi-transparent  so cards look like distinct tiles
- **Box shadow** added at resting state: `0 2px 12px rgba(0,0,0,0.10)` (hover elevated to `0 6px 24px rgba(0,0,0,0.15)`)
- **Border radius** explicitly set to `12px` (was already inheriting via var, now explicit)
- **margin-bottom: 1.5rem** added to each card for visible separation
- Removed `gap` from `.accomm-review-list` (card margin handles spacing now)

### Result
Each card now appears as a self-contained Hipcamp-style tile floating on the light grey page background (`#f8fafc`), with clear edges, rounded corners on the hero photo, and subtle drop shadow.