### PR TITLE
feat: Copy error report button on Admin Disco Activity and Cron error sections

### DIFF
--- a/app/_components/CopyErrorReportButton.tsx
+++ b/app/_components/CopyErrorReportButton.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+
+interface CopyErrorReportButtonProps {
+  report: string;
+}
+
+export default function CopyErrorReportButton({ report }: CopyErrorReportButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(report);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for older browsers / non-https
+      const el = document.createElement('textarea');
+      el.value = report;
+      el.style.position = 'fixed';
+      el.style.opacity = '0';
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand('copy');
+      document.body.removeChild(el);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="btn btn-sm"
+      style={{
+        fontSize: '0.75rem',
+        padding: '4px 10px',
+        background: copied ? 'rgba(34,197,94,0.15)' : 'rgba(244,67,54,0.1)',
+        color: copied ? '#22c55e' : '#f44336',
+        border: `1px solid ${copied ? 'rgba(34,197,94,0.3)' : 'rgba(244,67,54,0.3)'}`,
+        borderRadius: 6,
+        cursor: 'pointer',
+        transition: 'all 0.15s ease',
+        whiteSpace: 'nowrap',
+      }}
+      title="Copy error report to clipboard"
+    >
+      {copied ? '✓ Copied!' : '📋 Copy error report'}
+    </button>
+  );
+}

--- a/app/admin/AdminClient.tsx
+++ b/app/admin/AdminClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import WorkerCard from '../_components/WorkerCard';
+import CopyErrorReportButton from '../_components/CopyErrorReportButton';
 
 /* ---- Types ---- */
 
@@ -158,6 +159,86 @@ const AGENT_COLORS: Record<string, string> = {
 const AGENT_ROLES: Record<string, string> = { main: 'Orchestrator', devclaw: 'Development', disco: 'Discovery & Research' };
 const AGENT_ORDER: Record<string, number> = { main: 0, devclaw: 1, disco: 2 };
 
+/* ---- Error Report Builder ---- */
+
+function buildErrorReport(
+  discoActivity: DiscoActivityData | null,
+  crons: CronJob[],
+  workers: WorkerInfo[],
+  stats: AgentHealthStats | null,
+): string {
+  const now = new Date();
+  const dateStr = now.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+  const timeStr = now.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
+
+  const lines: string[] = [];
+  lines.push(`🔴 Compass Error Report — ${dateStr}, ${timeStr}`);
+  lines.push('');
+
+  // Disco errors
+  const discoErrorJobs = discoActivity?.jobs.filter(j => j.consecutiveErrors > 0) ?? [];
+  if (discoActivity && (discoActivity.errorsToday > 0 || discoErrorJobs.length > 0)) {
+    lines.push('Disco Activity:');
+    for (const job of discoErrorJobs) {
+      const errPlural = job.consecutiveErrors === 1 ? 'error' : 'errors';
+      const errMsg = job.lastError ? `${job.lastError}` : 'unknown error';
+      const lastRun = job.lastRun ? formatRelativeTime(job.lastRun) : 'never';
+      lines.push(`• ${job.name}: ${errMsg} (${job.consecutiveErrors} consecutive ${errPlural})`);
+      lines.push(`  Last run: ${lastRun} | Job ID: ${job.id.slice(0, 8)}`);
+    }
+    // Fallback: show raw errorDetails if no per-job breakdown
+    if (discoErrorJobs.length === 0 && discoActivity.errorDetails.length > 0) {
+      for (const e of discoActivity.errorDetails) {
+        lines.push(`• ${e}`);
+      }
+    }
+    lines.push('');
+  }
+
+  // Cron errors
+  const cronErrors = crons.filter(j => (j.consecutiveErrors ?? 0) > 0);
+  if (cronErrors.length > 0) {
+    lines.push('Cron Health:');
+    for (const job of cronErrors) {
+      const errMsg = job.lastError || 'unknown error';
+      const lastRun = job.lastRun ? formatRelativeTime(job.lastRun) : 'never';
+      const nextRun = job.nextRun ? formatRelativeTime(job.nextRun) : '—';
+      lines.push(`• ${job.name}: ${errMsg} (${job.consecutiveErrors} consecutive)`);
+      lines.push(`  Last run: ${lastRun} | Next: ${nextRun}`);
+    }
+    lines.push('');
+  }
+
+  // System context
+  lines.push('System:');
+  if (workers.length > 0) {
+    const workerNames = workers
+      .map(w => {
+        const sub = w.sessionKey.replace(/^agent:main:subagent:/, '');
+        const parts = sub.split('-');
+        // Format: project-role-level-name → "Name level"
+        if (parts.length >= 4) {
+          const name = parts.slice(3).map(p => p.charAt(0).toUpperCase() + p.slice(1)).join(' ');
+          const level = parts[2];
+          return `${name} ${level}`;
+        }
+        return sub;
+      })
+      .join(', ');
+    lines.push(`• Active workers: ${workers.length} (${workerNames})`);
+  }
+  if (discoActivity) {
+    const lastRunStr = discoActivity.lastRunAtMs ? formatRelativeTime(discoActivity.lastRunAtMs) : 'never';
+    lines.push(`• Last successful Disco run: ${lastRunStr}`);
+    lines.push(`• Discoveries today: ${discoActivity.discoveriesToday}`);
+  }
+  if (stats) {
+    lines.push(`• Place cards: ${stats.placeCards} | Cottages: ${stats.cottages}`);
+  }
+
+  return lines.join('\n');
+}
+
 /* ---- Collapsible Section ---- */
 
 function Section({ title, emoji, count, children }: {
@@ -299,7 +380,14 @@ export default function AdminClient() {
                   <td style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>{fmtDuration(job.lastDuration)}</td>
                   <td style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>{job.nextRun ? formatRelativeTime(job.nextRun) : '—'}</td>
                   <td style={{ textAlign: 'center', color: (job.consecutiveErrors ?? 0) > 0 ? '#f44336' : 'var(--text-muted)' }}>
-                    {(job.consecutiveErrors ?? 0) > 0 ? job.consecutiveErrors : '—'}
+                    {(job.consecutiveErrors ?? 0) > 0 ? (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'center' }}>
+                        <span>{job.consecutiveErrors}</span>
+                        <CopyErrorReportButton
+                          report={buildErrorReport(discoActivity, [job], workers, stats)}
+                        />
+                      </div>
+                    ) : '—'}
                   </td>
                 </tr>
                 );
@@ -500,6 +588,15 @@ export default function AdminClient() {
                 color: '#f44336',
               }}>
                 {discoActivity.errorDetails.map((e, i) => <div key={i}>{e}</div>)}
+              </div>
+            )}
+
+            {/* Copy error report button — shown when there are active errors */}
+            {(discoActivity.errorsToday > 0 || discoActivity.jobs.some(j => j.consecutiveErrors > 0)) && (
+              <div style={{ marginTop: 'var(--space-sm)' }}>
+                <CopyErrorReportButton
+                  report={buildErrorReport(discoActivity, crons, workers, stats)}
+                />
               </div>
             )}
 


### PR DESCRIPTION
## Summary

Adds a `📋 Copy error report` button that generates a Discord-ready error report for quick debugging.

## Changes

### New: `app/_components/CopyErrorReportButton.tsx`
- Client component using `navigator.clipboard.writeText()` with `execCommand` fallback
- Shows '✓ Copied!' for 2s after click, then resets

### `app/admin/AdminClient.tsx`
- `buildErrorReport()` helper: formats active disco job errors, cron errors, and system context (workers, discoveries today, stats) into a pasteable message
- **Disco Activity section**: button shown below error detail box when `errorsToday > 0` or any job has `consecutiveErrors > 0`
- **Cron Jobs table**: button shown inline in the Err column for each job with `consecutiveErrors > 0`

## Report format
```
🔴 Compass Error Report — Mon Mar 30, 10:16 PM

Disco Activity:
• Evening Source Scout: timeout (1 consecutive error)
  Last run: 4h ago | Job ID: adef7497

Cron Health:
• DevClaw Pipeline Check: timeout (1 consecutive)
  Last run: 30m ago | Next: in 30m

System:
• Active workers: 3 (Marji medior, Brunhilda medior, Seka medior)
• Last successful Disco run: 12m ago
• Discoveries today: 231
• Place cards: 95 | Cottages: 68
```

Addresses issue #162