### PR TITLE
feat: Platform source tags with brand colours on cottage cards

### DIFF
--- a/app/_components/AccommodationCard.tsx
+++ b/app/_components/AccommodationCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { resolveImageUrlClient } from '../_lib/image-url';
+import { getPlatformInfo } from '../_lib/platform';
 import TriageWidget from './TriageWidget';
 import MapWidget from './widgets/MapWidget';
 
@@ -200,6 +201,9 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
   // Listing URL
   const listingUrl = data.listing_url || data.url;
 
+  // Platform branding
+  const platformInfo = getPlatformInfo(data.platform);
+
   // Google Maps deep-link (only when placeId looks like a Google Place ID)
   const googleMapsUrl = placeId && placeId.startsWith('ChIJ')
     ? `https://www.google.com/maps/place/?q=place_id:${placeId}`
@@ -348,6 +352,22 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
               <span>{driveTime}</span>
             </div>
           )}
+          {data.platform && (
+            <div className="accommodation-vital">
+              <span className="accommodation-vital-icon">🏷️</span>
+              <span>
+                Listed on{' '}
+                <span
+                  style={{
+                    fontWeight: 600,
+                    color: platformInfo.colour,
+                  }}
+                >
+                  {platformInfo.label}
+                </span>
+              </span>
+            </div>
+          )}
         </div>
 
         {/* Summary prose */}
@@ -486,9 +506,14 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
               href={listingUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="btn btn-primary accommodation-cta"
+              className="btn accommodation-cta"
+              style={{
+                background: platformInfo.colour,
+                color: 'white',
+                borderColor: platformInfo.colour,
+              }}
             >
-              View Listing ↗
+              ● View on {platformInfo.label} ↗
             </a>
           )}
           {googleMapsUrl && (

--- a/app/_components/AccommodationReviewLayout.tsx
+++ b/app/_components/AccommodationReviewLayout.tsx
@@ -7,6 +7,7 @@ import type { Context } from '../_lib/types';
 import { getTriageState } from '../_lib/triage';
 import TriageButtons from './TriageButtons';
 import { resolveImageUrlClient } from '../_lib/image-url';
+import { getPlatformInfo } from '../_lib/platform';
 
 type Tab = 'unreviewed' | 'saved' | 'dismissed';
 
@@ -68,6 +69,8 @@ function AccommodationCard({
   const vibeTags = cottage?.vibeTags as string[] | undefined;
   const swimVerdict = cottage?.swimVerdict as string | undefined;
   const priceEstimated = cottage?.priceEstimated as boolean | undefined;
+  const platform = cottage?.platform as string | undefined;
+  const platformInfo = getPlatformInfo(platform);
 
   // Match score: average of scores, or fall back to discovery.rating
   const matchScore = scores
@@ -129,6 +132,14 @@ function AccommodationCard({
         >
           {matchScore != null && (
             <span className="accomm-hero-match">⭐ {matchScore}</span>
+          )}
+          {platform && (
+            <span
+              className="accomm-hero-platform"
+              style={{ background: platformInfo.colour }}
+            >
+              {platformInfo.label}
+            </span>
           )}
         </div>
       </Link>

--- a/app/_lib/platform.ts
+++ b/app/_lib/platform.ts
@@ -1,0 +1,42 @@
+/**
+ * Platform branding info for cottage listing sources.
+ */
+
+export interface PlatformInfo {
+  /** Display label for this platform */
+  label: string;
+  /** Brand colour as a CSS hex string */
+  colour: string;
+}
+
+const PLATFORM_MAP: Record<string, PlatformInfo> = {
+  airbnb: { label: 'Airbnb', colour: '#FF5A5F' },
+  vrbo: { label: 'VRBO', colour: '#3D6EE1' },
+  'vrbo-apify': { label: 'VRBO', colour: '#3D6EE1' },
+  cottagestays: { label: 'CottageStays', colour: '#2E7D32' },
+  cottagesincanada: { label: 'Cottages in Canada', colour: '#E65100' },
+  'cottages-in-canada': { label: 'Cottages in Canada', colour: '#E65100' },
+  'cottage.ca': { label: 'Cottage.ca', colour: '#6A1B9A' },
+  'cottagevacations': { label: 'Cottage Vacations', colour: '#00838F' },
+  'cottage-vacations': { label: 'Cottage Vacations', colour: '#00838F' },
+  'saublebeach': { label: 'Sauble Beach', colour: '#558B2F' },
+  'sauble-beach': { label: 'Sauble Beach', colour: '#558B2F' },
+  'sauble beach cottage rentals': { label: 'Sauble Beach', colour: '#558B2F' },
+  'huronshores': { label: 'Direct', colour: '#4527A0' },
+  'huron-shores': { label: 'Direct', colour: '#4527A0' },
+  'huronbeaches': { label: 'Direct', colour: '#4527A0' },
+  'huron-beaches': { label: 'Direct', colour: '#4527A0' },
+  direct: { label: 'Direct', colour: '#4527A0' },
+};
+
+const FALLBACK: PlatformInfo = { label: 'View Listing', colour: '#78909C' };
+
+/**
+ * Return display label and brand colour for a cottage platform string.
+ * The raw platform value from data is normalised to lowercase for matching.
+ */
+export function getPlatformInfo(platform?: string | null): PlatformInfo {
+  if (!platform) return FALLBACK;
+  const key = platform.trim().toLowerCase();
+  return PLATFORM_MAP[key] ?? FALLBACK;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -5517,6 +5517,20 @@ body {
   backdrop-filter: blur(4px);
 }
 
+/* Platform badge — top-right of hero */
+.accomm-hero-platform {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 4px;
+  backdrop-filter: blur(4px);
+  pointer-events: none;
+}
+
 /* Tags (kept for compatibility) */
 .accomm-card-tags {
   display: flex;


### PR DESCRIPTION
## Summary

Adds branded platform badges to cottage review cards and detail pages.

## Changes

### New: `app/_lib/platform.ts`
- `getPlatformInfo(platform)` utility mapping platform strings → `{ label, colour }`
- Covers: Airbnb (red), VRBO / vrbo-apify (blue), CottageStays (green), Cottages in Canada (orange), Cottage.ca (purple), Cottage Vacations (teal), Sauble Beach (olive), Direct/Huron* (indigo), unknown (grey)
- Normalises `vrbo-apify` → VRBO in display

### `AccommodationReviewLayout.tsx`
- Coloured platform badge (`.accomm-hero-platform`) top-right of hero photo on each review card

### `AccommodationCard.tsx`
- 'Listed on `<Platform>`' vital row with brand-coloured label
- CTA button now branded: '● View on Airbnb ↗' with platform background colour

### `globals.css`
- `.accomm-hero-platform`: absolute-positioned pill, top-right of hero

Addresses issue #147