### PR TITLE
feat: trip notes edit expand + archive, remove TripIntelWidget (#128)

### DIFF
--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -8,7 +8,6 @@ import PlaceGrid from './PlaceGrid';
 import BriefingBanner from './BriefingBanner';
 import Twemoji from './Twemoji';
 import TripPlanningWidget from './TripPlanningWidget';
-import TripIntelWidget, { type TripIntelData } from './TripIntelWidget';
 
 interface HomeClientProps {
   userId: string;
@@ -192,7 +191,9 @@ export default function HomeClient({
               </div>
 
               {/* Desktop: trip planning widget inline with header */}
-              {ctx.type === 'trip' && (
+              {ctx.type === 'trip' && (() => {
+                const raw = ctx as unknown as Record<string, unknown>;
+                return (
                 <div className="section-header-trip-widget">
                   <TripPlanningWidget
                     userId={userId}
@@ -201,9 +202,11 @@ export default function HomeClient({
                     accommodation={contextMeta[ctx.key]?.accommodation as never}
                     bookingStatus={contextMeta[ctx.key]?.bookingStatus}
                     savedCount={counts.saved}
+                    purpose={raw.purpose as string | undefined}
+                    people={raw.people as Array<{ name: string; relation?: string }> | undefined}
                   />
                 </div>
-              )}
+                );})()}
 
               <div className="section-header-right">
                 {ctx.type !== 'trip' && counts.saved > 0 && (
@@ -226,7 +229,9 @@ export default function HomeClient({
             </div>
 
             {/* Mobile: trip planning widget below header */}
-            {ctx.type === 'trip' && (
+            {ctx.type === 'trip' && (() => {
+              const raw = ctx as unknown as Record<string, unknown>;
+              return (
               <div className="section-trip-widget-mobile">
                 <TripPlanningWidget
                   userId={userId}
@@ -235,22 +240,11 @@ export default function HomeClient({
                   accommodation={contextMeta[ctx.key]?.accommodation as never}
                   bookingStatus={contextMeta[ctx.key]?.bookingStatus}
                   savedCount={counts.saved}
+                  purpose={raw.purpose as string | undefined}
+                  people={raw.people as Array<{ name: string; relation?: string }> | undefined}
                 />
               </div>
-            )}
-
-            {/* Trip Intelligence — purpose, people, schedule, anchors */}
-            {ctx.type === 'trip' && (() => {
-              const raw = ctx as unknown as Record<string, unknown>;
-              const hasIntel = raw.purpose || (raw.people as unknown[])?.length || (raw.schedule as unknown[])?.length || (raw.anchor_experiences as unknown[])?.length;
-              if (!hasIntel) return null;
-              return (
-                <TripIntelWidget
-                  intel={raw as unknown as TripIntelData}
-                  tripKey={ctx.key}
-                />
-              );
-            })()}
+              );})()}
 
             {discoveries.length > 0 ? (
               <PlaceGrid

--- a/app/_components/TripIntelInput.tsx
+++ b/app/_components/TripIntelInput.tsx
@@ -6,6 +6,8 @@ interface TripIntelInputProps {
   contextKey: string;
   onSaved?: () => void;
   inlineMode?: boolean; // always-visible transparent input row
+  purpose?: string;
+  people?: Array<{ name: string; relation?: string }>;
 }
 
 interface SaveResult {
@@ -15,12 +17,13 @@ interface SaveResult {
   tripFieldCount?: number;
 }
 
-export default function TripIntelInput({ contextKey, onSaved, inlineMode }: TripIntelInputProps) {
+export default function TripIntelInput({ contextKey, onSaved, inlineMode, purpose, people }: TripIntelInputProps) {
   const [open, setOpen] = useState(false);
   const [text, setText] = useState('');
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<SaveResult | null>(null);
   const [error, setError] = useState('');
+  const [expandOpen, setExpandOpen] = useState(false);
 
   async function handleSave() {
     if (!text.trim()) return;
@@ -49,25 +52,53 @@ export default function TripIntelInput({ contextKey, onSaved, inlineMode }: Trip
     }
   }
 
+  async function handleArchive() {
+    if (!confirm('Archive this trip? You can restore it later.')) return;
+    setLoading(true);
+    try {
+      const res = await fetch('/api/contexts/lifecycle', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contextKey, action: 'archive' }),
+      });
+      if (res.ok) {
+        window.location.href = '/';
+      } else {
+        setError('Failed to archive trip');
+      }
+    } catch {
+      setError('Error archiving trip');
+    } finally {
+      setLoading(false);
+    }
+  }
+
   // Inline mode: always-visible single-line input (the "Trip Notes" row in the widget)
   if (inlineMode) {
     return (
       <div className="tpw-notes-row">
         <span className="tpw-label">Trip Notes</span>
-        <input
-          type="text"
-          className="tpw-notes-input"
-          placeholder="Add details, people, plans..."
-          value={text}
-          onChange={e => setText(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter' && text.trim()) handleSave(); }}
-          disabled={loading}
-        />
-        {text.trim() && (
-          <button className="tpw-notes-save" onClick={handleSave} disabled={loading}>
-            {loading ? '…' : '↵'}
-          </button>
-        )}
+        <button className="tpw-notes-edit-link" onClick={() => setExpandOpen(e => !e)}>
+          {expandOpen ? '↑ cancel' : 'edit ↓'}
+        </button>
+        <div className={`tpw-notes-expand ${expandOpen ? 'open' : ''}`}>
+          <div className="tpw-notes-expand-body">
+            {purpose && <div className="tpw-notes-expand-purpose">Purpose: {purpose}</div>}
+            {people && people.length > 0 && (
+              <div>
+                {people.map((p, i) => (
+                  <span key={i} className="tpw-notes-expand-person">
+                    {p.name}
+                    {p.relation && <span className="tpw-notes-expand-person-rel">({p.relation})</span>}
+                  </span>
+                ))}
+              </div>
+            )}
+            <button className="tpw-archive-btn" onClick={handleArchive} disabled={loading}>
+              Archive trip
+            </button>
+          </div>
+        </div>
       </div>
     );
   }

--- a/app/_components/TripPlanningWidget.tsx
+++ b/app/_components/TripPlanningWidget.tsx
@@ -46,6 +46,8 @@ interface TripPlanningWidgetProps {
   accommodation?: AccommodationData;
   bookingStatus?: string;
   savedCount?: number;
+  purpose?: string;
+  people?: Array<{ name: string; relation?: string }>;
 }
 
 const STORAGE_KEY_PREFIX = 'compass-trip-planning-';
@@ -97,7 +99,7 @@ function FlightCard({ leg, label }: { leg: FlightLeg; label: string }) {
 }
 
 export default function TripPlanningWidget({
-  userId, contextKey, travel, accommodation, bookingStatus, savedCount = 0,
+  userId, contextKey, travel, accommodation, bookingStatus, savedCount = 0, purpose, people,
 }: TripPlanningWidgetProps) {
   const [planning, setPlanning] = useState<TripPlanning>(defaultPlanning);
   const [travelExpanded, setTravelExpanded] = useState(false);
@@ -271,7 +273,7 @@ export default function TripPlanningWidget({
       )}
 
       {/* Row 3: Trip Notes — always-visible transparent input with thin border */}
-      <TripIntelInput contextKey={contextKey} inlineMode />
+      <TripIntelInput contextKey={contextKey} inlineMode purpose={purpose} people={people} />
 
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -3811,6 +3811,62 @@ body {
   flex-shrink: 0;
 }
 
+/* Trip Notes edit expand */
+.tpw-notes-edit-link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0 0 0 var(--space-sm);
+  white-space: nowrap;
+  text-decoration: none;
+}
+.tpw-notes-edit-link:hover { text-decoration: underline; }
+
+.tpw-notes-expand {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.25s ease;
+}
+.tpw-notes-expand.open {
+  max-height: 200px;
+}
+.tpw-notes-expand-body {
+  padding: var(--space-sm) 0 var(--space-xs) 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+.tpw-notes-expand-purpose {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+.tpw-notes-expand-person {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+.tpw-notes-expand-person-rel {
+  margin-left: var(--space-xs);
+  color: var(--text-muted);
+  font-style: italic;
+}
+.tpw-archive-btn {
+  margin-top: var(--space-sm);
+  align-self: flex-start;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  padding: 3px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.tpw-archive-btn:hover {
+  background: var(--bg-hover, var(--bg-card));
+  color: var(--text-secondary);
+}
+
 .tpw-summary:hover { color: var(--text-secondary); }
 
 .tpw-collapse {


### PR DESCRIPTION
Replaces the Trip Intelligence grey box with an inline edit expand in the Trip Notes row. Adds archive functionality. Addresses issue #128

## Summary
- Modified TripIntelInput.tsx to show Trip Notes [edit ↓] with expand panel
- Expand shows purpose, people, and archive button
- Archive posts to /api/contexts/lifecycle and redirects on success
- Removed TripIntelWidget from HomeClient.tsx
- Added new CSS classes for the expand panel

## Test plan
- [ ] Verify Trip Notes row shows "edit ↓" link
- [ ] Click expands panel with purpose/people data
- [ ] Archive button works and redirects to home
- [ ] No TypeScript errors in modified files
🤖 Generated with [Claude Code](https://claude.com/claude-code)