### PR TITLE
feat: Google Maps deep-link on every place card and discovery card

### DIFF
--- a/app/_components/AccommodationCard.tsx
+++ b/app/_components/AccommodationCard.tsx
@@ -189,6 +189,11 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
   // Listing URL
   const listingUrl = data.listing_url || data.url;
 
+  // Google Maps deep-link (only when placeId looks like a Google Place ID)
+  const googleMapsUrl = placeId && placeId.startsWith('ChIJ')
+    ? `https://www.google.com/maps/place/?q=place_id:${placeId}`
+    : null;
+
   // Match score
   const rawScores = data.scores as Record<string, number> | undefined;
   const matchScore = data.match_score ||
@@ -354,6 +359,16 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
               className="btn btn-primary accommodation-cta"
             >
               View Listing ↗
+            </a>
+          )}
+          {googleMapsUrl && (
+            <a
+              href={googleMapsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="accommodation-maps-link"
+            >
+              View in Google Maps →
             </a>
           )}
           {userId && contextKey && (

--- a/app/_components/PlaceCard.tsx
+++ b/app/_components/PlaceCard.tsx
@@ -64,7 +64,7 @@ export default function PlaceCard({ discovery, contextKey, userId }: PlaceCardPr
         {mapsUrl && (
           <div className="place-card-footer">
             <a href={mapsUrl} target="_blank" rel="noopener noreferrer" className="place-card-maps"
-              onClick={(e) => e.stopPropagation()}>↗ Maps</a>
+              onClick={(e) => e.stopPropagation()}>View in Google Maps →</a>
           </div>
         )}
       </Link>

--- a/app/_components/PlaceCardDetail.tsx
+++ b/app/_components/PlaceCardDetail.tsx
@@ -253,7 +253,7 @@ export default function PlaceCardDetail({ card, userId, contextKey }: PlaceCardD
 
   const googleMapsUrl = card.place_id
     ? `https://www.google.com/maps/place/?q=place_id:${card.place_id}`
-    : `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(card.name + ' ' + address)}`;
+    : null;
 
   // Photo gallery — exclude hero, categorize
   const foodPhotos = allImages.filter(i => ['food', 'drinks'].includes(i.category) && i !== heroImg);
@@ -301,6 +301,18 @@ export default function PlaceCardDetail({ card, userId, contextKey }: PlaceCardD
       {/* ── Body ── */}
       <div className="place-detail-v2-body">
 
+        {/* ── Google Maps CTA — prominent, below hero ── */}
+        {googleMapsUrl && (
+          <a
+            href={googleMapsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="place-detail-maps-cta"
+          >
+            View in Google Maps →
+          </a>
+        )}
+
         {/* ── ABOVE THE FOLD: hours first, then food strip, identity, narrative ── */}
 
         {/* ── Hours + Go When (FIRST in body) ── */}
@@ -335,11 +347,18 @@ export default function PlaceCardDetail({ card, userId, contextKey }: PlaceCardD
         {/* Practical info — address, website, menu */}
         <div className="place-detail-v2-identity">
           {address && (
-            <a href={googleMapsUrl} target="_blank" rel="noopener noreferrer" className="place-detail-v2-identity-row">
-              <span className="place-detail-v2-identity-icon">📍</span>
-              <span>{address}</span>
-              <span className="place-detail-v2-identity-link">↗</span>
-            </a>
+            googleMapsUrl ? (
+              <a href={googleMapsUrl} target="_blank" rel="noopener noreferrer" className="place-detail-v2-identity-row">
+                <span className="place-detail-v2-identity-icon">📍</span>
+                <span>{address}</span>
+                <span className="place-detail-v2-identity-link">↗</span>
+              </a>
+            ) : (
+              <div className="place-detail-v2-identity-row">
+                <span className="place-detail-v2-identity-icon">📍</span>
+                <span>{address}</span>
+              </div>
+            )
           )}
           {phone && (
             <a href={`tel:${phone}`} className="place-detail-v2-identity-row">
@@ -416,10 +435,12 @@ export default function PlaceCardDetail({ card, userId, contextKey }: PlaceCardD
 
         {/* ── Compact actions row ── */}
         <div className="place-detail-actions-row">
-          <a href={googleMapsUrl} target="_blank" rel="noopener noreferrer"
-             className="place-detail-action-btn place-detail-action-maps">
-            🗺 Maps
-          </a>
+          {googleMapsUrl && (
+            <a href={googleMapsUrl} target="_blank" rel="noopener noreferrer"
+               className="place-detail-action-btn place-detail-action-maps">
+              View in Google Maps →
+            </a>
+          )}
           <ShareButton name={card.name} />
           {userId && contextKey && card.place_id && (
             <TriageWidget

--- a/app/_components/ReviewContextClient.tsx
+++ b/app/_components/ReviewContextClient.tsx
@@ -281,7 +281,20 @@ export default function ReviewContextClient({
                             )}
                           </div>
                         </div>
-                        <TriageButtons userId={userId} contextKey={context.key} placeId={placeId} />
+                        <div className="review-item-actions">
+                          <TriageButtons userId={userId} contextKey={context.key} placeId={placeId} />
+                          {d.place_id && (
+                            <a
+                              href={`https://www.google.com/maps/place/?q=place_id:${d.place_id}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="review-item-maps-link"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              View in Google Maps →
+                            </a>
+                          )}
+                        </div>
                       </div>
                     </div>
                   );


### PR DESCRIPTION
## Summary

Adds 'View in Google Maps →' links to all place/discovery/accommodation cards per issue #125.

## Changes

**PlaceCard** (homepage + review list grid cards)
- Updated footer link label from `↗ Maps` to `View in Google Maps →`
- Only shown when `place_id` is present (was already the case)

**PlaceCardDetail** (full place detail page)
- Added prominent `View in Google Maps →` CTA button below the hero image
- Updated actions row label from `🗺 Maps` to `View in Google Maps →`
- Restricted to `place_id` only — removed fallback search URL

**ReviewContextClient** (review list per context)
- Added secondary `View in Google Maps →` link below triage buttons on each discovery item
- Only shown when `place_id` is present

**AccommodationCard** (accommodation detail)
- Added `View in Google Maps →` link in the actions section
- Only shown when `placeId` starts with `ChIJ` (Google Place ID format)

**CSS** (globals.css)
- `.place-detail-maps-cta` — prominent block button, blue Google Maps color
- `.accommodation-maps-link` — secondary link style
- `.review-item-actions` — flex column wrapper for triage + maps link
- `.review-item-maps-link` — small secondary link style

## URL format
`https://www.google.com/maps/place/?q=place_id:{place_id}`
All links use `target="_blank" rel="noopener noreferrer"`

Addresses issue #125