### PR TITLE
feat: filesystem-only PlaceCardStore — eliminate Blob layer for place cards

### DIFF
--- a/app/_lib/place-card-store.ts
+++ b/app/_lib/place-card-store.ts
@@ -1,14 +1,14 @@
 /* ============================================================
-   PlaceCardStore — Blob-backed place card data layer.
-   Replaces readFileSync('data/placecards/...') calls.
+   PlaceCardStore — Filesystem-only place card data layer.
+   Place cards live in data/placecards/{id}/card.json in the
+   git repo. Committed, deployed, served directly from disk.
+   No Blob for place cards — edit card.json, commit, deploy.
    ============================================================ */
 
 import { put } from '@vercel/blob';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import type { DiscoveryType } from './types';
-
-const BLOB_BASE = process.env.NEXT_PUBLIC_BLOB_BASE_URL || 'https://m0xwjuazo5epn9u7.public.blob.vercel-storage.com';
 
 // ---- Types ----
 
@@ -23,64 +23,35 @@ export class PlaceCardStore {
   private static indexCacheMs = 0;
   private static readonly INDEX_TTL = 5 * 60 * 1000; // 5 min
 
-  /** Get a single card from Blob. Falls back to local data/ if Blob returns 404. */
+  /** Get a single card from filesystem. */
   static async getCard(placeId: string): Promise<Record<string, unknown> | null> {
-    // Try Blob first
-    try {
-      const url = `${BLOB_BASE}/place-cards/${placeId}/card.json`;
-      const res = await fetch(url, { next: { revalidate: 300 } });
-      if (res.ok) return res.json();
-    } catch { /* fall through */ }
-
-    // Fall back to local filesystem (during migration period)
     try {
       const localPath = join(process.cwd(), 'data', 'placecards', placeId, 'card.json');
       if (existsSync(localPath)) {
         return JSON.parse(readFileSync(localPath, 'utf-8'));
       }
     } catch { /* ignore */ }
-
     return null;
   }
 
-  /** Get manifest from Blob. Falls back to local. */
+  /** Get manifest from filesystem. */
   static async getManifest(placeId: string): Promise<Record<string, unknown> | null> {
-    try {
-      const url = `${BLOB_BASE}/place-cards/${placeId}/manifest.json`;
-      const res = await fetch(url, { next: { revalidate: 300 } });
-      if (res.ok) return res.json();
-    } catch { /* fall through */ }
-
     try {
       const localPath = join(process.cwd(), 'data', 'placecards', placeId, 'manifest.json');
       if (existsSync(localPath)) {
         return JSON.parse(readFileSync(localPath, 'utf-8'));
       }
     } catch { /* ignore */ }
-
     return null;
   }
 
-  /** Get index (cached, with TTL). Falls back to local. */
+  /** Get index (cached, with TTL) from filesystem. */
   static async getIndex(): Promise<PlaceCardIndex> {
     // Memory cache
     if (PlaceCardStore.indexCache && Date.now() - PlaceCardStore.indexCacheMs < PlaceCardStore.INDEX_TTL) {
       return PlaceCardStore.indexCache;
     }
 
-    // Try Blob
-    try {
-      const url = `${BLOB_BASE}/place-cards/index.json`;
-      const res = await fetch(url, { next: { revalidate: 300 } });
-      if (res.ok) {
-        const idx = await res.json() as PlaceCardIndex;
-        PlaceCardStore.indexCache = idx;
-        PlaceCardStore.indexCacheMs = Date.now();
-        return idx;
-      }
-    } catch { /* fall through */ }
-
-    // Fall back to local
     try {
       const localPath = join(process.cwd(), 'data', 'placecards', 'index.json');
       if (existsSync(localPath)) {
@@ -108,14 +79,15 @@ export class PlaceCardStore {
       .sort((a, b) => a.name.localeCompare(b.name));
   }
 
-  /** Write a card to Blob (requires server-side token). */
-  static async upsertCard(placeId: string, card: Record<string, unknown>): Promise<void> {
-    await put(`place-cards/${placeId}/card.json`, JSON.stringify(card, null, 2), {
+  /** Write user-generated data to Blob (discoveries, triage, chat, etc.).
+   *  Place card data is NOT written here — it lives in the git repo.
+   *  This method is kept for user data writes only.
+   */
+  static async putUserData(blobPath: string, data: Record<string, unknown>): Promise<void> {
+    await put(blobPath, JSON.stringify(data, null, 2), {
       access: 'public',
       contentType: 'application/json',
       addRandomSuffix: false,
     });
-    // Invalidate index cache
-    PlaceCardStore.indexCache = null;
   }
 }


### PR DESCRIPTION
## Summary

Eliminates the Blob storage layer for place cards, making the filesystem the single source of truth.

## Changes

### `app/_lib/place-card-store.ts`
- `getCard()`: reads from `data/placecards/{id}/card.json` only (no Blob fetch)
- `getManifest()`: reads from `data/placecards/{id}/manifest.json` only (no Blob fetch)
- `getIndex()`: reads from `data/placecards/index.json` only (no Blob fetch)
- Removed `BLOB_BASE` constant — not needed for place card paths
- Renamed `upsertCard()` → `putUserData()` to make it clear this is for user data only (discoveries, triage, chat), not place cards
- Memory cache (5-min TTL) preserved for index performance

### Cron jobs
- Disabled **Morning Vercel Sync (Place Cards)** cron — it syncs Blob which is no longer the source of truth

## What stays in Blob (unchanged)
- `users/{id}/discoveries.json`, `triage.json`, `chat.json`, etc.
- `place-photos/{id}/*` (images stay in Blob)
- All image URL resolution (`image-url.ts`, `enrich-photos`) unchanged

## Result
- Edit `card.json` → git commit → Vercel deploys → immediately correct
- No sync step, no stale data, no two-storage confusion
- 555 local cards are now the definitive set

Addresses issue #153