### PR TITLE
feat: Street View fallback for cottages with no hero photo

### DIFF
--- a/app/_components/AccommodationCard.tsx
+++ b/app/_components/AccommodationCard.tsx
@@ -95,6 +95,7 @@ interface AccommodationData {
   address?: string;
   city?: string;
   heroImage?: string | null;
+  heroSource?: string;
   images?: Array<{ path: string; category: string }>;
   // Cottage-specific fields
   platform?: string;
@@ -208,11 +209,29 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
         className="accommodation-hero"
         style={{
           minHeight: 'min(45vw, 320px)',
+          position: 'relative',
           background: heroImage
             ? `linear-gradient(to bottom, rgba(0,0,0,0) 35%, rgba(0,0,0,0.75) 100%), url(${heroImage}) center/cover no-repeat`
             : LAKE_GRADIENT,
         }}
       >
+        {data.heroSource === 'street-view' && (
+          <span
+            style={{
+              position: 'absolute',
+              top: 8,
+              right: 8,
+              background: 'rgba(0,0,0,0.55)',
+              color: 'white',
+              fontSize: '0.7rem',
+              padding: '2px 8px',
+              borderRadius: '12px',
+              backdropFilter: 'blur(4px)',
+            }}
+          >
+            📷 Street view
+          </span>
+        )}
         <div className="accommodation-hero-overlay">
           <div className="accommodation-hero-top">
             <span className="accommodation-type-badge">🏡 Cottage</span>

--- a/scripts/enrich-street-view.mjs
+++ b/scripts/enrich-street-view.mjs
@@ -1,0 +1,97 @@
+// Usage: node scripts/enrich-street-view.mjs
+// Requires: NEXT_PUBLIC_GOOGLE_MAPS_KEY in .env.local
+
+import fs from 'fs';
+import path from 'path';
+
+const COTTAGES_PATH = path.join(process.cwd(), 'data', 'cottages', 'index.json');
+const ENV_PATH = path.join(process.cwd(), '.env.local');
+
+function loadEnv() {
+  const env = {};
+  if (!fs.existsSync(ENV_PATH)) {
+    console.error('❌ .env.local not found');
+    process.exit(1);
+  }
+  const content = fs.readFileSync(ENV_PATH, 'utf8');
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx > 0) {
+      const key = trimmed.slice(0, eqIdx).trim();
+      const value = trimmed.slice(eqIdx + 1).trim();
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+function getCoords(cottage) {
+  // Try coordinates object first
+  if (cottage.coordinates?.lat && cottage.coordinates?.lng) {
+    return { lat: cottage.coordinates.lat, lng: cottage.coordinates.lng };
+  }
+  // Fall back to top-level lat/lng
+  if (cottage.lat != null && cottage.lng != null) {
+    return { lat: cottage.lat, lng: cottage.lng };
+  }
+  return null;
+}
+
+async function main() {
+  const env = loadEnv();
+  const apiKey = env.NEXT_PUBLIC_GOOGLE_MAPS_KEY;
+  if (!apiKey) {
+    console.error('❌ NEXT_PUBLIC_GOOGLE_MAPS_KEY not found in .env.local');
+    process.exit(1);
+  }
+
+  const data = JSON.parse(fs.readFileSync(COTTAGES_PATH, 'utf8'));
+  const cottages = data.cottages || [];
+
+  let updated = 0;
+  let skipped = 0;
+
+  for (const cottage of cottages) {
+    // Skip if already has heroImage
+    if (cottage.heroImage) {
+      skipped++;
+      continue;
+    }
+
+    const coords = getCoords(cottage);
+    if (!coords) {
+      console.log(`⏭️  no coords for ${cottage.id}`);
+      skipped++;
+      continue;
+    }
+
+    // Call Street View Metadata API
+    const metadataUrl = `https://maps.googleapis.com/maps/api/streetview/metadata?location=${coords.lat},${coords.lng}&key=${apiKey}`;
+    const metaRes = await fetch(metadataUrl);
+    const meta = await metaRes.json();
+
+    if (meta.status === 'OK') {
+      cottage.heroImage = `https://maps.googleapis.com/maps/api/streetview?size=800x400&location=${coords.lat},${coords.lng}&key=${apiKey}&fov=90&pitch=0`;
+      cottage.heroSource = 'street-view';
+      console.log(`✅ added street view for ${cottage.id}`);
+      updated++;
+    } else {
+      console.log(`⏭️  no street view for ${cottage.id} (${meta.status})`);
+      skipped++;
+    }
+
+    // Small delay to avoid rate limiting
+    await new Promise(r => setTimeout(r, 200));
+  }
+
+  // Write back
+  fs.writeFileSync(COTTAGES_PATH, JSON.stringify(data, null, 2));
+  console.log(`\n📊 Summary: ${updated} updated, ${skipped} skipped`);
+}
+
+main().catch(err => {
+  console.error('Error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Addresses issue #137

Implements a build-time Street View image fallback for cottage cards that have no `heroImage`.

## Changes

### `scripts/enrich-street-view.mjs` (new)
Build-time enrichment script that:
- Reads `data/cottages/index.json` and finds cottages with no `heroImage`
- Gets coordinates from `coordinates.lat/lng` or top-level `lat/lng`
- Calls Google Street View **Metadata API** first to check if imagery exists
- If imagery is available (status `OK`), sets:
  - `heroImage` to the Street View Static API URL (`size=800x400`, `fov=90`, `pitch=0`)
  - `heroSource: "street-view"` as a new field
- Adds 200ms delay between API calls to avoid rate limiting
- Writes updated JSON back and prints a summary

**To run:**
```bash
node scripts/enrich-street-view.mjs
```

### `app/_components/AccommodationCard.tsx`
- Added `heroSource?: string` to `AccommodationData` interface
- Added `position: relative` to the hero container
- Shows a subtle pill badge **"📷 Street view"** (top-right, semi-transparent dark background) when `heroSource === 'street-view'`

## Notes
- 43 cottages currently have no `heroImage`; 29 of those have coordinates available
- The API key (`NEXT_PUBLIC_GOOGLE_MAPS_KEY`) must be set in `.env.local`
- Street View Static API must be enabled in Google Cloud Console