### PR TITLE
feat: AccommodationCard aerial drone video hero with photo fallback (#142)

### DIFF
--- a/app/_components/AccommodationCard.tsx
+++ b/app/_components/AccommodationCard.tsx
@@ -135,6 +135,9 @@ interface AccommodationData {
   airQualityJuly?: { aqi: number; category: string };
   pollenJulyTree?: string;
   pollenJulyGrass?: string;
+  // Aerial View drone video (enriched by enrich-aerial-view.mjs)
+  aerialVideoUrl?: string | null;
+  aerialVideoUrlWebm?: string | null;
 }
 
 interface AccommodationCardProps {
@@ -157,6 +160,8 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
     : heroImg ? resolveImageUrlClient(heroImg.path) : null;
 
   const LAKE_GRADIENT = 'linear-gradient(135deg, #0ea5e9 0%, #0369a1 100%)';
+
+  const hasAerialVideo = !!data.aerialVideoUrl;
 
   // Vitals
   const pricePerWeek = data.pricePerWeek || data.price_per_week;
@@ -200,6 +205,11 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
     ? `https://www.google.com/maps/place/?q=place_id:${placeId}`
     : null;
 
+  // Google Earth 3D link
+  const googleEarthUrl = (name || region)
+    ? `https://earth.google.com/web/search/${encodeURIComponent([name, region].filter(Boolean).join(' '))}`
+    : null;
+
   // Match score
   const rawScores = data.scores as Record<string, number> | undefined;
   const matchScore = data.match_score ||
@@ -215,12 +225,67 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
         style={{
           minHeight: 'min(45vw, 320px)',
           position: 'relative',
-          background: heroImage
-            ? `linear-gradient(to bottom, rgba(0,0,0,0) 35%, rgba(0,0,0,0.75) 100%), url(${heroImage}) center/cover no-repeat`
-            : LAKE_GRADIENT,
+          background: hasAerialVideo
+            ? undefined
+            : heroImage
+              ? `linear-gradient(to bottom, rgba(0,0,0,0) 35%, rgba(0,0,0,0.75) 100%), url(${heroImage}) center/cover no-repeat`
+              : LAKE_GRADIENT,
         }}
       >
-        {data.heroSource === 'street-view' && (
+        {/* Aerial drone video hero */}
+        {hasAerialVideo && (
+          <>
+            <video
+              autoPlay
+              muted
+              loop
+              playsInline
+              poster={heroImage || undefined}
+              style={{
+                position: 'absolute',
+                inset: 0,
+                width: '100%',
+                height: '100%',
+                objectFit: 'cover',
+                zIndex: 0,
+              }}
+            >
+              {data.aerialVideoUrlWebm && (
+                <source src={data.aerialVideoUrlWebm} type="video/webm" />
+              )}
+              <source src={data.aerialVideoUrl!} type="video/mp4" />
+            </video>
+            {/* Dark gradient overlay on top of video */}
+            <div
+              style={{
+                position: 'absolute',
+                inset: 0,
+                background: 'linear-gradient(to bottom, rgba(0,0,0,0) 35%, rgba(0,0,0,0.75) 100%)',
+                zIndex: 1,
+              }}
+            />
+            {/* Aerial view badge */}
+            <span
+              style={{
+                position: 'absolute',
+                bottom: 52,
+                left: 8,
+                background: 'rgba(0,0,0,0.55)',
+                color: 'white',
+                fontSize: '0.7rem',
+                padding: '2px 8px',
+                borderRadius: '12px',
+                backdropFilter: 'blur(4px)',
+                zIndex: 2,
+              }}
+            >
+              🛸 Aerial view
+            </span>
+          </>
+        )}
+
+        {/* Street view badge (only when no aerial video) */}
+        {data.heroSource === 'street-view' && !hasAerialVideo && (
           <span
             style={{
               position: 'absolute',
@@ -237,7 +302,8 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
             📷 Street view
           </span>
         )}
-        <div className="accommodation-hero-overlay">
+
+        <div className="accommodation-hero-overlay" style={{ position: 'relative', zIndex: 2 }}>
           <div className="accommodation-hero-top">
             <span className="accommodation-type-badge">🏡 Cottage</span>
             {matchScore && (
@@ -446,6 +512,20 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
             </div>
           )}
         </div>
+
+        {/* Google Earth 3D link */}
+        {googleEarthUrl && (
+          <div style={{ textAlign: 'center', marginBottom: '8px' }}>
+            <a
+              href={googleEarthUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="accommodation-maps-link"
+            >
+              🌍 View in Google Earth 3D →
+            </a>
+          </div>
+        )}
 
         {/* Map — use address for non-Google-Places cottages */}
         <MapWidget

--- a/scripts/enrich-aerial-view.mjs
+++ b/scripts/enrich-aerial-view.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * enrich-aerial-view.mjs
+ *
+ * For each cottage with lat/lng, calls the Google Maps Aerial View API.
+ * If state === 'ACTIVE', saves aerialVideoUrl (MP4) and aerialVideoUrlWebm (WEBM)
+ * to the cottage JSON in data/cottages/index.json.
+ *
+ * Usage:
+ *   GOOGLE_MAPS_KEY=<key> node scripts/enrich-aerial-view.mjs
+ *   OR if GOOGLE_MAPS_KEY is already in the environment or .env.local
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+// Load .env.local if present
+const envPath = resolve(ROOT, '.env.local');
+if (existsSync(envPath)) {
+  const lines = readFileSync(envPath, 'utf-8').split('\n');
+  for (const line of lines) {
+    const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (match) process.env[match[1]] = match[2].replace(/^['"]|['"]$/g, '');
+  }
+}
+
+const API_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY || process.env.GOOGLE_MAPS_KEY;
+if (!API_KEY) {
+  console.error('❌ No Google Maps API key found. Set NEXT_PUBLIC_GOOGLE_MAPS_KEY or GOOGLE_MAPS_KEY.');
+  process.exit(1);
+}
+
+const AERIAL_VIEW_BASE = 'https://aerialview.googleapis.com/v1/videos:lookupVideo';
+const DELAY_MS = 300; // be polite between requests
+
+function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+async function lookupAerialView(lat, lng) {
+  const url = `${AERIAL_VIEW_BASE}?lat=${lat}&lng=${lng}&key=${API_KEY}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    const body = await res.text();
+    console.warn(`  ⚠️  HTTP ${res.status}: ${body.slice(0, 200)}`);
+    return null;
+  }
+  return res.json();
+}
+
+async function main() {
+  const cottagesPath = resolve(ROOT, 'data/cottages/index.json');
+  const raw = readFileSync(cottagesPath, 'utf-8');
+  const data = JSON.parse(raw);
+  const cottages = data.cottages;
+
+  let updated = 0;
+  let skipped = 0;
+  let noData = 0;
+
+  for (const cottage of cottages) {
+    const lat = cottage.coordinates?.lat || cottage.lat || cottage.latitude;
+    const lng = cottage.coordinates?.lng || cottage.lng || cottage.longitude;
+
+    if (!lat || !lng) {
+      console.log(`  ⏭  ${cottage.name || cottage.id} — no coordinates, skipping`);
+      skipped++;
+      continue;
+    }
+
+    // Skip if already enriched (re-run safe)
+    if (cottage.aerialVideoUrl) {
+      console.log(`  ✅ ${cottage.name || cottage.id} — already has aerial video`);
+      updated++;
+      continue;
+    }
+
+    console.log(`🔍 ${cottage.name || cottage.id} (${lat}, ${lng})...`);
+
+    try {
+      const result = await lookupAerialView(lat, lng);
+      await sleep(DELAY_MS);
+
+      if (!result) {
+        console.log(`  ⚠️  No response for ${cottage.name || cottage.id}`);
+        noData++;
+        continue;
+      }
+
+      if (result.state === 'ACTIVE' && result.uris) {
+        const mp4 = result.uris.MP4_HIGH || result.uris.MP4_MEDIUM;
+        const webm = result.uris.WEBM;
+        if (mp4) {
+          cottage.aerialVideoUrl = mp4;
+          cottage.aerialVideoUrlWebm = webm || null;
+          console.log(`  🛸 ACTIVE — saved aerial video`);
+          updated++;
+        } else {
+          console.log(`  ⚠️  ACTIVE but no MP4 URI`);
+          noData++;
+        }
+      } else {
+        console.log(`  📷 state=${result.state || 'unknown'} — using photo fallback`);
+        noData++;
+      }
+    } catch (err) {
+      console.error(`  ❌ Error for ${cottage.name || cottage.id}: ${err.message}`);
+      noData++;
+    }
+  }
+
+  writeFileSync(cottagesPath, JSON.stringify(data, null, 2));
+
+  console.log(`\n✅ Done: ${updated} aerial videos saved, ${noData} photo fallbacks, ${skipped} skipped (no coords)`);
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Replaces the static hero photo on cottage cards with a 5-second aerial drone video clip where Google has coverage. Falls back to photo silently if no coverage exists.

## Changes

### AccommodationCard.tsx
- When `aerialVideoUrl` is present, renders a `<video autoPlay muted loop playsInline poster={heroImage}>` as the hero
- WebM source first for bandwidth efficiency, MP4 fallback
- Absolute-positioned video fills the hero container with `object-fit: cover`
- Dark gradient overlay sits on top of video (same effect as photo hero)
- **🛸 Aerial view** badge bottom-left when video is active
- Street view badge only shows when no aerial video present
- **🌍 View in Google Earth 3D →** text link above the map widget
- `aerialVideoUrl` / `aerialVideoUrlWebm` added to `AccommodationData` interface

### scripts/enrich-aerial-view.mjs (new)
- Build-time enrichment script for cottage data
- Reads `data/cottages/index.json`, calls Google Aerial View API for each cottage with coordinates
- If `state === 'ACTIVE'`, saves `aerialVideoUrl` (MP4_HIGH) and `aerialVideoUrlWebm` to cottage object
- If no coverage (`UNPROCESSED`), leaves fields empty — card uses photo as normal
- Re-run safe (skips already-enriched cottages)
- Loads `NEXT_PUBLIC_GOOGLE_MAPS_KEY` from `.env.local` automatically

## Fallback behaviour
- `poster={heroImage}` shows photo while video loads → seamless
- If video fails entirely, browser shows poster → seamless
- If no `aerialVideoUrl` on cottage data → hero renders as photo, no change

## Running the enrichment
```bash
node scripts/enrich-aerial-view.mjs
```
(Requires Aerial View API enabled in Google Cloud Console for the project API key)

## Smoke test
✅ 8/8 passed

Addresses issue #142