### PR TITLE
feat: Map tab on review pages — static map of unreviewed places

### DIFF
--- a/app/_components/ReviewContextClient.tsx
+++ b/app/_components/ReviewContextClient.tsx
@@ -9,8 +9,9 @@ import TypeBadge from './TypeBadge';
 import TriageButtons from './TriageButtons';
 import TripRouteMap from './TripRouteMap';
 import AccommodationReviewLayout from './AccommodationReviewLayout';
+import ReviewMapPanel from './ReviewMapPanel';
 
-type Tab = 'unreviewed' | 'saved' | 'dismissed';
+type Tab = 'unreviewed' | 'saved' | 'dismissed' | 'map';
 
 interface ReviewContextClientProps {
   userId: string;
@@ -163,10 +164,21 @@ export default function ReviewContextClient({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [discoveries, userId, context.key, triageKey]);
 
+  // Count mappable unreviewed places for Map tab badge
+  const mappableCount = useMemo(() => {
+    return discoveries.filter(d => {
+      const state = getTriageState(userId, context.key, d.place_id ?? d.id);
+      if (state !== 'unreviewed' && state !== 'resurfaced') return false;
+      return !!(d.lat ?? placeCoords[d.place_id ?? '']?.lat);
+    }).length;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [discoveries, userId, context.key, triageKey, placeCoords]);
+
   const tabs: { key: Tab; label: string; count: number }[] = [
     { key: 'unreviewed', label: 'Needs Review', count: counts.unreviewed },
     { key: 'saved', label: 'Saved', count: counts.saved },
     { key: 'dismissed', label: 'Dismissed', count: counts.dismissed },
+    { key: 'map', label: '🗺 Map', count: mappableCount },
   ];
 
   // Detect if >50% accommodation type → use rich layout
@@ -213,10 +225,20 @@ export default function ReviewContextClient({
           userId={userId}
           context={context}
           discoveries={discoveries}
-          tab={tab}
+          tab={(tab === 'map' ? 'unreviewed' : tab) as 'unreviewed' | 'saved' | 'dismissed'}
+        />
+      ) : tab === 'map' ? (
+        /* ── Map-only view (mobile full-screen, or desktop standalone) ── */
+        <ReviewMapPanel
+          discoveries={filtered}
+          placeCoords={placeCoords}
+          contextLabel={context.label}
+          city={context.city}
         />
       ) : (
-        <div className="review-list">
+        /* ── Desktop: list + sticky map side-by-side; mobile: list only ── */
+        <div className="review-list-map-layout">
+          <div className="review-list">
           {(() => {
             // Group by neighbourhood
             const groups: { name: string; items: typeof filtered }[] = [];
@@ -312,6 +334,17 @@ export default function ReviewContextClient({
               </p>
             </div>
           )}
+          </div>
+
+          {/* Desktop sticky map panel — hidden on mobile */}
+          <div className="review-map-sidebar">
+            <ReviewMapPanel
+              discoveries={filtered}
+              placeCoords={placeCoords}
+              contextLabel={context.label}
+              city={context.city}
+            />
+          </div>
         </div>
       )}
     </main>

--- a/app/_components/ReviewMapPanel.tsx
+++ b/app/_components/ReviewMapPanel.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import type { Discovery } from '../_lib/types';
+
+interface MappablePlace {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  index: number; // 1-based label matching card list order
+}
+
+interface ReviewMapPanelProps {
+  discoveries: Discovery[];
+  /** Pre-loaded place coords keyed by place_id */
+  placeCoords: Record<string, { lat: number; lng: number }>;
+  /** City / context label for fallback embed search */
+  contextLabel?: string;
+  city?: string;
+}
+
+const MAPS_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY || '';
+
+/** Auto-detect zoom based on marker spread (lat/lng span) */
+function calcZoom(places: MappablePlace[]): number {
+  if (places.length === 0) return 13;
+  const lats = places.map(p => p.lat);
+  const lngs = places.map(p => p.lng);
+  const latSpan = Math.max(...lats) - Math.min(...lats);
+  const lngSpan = Math.max(...lngs) - Math.min(...lngs);
+  const span = Math.max(latSpan, lngSpan);
+  if (span > 5) return 6;   // province-wide (cottages)
+  if (span > 2) return 8;
+  if (span > 0.5) return 11;
+  if (span > 0.1) return 13;
+  return 15;
+}
+
+/** Build Static Maps URL with numbered markers */
+function buildStaticMapUrl(places: MappablePlace[], size = '600x500'): string {
+  if (!MAPS_KEY || places.length === 0) return '';
+  const base = 'https://maps.googleapis.com/maps/api/staticmap';
+  const params = new URLSearchParams({ size, scale: '2', maptype: 'roadmap', key: MAPS_KEY });
+  // Static Maps supports label A–Z only, so we use letters for first 26
+  const LABELS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const markerParams: string[] = [];
+  for (const p of places) {
+    const label = p.index <= 26 ? LABELS[p.index - 1] : '+';
+    markerParams.push(`color:red|label:${label}|${p.lat},${p.lng}`);
+  }
+  // URLSearchParams doesn't support duplicate keys well, build manually
+  const markerStr = markerParams.map(m => `markers=${encodeURIComponent(m)}`).join('&');
+  return `${base}?${params.toString()}&${markerStr}`;
+}
+
+/** Google Maps link centered on the spread of markers */
+function buildGoogleMapsUrl(places: MappablePlace[], contextLabel = ''): string {
+  if (places.length === 0) return 'https://maps.google.com';
+  if (places.length === 1) {
+    return `https://www.google.com/maps/search/?api=1&query=${places[0]!.lat},${places[0]!.lng}`;
+  }
+  // Link to a Maps search for the context label
+  const q = encodeURIComponent(contextLabel || 'places');
+  return `https://www.google.com/maps/search/${q}/`;
+}
+
+export default function ReviewMapPanel({ discoveries, placeCoords, contextLabel, city }: ReviewMapPanelProps) {
+  // Build list of mappable places in card-list order
+  const mappable: MappablePlace[] = [];
+  let labelIndex = 1;
+  for (const d of discoveries) {
+    const lat = d.lat ?? (placeCoords[d.place_id ?? '']?.lat);
+    const lng = d.lng ?? (placeCoords[d.place_id ?? '']?.lng);
+    if (lat !== undefined && lng !== undefined) {
+      mappable.push({ id: d.id, name: d.name ?? '', lat, lng, index: labelIndex });
+    }
+    labelIndex++;
+  }
+
+  const unmappedCount = discoveries.length - mappable.length;
+  const zoom = calcZoom(mappable);
+  const mapUrl = buildStaticMapUrl(mappable);
+  const mapsLink = buildGoogleMapsUrl(mappable, contextLabel || city);
+
+  if (!MAPS_KEY) {
+    return (
+      <div className="review-map-panel review-map-panel-empty">
+        <p className="text-muted text-sm">Map unavailable — no API key configured.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="review-map-panel">
+      {/* Header */}
+      <div className="review-map-header">
+        <span className="review-map-count">
+          {mappable.length} place{mappable.length !== 1 ? 's' : ''} on map
+        </span>
+        {unmappedCount > 0 && (
+          <span className="review-map-unmapped text-muted text-xs">
+            · {unmappedCount} couldn&apos;t be mapped
+          </span>
+        )}
+      </div>
+
+      {/* Static map image */}
+      {mappable.length > 0 && mapUrl ? (
+        <a
+          href={mapsLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="review-map-link"
+          title="Open in Google Maps"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={mapUrl}
+            alt={`Map of ${mappable.length} places`}
+            className="review-map-img"
+            loading="lazy"
+          />
+        </a>
+      ) : (
+        <div className="review-map-panel-empty">
+          <p className="text-muted text-sm">No coordinates available for these places.</p>
+        </div>
+      )}
+
+      {/* Legend: place labels */}
+      {mappable.length > 0 && (
+        <div className="review-map-legend">
+          {mappable.map((p) => {
+            const LABELS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+            const label = p.index <= 26 ? LABELS[p.index - 1] : '•';
+            return (
+              <div key={p.id} className="review-map-legend-item">
+                <span className="review-map-legend-label">{label}</span>
+                <span className="review-map-legend-name">{p.name}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2168,6 +2168,124 @@ a:hover {
 }
 
 
+/* ---- Review Map Panel ---- */
+
+.review-list-map-layout {
+  display: flex;
+  gap: var(--space-md);
+  align-items: flex-start;
+}
+
+.review-list-map-layout .review-list {
+  flex: 1;
+  min-width: 0;
+}
+
+.review-map-sidebar {
+  width: 40%;
+  min-width: 260px;
+  max-width: 480px;
+  position: sticky;
+  top: 80px;
+  flex-shrink: 0;
+}
+
+/* On mobile: hide sidebar, map tab shows full panel */
+@media (max-width: 768px) {
+  .review-list-map-layout {
+    flex-direction: column;
+  }
+  .review-map-sidebar {
+    display: none;
+  }
+}
+
+.review-map-panel {
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--card-border);
+  background: var(--card-bg);
+}
+
+.review-map-panel-empty {
+  padding: var(--space-lg);
+  text-align: center;
+}
+
+.review-map-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--card-border);
+  font-size: 0.8rem;
+}
+
+.review-map-count {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.review-map-unmapped {
+  color: var(--text-muted);
+}
+
+.review-map-link {
+  display: block;
+  line-height: 0;
+}
+
+.review-map-img {
+  width: 100%;
+  height: auto;
+  display: block;
+  object-fit: cover;
+}
+
+.review-map-legend {
+  padding: var(--space-sm) var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 240px;
+  overflow-y: auto;
+  border-top: 1px solid var(--card-border);
+}
+
+.review-map-legend-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: 0.78rem;
+}
+
+.review-map-legend-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  min-width: 18px;
+  background: #e53e3e;
+  color: white;
+  font-size: 0.65rem;
+  font-weight: 700;
+  border-radius: 50% 50% 50% 0;
+  transform: rotate(-45deg);
+  flex-shrink: 0;
+}
+
+.review-map-legend-label > * {
+  transform: rotate(45deg);
+}
+
+.review-map-legend-name {
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ---- 22. Place Browse ---- */
 
 .place-browse-card {


### PR DESCRIPTION
## What

Adds a **🗺 Map** tab to every review page showing all unreviewed discoveries as lettered markers on a Google Static Map.

## Changes

### New: `app/_components/ReviewMapPanel.tsx`
- Builds a Google Static Maps API URL with `markers=color:red|label:A|lat,lng` for each mappable discovery
- Letters A–Z match card-list order so users can cross-reference
- Auto-detects zoom from marker spread: province-wide (zoom 6) for cottages, city-level (zoom 13–15) for trip contexts
- Clicking the map opens Google Maps at the location
- Shows count of mapped vs total, with note for unmapped places
- Graceful empty state when no API key or no coords available

### Updated: `app/_components/ReviewContextClient.tsx`
- `Tab` type extended with `'map'`
- `mappableCount` computed for tab badge (unreviewed discoveries with lat/lng)
- `'🗺 Map (N)'` tab added after Dismissed
- **Mobile**: map tab shows ReviewMapPanel full-width
- **Desktop**: list + sticky map panel side-by-side (40% width, sticky top)

### Updated: `app/globals.css`
- `.review-list-map-layout` — flex row layout, list `flex:1`, map panel 40%
- `.review-map-sidebar` — sticky, hidden on mobile (`max-width: 768px`)
- Full `.review-map-panel` styling — panel, header, img, scrollable legend

## Smoke test: 8/8 ✅ | TypeScript: clean ✅ | Build: passes ✅

Addresses issue #158