### PR TITLE
feat: admin - compact worker sub-agent cards (#131)

### DIFF
--- a/app/_components/WorkerCard.tsx
+++ b/app/_components/WorkerCard.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+/* ---- Worker Session Parser ---- */
+
+function parseWorkerSession(key: string): { project: string; role: string; level: string; name: string } {
+  // Format: "agent:main:subagent:compass-v2-developer-medior-brunhilda"
+  const subagentPart = key.replace(/^agent:main:subagent:/, '');
+  const parts = subagentPart.split('-');
+
+  // Handle UUID-style keys (no structured name)
+  if (parts.length < 4 || (parts[0]?.length ?? 0) === 12) {
+    return { project: 'unknown', role: 'unknown', level: 'unknown', name: subagentPart.slice(0, 8) };
+  }
+
+  const name = parts[parts.length - 1] ?? '';
+  const level = parts[parts.length - 2] ?? '';
+  const role = parts[parts.length - 3] ?? '';
+  const project = parts.slice(0, parts.length - 3).join('-');
+
+  return { project, role, level, name };
+}
+
+/* ---- Role Emoji Mapping ---- */
+
+const ROLE_EMOJI: Record<string, string> = {
+  developer: '🔨',
+  tester: '🧪',
+  reviewer: '👁️',
+  architect: '🏗️',
+};
+
+/* ---- Token Formatter ---- */
+
+function formatTokens(n: number): string {
+  if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+  if (n >= 1000) return Math.round(n / 1000) + 'K';
+  return String(n);
+}
+
+/* ---- WorkerCard Component ---- */
+
+export default function WorkerCard({ worker }: { worker: {
+  sessionKey: string;
+  status: string;
+  model: string;
+  totalTokens: number;
+  startedAt: number;
+}}) {
+  const { project, role, level, name } = parseWorkerSession(worker.sessionKey);
+  const emoji = ROLE_EMOJI[role] || '🤖';
+
+  // Status indicator
+  const statusIcon = worker.status === 'running'
+    ? '●'
+    : worker.status === 'done'
+      ? '✓'
+      : '✗';
+  const statusColor = worker.status === 'running'
+    ? '#22c55e'
+    : worker.status === 'done'
+      ? '#94a3b8'
+      : '#f44336';
+
+  return (
+    <div className="worker-card">
+      <div className="worker-card-header">
+        <span className="worker-emoji">{emoji}</span>
+        <span className="worker-name">{name}</span>
+        <span className="worker-status" style={{ color: statusColor }}>{statusIcon}</span>
+      </div>
+      <div className="worker-meta">
+        {level} {role}
+      </div>
+      <div className="worker-project">{project}</div>
+      <div className="worker-tokens">
+        {formatTokens(worker.totalTokens)} tokens
+      </div>
+    </div>
+  );
+}

--- a/app/admin/AdminClient.tsx
+++ b/app/admin/AdminClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import WorkerCard from '../_components/WorkerCard';
 
 /* ---- Types ---- */
 
@@ -61,6 +62,14 @@ interface DiscoActivityData {
     consecutiveErrors: number;
     lastError: string | null;
   }>;
+}
+
+interface WorkerInfo {
+  sessionKey: string;
+  status: string;
+  model: string;
+  totalTokens: number;
+  startedAt: number;
 }
 
 interface TokenData {
@@ -176,6 +185,7 @@ export default function AdminClient() {
   const [tokenData, setTokenData] = useState<TokenData | null>(null);
   const [users, setUsers] = useState<UserWithData[]>([]);
   const [discoActivity, setDiscoActivity] = useState<DiscoActivityData | null>(null);
+  const [workers, setWorkers] = useState<WorkerInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [expandedUsers, setExpandedUsers] = useState<Set<string>>(new Set());
   const [activeTab, setActiveTab] = useState<AdminTab>('overview');
@@ -193,6 +203,7 @@ export default function AdminClient() {
         const data = await agentsRes.json();
         setAgents(data.agents || []);
         setStats(data.stats || null);
+        setWorkers(data.workers || []);
       }
       if (cronsRes.ok) setCrons((await cronsRes.json()).jobs || []);
       if (tokensRes.ok) setTokenData(await tokensRes.json());
@@ -406,6 +417,16 @@ export default function AdminClient() {
           })()}
         </div>
       </Section>
+
+      {/* ---- Workers (sub-agents) ---- */}
+      {workers.length > 0 && (
+        <>
+          <h2 className="section-label">Workers</h2>
+          <div className="worker-grid">
+            {workers.map(w => <WorkerCard key={w.sessionKey} worker={w} />)}
+          </div>
+        </>
+      )}
 
       {/* ---- Disco Activity ---- */}
       <Section title="Disco Activity" emoji="🔍">

--- a/app/api/admin/agents/route.ts
+++ b/app/api/admin/agents/route.ts
@@ -31,6 +31,8 @@ interface SessionEntry {
   totalTokens?: number;
   contextTokens?: number;
   model?: string;
+  status?: string;
+  startedAt?: number;
   [key: string]: unknown;
 }
 
@@ -133,6 +135,54 @@ function loadStats() {
   return { placeCards, cottages, activeContexts };
 }
 
+function loadWorkers(): Array<{
+  sessionKey: string; status: string; model: string;
+  totalTokens: number; startedAt: number;
+}> {
+  const agentsDir = path.join(homeDir(), '.openclaw', 'agents');
+  if (!existsSync(agentsDir)) return [];
+
+  const now = Date.now();
+  const HOUR = 3600000;
+  const workers: Array<{
+    sessionKey: string; status: string; model: string;
+    totalTokens: number; startedAt: number;
+  }> = [];
+
+  // Scan all agent directories for subagent sessions
+  for (const agentId of readdirSync(agentsDir)) {
+    if (agentId.startsWith('.')) continue;
+    const sessionsPath = path.join(agentsDir, agentId, 'sessions', 'sessions.json');
+    const sessionsData = safeReadJSON(sessionsPath) as Record<string, SessionEntry> | null;
+    if (!sessionsData) continue;
+
+    for (const [key, session] of Object.entries(sessionsData)) {
+      // Match subagent sessions: agent:main:subagent:*
+      if (!key.includes(':subagent:')) continue;
+
+      // Only include workers from last 24h
+      if (now - session.updatedAt > 24 * HOUR) continue;
+
+      workers.push({
+        sessionKey: key,
+        status: session.status || 'unknown',
+        model: session.model?.replace(/^(anthropic|openai|google)\//, '') || '—',
+        totalTokens: session.totalTokens || 0,
+        startedAt: session.startedAt || session.updatedAt,
+      });
+    }
+  }
+
+  // Sort: running first, then by most recent
+  workers.sort((a, b) => {
+    if (a.status === 'running' && b.status !== 'running') return -1;
+    if (b.status === 'running' && a.status !== 'running') return 1;
+    return b.startedAt - a.startedAt;
+  });
+
+  return workers.slice(0, 10);
+}
+
 export async function GET() {
   const currentUser = await getCurrentUser();
   if (!currentUser || !currentUser.isOwner) {
@@ -141,6 +191,7 @@ export async function GET() {
 
   const agents = loadAgents();
   const stats = loadStats();
+  const workers = loadWorkers();
   const totalTokens24h = agents.reduce((sum, a) => sum + a.totalTokens, 0);
 
   return NextResponse.json({
@@ -153,5 +204,6 @@ export async function GET() {
       activeContexts: stats.activeContexts,
       totalTokens24h,
     },
+    workers,
   });
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -5688,3 +5688,74 @@ body {
   border-radius: 8px;
   margin: 0 16px 16px;
 }
+
+/* Worker sub-agent cards */
+.worker-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.worker-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem;
+  font-size: 0.8rem;
+}
+
+.worker-card-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.worker-emoji {
+  font-size: 1rem;
+}
+
+.worker-name {
+  font-weight: 600;
+  color: var(--text-primary);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.worker-status {
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.worker-meta {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-transform: capitalize;
+  margin-bottom: 2px;
+}
+
+.worker-project {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 4px;
+}
+
+.worker-tokens {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.section-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin: 1.5rem 0 0.5rem;
+}


### PR DESCRIPTION
Addresses issue #131

## Summary
- Added compact WorkerCard component for sub-agent sessions
- Workers grid (5-6 per row desktop, 2-3 mobile) below core agent cards
- Parses session key to extract project/role/level/name
- Status indicators: green running, grey done, red failed
- Shows last 10 workers (running first), only if any in last 24h
- Section label separates core agents from workers

## Test plan
- [ ] Verify admin page loads at /admin
- [ ] Check that worker cards appear below core agent cards when sub-agents exist
- [ ] Verify status indicators show correct colors
- [ ] Verify token formatting works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)