### PR TITLE
feat: aerial drone video hero for cottage cards

### DIFF
--- a/app/_components/AccommodationCard.tsx
+++ b/app/_components/AccommodationCard.tsx
@@ -135,6 +135,9 @@ interface AccommodationData {
   airQualityJuly?: { aqi: number; category: string };
   pollenJulyTree?: string;
   pollenJulyGrass?: string;
+  // Aerial View (Google Maps Aerial View API)
+  aerialVideoUrl?: string | null;
+  aerialVideoUrlWebm?: string | null;
 }
 
 interface AccommodationCardProps {
@@ -200,6 +203,14 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
     ? `https://www.google.com/maps/place/?q=place_id:${placeId}`
     : null;
 
+  // Aerial video
+  const aerialVideoUrl = data.aerialVideoUrl || null;
+  const aerialVideoUrlWebm = data.aerialVideoUrlWebm || null;
+
+  // Google Earth 3D link
+  const googleEarthUrl = `https://earth.google.com/web/search/${encodeURIComponent(`${name}${region ? ', ' + region : ''}`)}`;
+
+
   // Match score
   const rawScores = data.scores as Record<string, number> | undefined;
   const matchScore = data.match_score ||
@@ -210,34 +221,89 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
   return (
     <div className="accommodation-card">
       {/* ── Hero ── */}
-      <div
-        className="accommodation-hero"
-        style={{
-          minHeight: 'min(45vw, 320px)',
-          position: 'relative',
-          background: heroImage
-            ? `linear-gradient(to bottom, rgba(0,0,0,0) 35%, rgba(0,0,0,0.75) 100%), url(${heroImage}) center/cover no-repeat`
-            : LAKE_GRADIENT,
-        }}
-      >
-        {data.heroSource === 'street-view' && (
-          <span
+      <div className="accommodation-hero" style={{ position: 'relative', minHeight: 'min(45vw, 320px)' }}>
+        {aerialVideoUrl ? (
+          /* ── Aerial video hero ── */
+          <>
+            <video
+              autoPlay
+              muted
+              loop
+              playsInline
+              poster={heroImage || undefined}
+              style={{
+                width: '100%',
+                height: 'min(45vw, 320px)',
+                objectFit: 'cover',
+                borderRadius: '12px 12px 0 0',
+                display: 'block',
+              }}
+            >
+              {aerialVideoUrlWebm && <source src={aerialVideoUrlWebm} type="video/webm" />}
+              <source src={aerialVideoUrl} type="video/mp4" />
+            </video>
+            {/* Gradient overlay for text legibility */}
+            <div
+              style={{
+                position: 'absolute',
+                inset: 0,
+                background: 'linear-gradient(to bottom, rgba(0,0,0,0) 35%, rgba(0,0,0,0.75) 100%)',
+                borderRadius: '12px 12px 0 0',
+                pointerEvents: 'none',
+              }}
+            />
+            {/* Aerial badge */}
+            <span
+              style={{
+                position: 'absolute',
+                bottom: 56,
+                left: 12,
+                background: 'rgba(0,0,0,0.55)',
+                color: 'white',
+                fontSize: '0.7rem',
+                padding: '2px 8px',
+                borderRadius: '12px',
+                backdropFilter: 'blur(4px)',
+              }}
+            >
+              🛸 Aerial view
+            </span>
+          </>
+        ) : (
+          /* ── Static photo hero (fallback) ── */
+          <div
             style={{
+              minHeight: 'min(45vw, 320px)',
               position: 'absolute',
-              top: 8,
-              right: 8,
-              background: 'rgba(0,0,0,0.55)',
-              color: 'white',
-              fontSize: '0.7rem',
-              padding: '2px 8px',
-              borderRadius: '12px',
-              backdropFilter: 'blur(4px)',
+              inset: 0,
+              background: heroImage
+                ? `linear-gradient(to bottom, rgba(0,0,0,0) 35%, rgba(0,0,0,0.75) 100%), url(${heroImage}) center/cover no-repeat`
+                : LAKE_GRADIENT,
+              borderRadius: '12px 12px 0 0',
             }}
           >
-            📷 Street view
-          </span>
+            {data.heroSource === 'street-view' && (
+              <span
+                style={{
+                  position: 'absolute',
+                  top: 8,
+                  right: 8,
+                  background: 'rgba(0,0,0,0.55)',
+                  color: 'white',
+                  fontSize: '0.7rem',
+                  padding: '2px 8px',
+                  borderRadius: '12px',
+                  backdropFilter: 'blur(4px)',
+                }}
+              >
+                📷 Street view
+              </span>
+            )}
+          </div>
         )}
-        <div className="accommodation-hero-overlay">
+
+        {/* Hero text overlay — sits on top of both video and photo */}
+        <div className="accommodation-hero-overlay" style={{ position: 'absolute', bottom: 0, left: 0, right: 0, padding: '12px 16px' }}>
           <div className="accommodation-hero-top">
             <span className="accommodation-type-badge">🏡 Cottage</span>
             {matchScore && (
@@ -435,6 +501,14 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
               View in Google Maps →
             </a>
           )}
+          <a
+            href={googleEarthUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="accommodation-maps-link"
+          >
+            🌍 View in Google Earth 3D →
+          </a>
           {userId && contextKey && (
             <div className="accommodation-triage-row">
               <TriageWidget

--- a/scripts/enrich-cottage-aerial.mjs
+++ b/scripts/enrich-cottage-aerial.mjs
@@ -1,0 +1,119 @@
+/**
+ * enrich-cottage-aerial.mjs
+ *
+ * For each cottage with coordinates, calls the Google Maps Aerial View API.
+ * If state === 'ACTIVE', saves aerialVideoUrl (MP4) and aerialVideoUrlWebm to
+ * the cottage's JSON. Skips cottages that already have a video URL.
+ *
+ * Usage:
+ *   GOOGLE_MAPS_API_KEY=<key> node scripts/enrich-cottage-aerial.mjs
+ *   node scripts/enrich-cottage-aerial.mjs --dry-run
+ *   node scripts/enrich-cottage-aerial.mjs --force   # re-fetch even if already set
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH = path.join(__dirname, '..', 'data', 'cottages', 'index.json');
+
+const API_KEY = process.env.GOOGLE_MAPS_API_KEY || process.env.MAPS_KEY || '';
+const DRY_RUN = process.argv.includes('--dry-run');
+const FORCE = process.argv.includes('--force');
+
+const AERIAL_API = 'https://aerialview.googleapis.com/v1/videos:lookupVideo';
+
+async function lookupAerialVideo(lat, lng) {
+  if (!API_KEY) return null;
+  const url = `${AERIAL_API}?lat=${lat}&lng=${lng}&key=${API_KEY}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      if (res.status === 403) throw new Error('API key not authorized for Aerial View API');
+      return null; // 404 = no coverage
+    }
+    const data = await res.json();
+    if (data.state !== 'ACTIVE') return null;
+    return {
+      mp4: data.uris?.MP4_HIGH || data.uris?.MP4_MEDIUM || null,
+      webm: data.uris?.WEBM || null,
+    };
+  } catch (err) {
+    if (err.message?.includes('not authorized')) throw err;
+    return null;
+  }
+}
+
+async function main() {
+  if (!API_KEY && !DRY_RUN) {
+    console.warn('⚠️  No GOOGLE_MAPS_API_KEY set — running in dry-run mode');
+  }
+
+  const raw = readFileSync(INDEX_PATH, 'utf8');
+  const data = JSON.parse(raw);
+  const cottages = data.cottages || [];
+
+  let skipped = 0, fetched = 0, found = 0, noData = 0, errors = 0;
+
+  for (const cottage of cottages) {
+    const lat = cottage.coordinates?.lat || cottage.lat;
+    const lng = cottage.coordinates?.lng || cottage.lng;
+
+    if (!lat || !lng) {
+      console.log(`  ⏭  ${cottage.id}: no coordinates, skipping`);
+      skipped++;
+      continue;
+    }
+
+    if (!FORCE && cottage.aerialVideoUrl) {
+      console.log(`  ✓  ${cottage.id}: already has aerial video, skipping`);
+      skipped++;
+      continue;
+    }
+
+    if (DRY_RUN || !API_KEY) {
+      console.log(`  🔍 ${cottage.id}: would fetch aerial for (${lat}, ${lng})`);
+      fetched++;
+      continue;
+    }
+
+    try {
+      const result = await lookupAerialVideo(lat, lng);
+      fetched++;
+
+      if (result?.mp4) {
+        cottage.aerialVideoUrl = result.mp4;
+        cottage.aerialVideoUrlWebm = result.webm || null;
+        console.log(`  🛸 ${cottage.id}: ACTIVE — ${result.mp4.slice(0, 60)}...`);
+        found++;
+      } else {
+        // No coverage — clear any stale URL
+        delete cottage.aerialVideoUrl;
+        delete cottage.aerialVideoUrlWebm;
+        console.log(`  —  ${cottage.id}: no aerial coverage`);
+        noData++;
+      }
+
+      // Polite rate limit: 50ms between requests
+      await new Promise(r => setTimeout(r, 50));
+    } catch (err) {
+      console.error(`  ✗  ${cottage.id}: ${err.message}`);
+      errors++;
+      if (err.message?.includes('not authorized')) {
+        console.error('Aborting: API key not authorized for Aerial View API.');
+        console.error('Enable it at: https://console.cloud.google.com/apis/library/aerialview.googleapis.com');
+        break;
+      }
+    }
+  }
+
+  if (!DRY_RUN && API_KEY) {
+    writeFileSync(INDEX_PATH, JSON.stringify(data, null, 2));
+    console.log(`\nSaved ${INDEX_PATH}`);
+  }
+
+  console.log(`\nDone: ${fetched} fetched, ${found} with aerial, ${noData} no coverage, ${skipped} skipped, ${errors} errors`);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## What

Replaces the static hero photo on cottage cards with a 5-second aerial drone video clip where Google has coverage. Falls back to photo silently when no coverage exists.

## Changes

### `app/_components/AccommodationCard.tsx`
- Added `aerialVideoUrl` and `aerialVideoUrlWebm` to `AccommodationData` interface
- Hero section is now conditional:
  - **With aerial video**: renders `<video autoPlay muted loop playsInline poster={heroImage}>` with webm+mp4 sources, gradient overlay, and **🛸 Aerial view** badge bottom-left
  - **Without aerial video**: existing static photo/gradient hero unchanged (silent fallback)
- Added **🌍 View in Google Earth 3D →** link in actions section (links to `earth.google.com/web/search/{name+city}`, zero weight)
- Hero text overlay (name, location, badges) works on both video and photo via absolute positioning

### `scripts/enrich-cottage-aerial.mjs`
- New build-time enrichment script
- Calls `https://aerialview.googleapis.com/v1/videos:lookupVideo?lat=&lng=&key=` for each cottage with coordinates
- If `state === 'ACTIVE'`: saves `aerialVideoUrl` (MP4_HIGH) and `aerialVideoUrlWebm` to cottage in `data/cottages/index.json`
- If no coverage (`UNPROCESSED` or 404): skips cleanly
- Flags: `--dry-run` (no writes), `--force` (re-fetch even if URL already set)
- Requires `GOOGLE_MAPS_API_KEY` env var with Aerial View API enabled
- 50ms polite rate limit between requests

## Usage
```bash
GOOGLE_MAPS_API_KEY=<key> node scripts/enrich-cottage-aerial.mjs
node scripts/enrich-cottage-aerial.mjs --dry-run  # preview without API key
```

## Notes
- Video autoplay works on iOS Safari: muted + playsInline satisfies iOS requirements
- `poster={heroImage}` shows the photo while video loads — no blank frame
- Rural Ontario coverage is patchy; fallback is seamless and zero-code-path-change
- Aerial View API must be enabled in Google Cloud Console

Addresses issue #142