### PR TITLE
feat: AccommodationCard aerial drone video hero with photo fallback (#142)

### DIFF
--- a/app/_components/AccommodationCard.tsx
+++ b/app/_components/AccommodationCard.tsx
@@ -129,6 +129,9 @@ interface AccommodationData {
   lng?: number;
   latitude?: number;
   longitude?: number;
+  // Aerial view video from Google Aerial View API
+  aerialVideoUrl?: string | null;
+  aerialVideoUrlWebm?: string | null;
 }
 
 interface AccommodationCardProps {
@@ -199,26 +202,53 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
   return (
     <div className="accommodation-card">
       {/* ── Hero ── */}
-      <div
-        className="accommodation-hero"
-        style={{
-          minHeight: 'min(45vw, 320px)',
-          background: heroImage
-            ? `linear-gradient(to bottom, rgba(0,0,0,0) 35%, rgba(0,0,0,0.75) 100%), url(${heroImage}) center/cover no-repeat`
-            : LAKE_GRADIENT,
-        }}
-      >
-        <div className="accommodation-hero-overlay">
-          <div className="accommodation-hero-top">
-            <span className="accommodation-type-badge">🏡 Cottage</span>
-            {matchScore && (
-              <span className="accommodation-match-badge">⭐ {matchScore}/5</span>
-            )}
+      {data.aerialVideoUrl ? (
+        <div className="accommodation-hero" style={{ position: 'relative', minHeight: 'min(45vw, 320px)', borderRadius: '12px 12px 0 0', overflow: 'hidden' }}>
+          <video
+            autoPlay
+            muted
+            loop
+            playsInline
+            poster={heroImage || undefined}
+            style={{ width: '100%', height: '300px', objectFit: 'cover', display: 'block' }}
+          >
+            {data.aerialVideoUrlWebm && <source src={data.aerialVideoUrlWebm} type="video/webm" />}
+            <source src={data.aerialVideoUrl} type="video/mp4" />
+          </video>
+          <div className="accommodation-hero-overlay" style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, background: 'linear-gradient(to bottom, rgba(0,0,0,0) 40%, rgba(0,0,0,0.75) 100%)' }}>
+            <div className="accommodation-hero-top">
+              <span className="accommodation-type-badge">🏡 Cottage</span>
+              {matchScore && <span className="accommodation-match-badge">⭐ {matchScore}/5</span>}
+            </div>
+            <h1 className="accommodation-name">{name}</h1>
+            {region && <p className="accommodation-location">📍 {region}</p>}
           </div>
-          <h1 className="accommodation-name">{name}</h1>
-          {region && <p className="accommodation-location">📍 {region}</p>}
+          <div style={{ position: 'absolute', bottom: '8px', left: '10px', background: 'rgba(0,0,0,0.55)', color: '#fff', borderRadius: '6px', padding: '3px 8px', fontSize: '11px', backdropFilter: 'blur(4px)' }}>
+            🛸 Aerial view
+          </div>
         </div>
-      </div>
+      ) : (
+        <div
+          className="accommodation-hero"
+          style={{
+            minHeight: 'min(45vw, 320px)',
+            background: heroImage
+              ? `linear-gradient(to bottom, rgba(0,0,0,0) 35%, rgba(0,0,0,0.75) 100%), url(${heroImage}) center/cover no-repeat`
+              : LAKE_GRADIENT,
+          }}
+        >
+          <div className="accommodation-hero-overlay">
+            <div className="accommodation-hero-top">
+              <span className="accommodation-type-badge">🏡 Cottage</span>
+              {matchScore && (
+                <span className="accommodation-match-badge">⭐ {matchScore}/5</span>
+              )}
+            </div>
+            <h1 className="accommodation-name">{name}</h1>
+            {region && <p className="accommodation-location">📍 {region}</p>}
+          </div>
+        </div>
+      )}
 
       {/* ── Body ── */}
       <div className="accommodation-body">
@@ -375,6 +405,17 @@ export default function AccommodationCard({ data, placeId, userId, contextKey }:
           lng={data.lng || data.longitude}
           name={`${name}${region ? ', ' + region : ''}`}
         />
+
+        <div style={{ textAlign: 'center', marginTop: '8px', paddingBottom: '4px' }}>
+          <a
+            href={`https://earth.google.com/web/search/${encodeURIComponent(`${name}${region ? ', ' + region : ''}`)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ fontSize: '13px', color: '#0ea5e9', textDecoration: 'none' }}
+          >
+            🌍 View in Google Earth 3D →
+          </a>
+        </div>
 
       </div>
     </div>

--- a/data/cottages/concierge-cottages.json
+++ b/data/cottages/concierge-cottages.json
@@ -12,9 +12,28 @@
     "swimScore": 4,
     "swimType": "Sandy",
     "swimVerdict": "Sandy beach access via ~90 shared stairs (flights of 6-8 steps with platforms). Shared with sister cottage Shades of Blue.",
-    "amenities": ["WiFi", "Satellite TV", "Amazon FireStick", "Large Screen TV", "Dishwasher", "Full Kitchen", "Fire Pit", "Gas BBQ", "2 Picnic Tables", "Snug/Reading Nook", "Dog Friendly"],
-    "coordinates": {"lat": 43.573, "lng": -81.698},
-    "driveTimes": {"groceries": "2 min (Bayfield)", "restaurants": "2 min (Bayfield)", "dianaKlaus": "1h 15min"},
+    "amenities": [
+      "WiFi",
+      "Satellite TV",
+      "Amazon FireStick",
+      "Large Screen TV",
+      "Dishwasher",
+      "Full Kitchen",
+      "Fire Pit",
+      "Gas BBQ",
+      "2 Picnic Tables",
+      "Snug/Reading Nook",
+      "Dog Friendly"
+    ],
+    "coordinates": {
+      "lat": 43.573,
+      "lng": -81.698
+    },
+    "driveTimes": {
+      "groceries": "2 min (Bayfield)",
+      "restaurants": "2 min (Bayfield)",
+      "dianaKlaus": "1h 15min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "Rates page mentions 2026 rates but calendar rendering unclear. Weekly-only in July/August (Sun-Sun). Inquiry needed for specific weeks.",
     "notes": "Classic rustic 3-season lakefront cottage. 2BR main cottage + 2BR bunkie. Max 8 people. 2.3km from Bayfield downtown. No linens/towels provided. $500 refundable security deposit. Sister cottage to Shades of Blue. Beds: BR1 single bunks (sleeps 2), BR2 queen (2), BR3 double (2), BR4 single-over-double bunk + single (3)."
@@ -32,9 +51,25 @@
     "swimScore": 5,
     "swimType": "Sandy/Waterfront",
     "swimVerdict": "Directly on Lake Huron waterfront with spacious lot. Double-wide lot backing right onto the water.",
-    "amenities": ["WiFi", "Gas Fireplace", "Dishwasher", "Laundry", "BBQ", "Firepit", "3 Decks", "Bunkie House"],
-    "coordinates": {"lat": 43.565, "lng": -81.700},
-    "driveTimes": {"groceries": "5 min (Bayfield)", "restaurants": "5 min (Bayfield)", "dianaKlaus": "1h 15min"},
+    "amenities": [
+      "WiFi",
+      "Gas Fireplace",
+      "Dishwasher",
+      "Laundry",
+      "BBQ",
+      "Firepit",
+      "3 Decks",
+      "Bunkie House"
+    ],
+    "coordinates": {
+      "lat": 43.565,
+      "lng": -81.7
+    },
+    "driveTimes": {
+      "groceries": "5 min (Bayfield)",
+      "restaurants": "5 min (Bayfield)",
+      "dianaKlaus": "1h 15min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "VRBO listing — check availability on platform. 15 min drive to Grand Bend.",
     "notes": "3 bedrooms + bunkie house with bunk beds. 2 full bathrooms. Double wide lot with three decks. Directly on Lake Huron waterfront. Host named Heather — described as excellent. Reviews praise spaciousness exceeding photos. 5 min to Bayfield, 15 min to Grand Bend."
@@ -52,9 +87,22 @@
     "swimScore": 3,
     "swimType": "Mixed sand/stone",
     "swimVerdict": "Lake access with variable lakebed — sandy or stoney depending on conditions. Sand typically found 3ft out. Good for stone collecting. Not weedy or slimy. Water shoes recommended.",
-    "amenities": ["WiFi", "Lake View", "Lake Access", "Dog Friendly (2 dogs)", "Noise Monitor"],
-    "coordinates": {"lat": 43.560, "lng": -81.695},
-    "driveTimes": {"groceries": "5 min (Bayfield)", "restaurants": "5 min (Bayfield)", "dianaKlaus": "1h 15min"},
+    "amenities": [
+      "WiFi",
+      "Lake View",
+      "Lake Access",
+      "Dog Friendly (2 dogs)",
+      "Noise Monitor"
+    ],
+    "coordinates": {
+      "lat": 43.56,
+      "lng": -81.695
+    },
+    "driveTimes": {
+      "groceries": "5 min (Bayfield)",
+      "restaurants": "5 min (Bayfield)",
+      "dianaKlaus": "1h 15min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "Summer weekly rentals Sun-Sun. Contact CottageStays for pricing/availability. License #BWSTR25-019.",
     "notes": "3BR, 1 bath, sleeps 6. Max 2 dogs allowed (pet addendum required). Parking limited to 3 vehicles. Noise/temp/wifi monitoring device. Primary renter must be over 25. Parties strictly prohibited. Max occupancy 6 at all times."
@@ -72,9 +120,39 @@
     "swimScore": 3,
     "swimType": "Sandy (stairs)",
     "swimVerdict": "Lake access via approx 45 stairs to beach. Includes kayaks, paddleboard & lake mat for water activities.",
-    "amenities": ["WiFi", "AC", "Gas Fireplace", "TV with FireStick", "Netflix", "Prime Video", "Piano", "Games", "Cedar Barrel Sauna", "EV Charger", "Kayaks", "Paddleboard", "Lake Mat", "Hammock", "Espresso Maker", "Propane BBQ", "Charcoal BBQ", "Fire Pit", "Dishwasher", "Ice Maker", "Private Balcony", "Dog Friendly (2 pets)"],
-    "coordinates": {"lat": 43.555, "lng": -81.690},
-    "driveTimes": {"groceries": "10 min (Bayfield)", "restaurants": "10 min (Bayfield)", "dianaKlaus": "1h 10min"},
+    "amenities": [
+      "WiFi",
+      "AC",
+      "Gas Fireplace",
+      "TV with FireStick",
+      "Netflix",
+      "Prime Video",
+      "Piano",
+      "Games",
+      "Cedar Barrel Sauna",
+      "EV Charger",
+      "Kayaks",
+      "Paddleboard",
+      "Lake Mat",
+      "Hammock",
+      "Espresso Maker",
+      "Propane BBQ",
+      "Charcoal BBQ",
+      "Fire Pit",
+      "Dishwasher",
+      "Ice Maker",
+      "Private Balcony",
+      "Dog Friendly (2 pets)"
+    ],
+    "coordinates": {
+      "lat": 43.555,
+      "lng": -81.69
+    },
+    "driveTimes": {
+      "groceries": "10 min (Bayfield)",
+      "restaurants": "10 min (Bayfield)",
+      "dianaKlaus": "1h 10min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "Summer weekly rentals Sun-Sun. Contact CottageStays for pricing. $500 security deposit, $75 booking fee, $125 cleaning fee. Linen rental $20/person.",
     "notes": "Standout property — newly added AC, panoramic window cedar barrel sauna (wood provided), EV charger. Upstairs master with NEW king bed, 2 downstairs queens. Upstairs + downstairs 3pc bathrooms with showers. Well-equipped kitchen with espresso maker, Ninja blender, ice maker. 10 min from Bayfield. Max 5 occupancy. License #BWSTR25-063."
@@ -92,9 +170,26 @@
     "swimScore": 4,
     "swimType": "Sandy/Lakefront",
     "swimVerdict": "Lakefront property designed to take advantage of lake views from every angle — kitchen, fireplace, hot tub, gazebo, and beach. Direct lake view and access.",
-    "amenities": ["WiFi", "AC", "Gas Fireplace", "Hot Tub", "Lake View", "Lake Access", "Gazebo", "Dog Friendly (2 pets)", "Noise Monitor"],
-    "coordinates": {"lat": 43.562, "lng": -81.697},
-    "driveTimes": {"groceries": "5 min (Bayfield)", "restaurants": "5 min (Bayfield)", "dianaKlaus": "1h 15min"},
+    "amenities": [
+      "WiFi",
+      "AC",
+      "Gas Fireplace",
+      "Hot Tub",
+      "Lake View",
+      "Lake Access",
+      "Gazebo",
+      "Dog Friendly (2 pets)",
+      "Noise Monitor"
+    ],
+    "coordinates": {
+      "lat": 43.562,
+      "lng": -81.697
+    },
+    "driveTimes": {
+      "groceries": "5 min (Bayfield)",
+      "restaurants": "5 min (Bayfield)",
+      "dianaKlaus": "1h 15min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "Summer weekly rentals Sun-Sun. Contact CottageStays for pricing. Max occupancy 4 per listing terms (task says sleeps 5).",
     "notes": "Open concept with reclaimed barn wood beams, thick stone walls, full wall of windows. Hot tub with lake views. Designed for immersive lakefront experience. Max occupancy listed as 4 on rental terms (original brief says sleeps 5). Parking limited to 3 vehicles. License #BWSTR25-054."
@@ -112,9 +207,26 @@
     "swimScore": 4,
     "swimType": "Sandy/Lakefront",
     "swimVerdict": "Lake view and lake access. Exceptional Bayfield beach cottage with stunning lake views inside and out.",
-    "amenities": ["WiFi", "Gas Fireplace", "Hot Tub", "AC", "Lake View", "Lake Access", "Parking", "Dog Friendly (1 dog)", "Noise Monitor"],
-    "coordinates": {"lat": 43.567, "lng": -81.699},
-    "driveTimes": {"groceries": "5 min (Bayfield)", "restaurants": "5 min (Bayfield)", "dianaKlaus": "1h 15min"},
+    "amenities": [
+      "WiFi",
+      "Gas Fireplace",
+      "Hot Tub",
+      "AC",
+      "Lake View",
+      "Lake Access",
+      "Parking",
+      "Dog Friendly (1 dog)",
+      "Noise Monitor"
+    ],
+    "coordinates": {
+      "lat": 43.567,
+      "lng": -81.699
+    },
+    "driveTimes": {
+      "groceries": "5 min (Bayfield)",
+      "restaurants": "5 min (Bayfield)",
+      "dianaKlaus": "1h 15min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "Also listed on VRBO (#9548393ha) at ~$215/night avg and Airbnb (#47579306). Summer weekly rentals Sun-Sun via CottageStays. $257/night on Tripadvisor.",
     "notes": "2BR, 1 bath, sleeps 4. Queen bed in master. Hot tub. Gas fireplace. Stunning lake views from inside. Full-size appliances, plenty of counter space. Max 1 well-behaved dog. Professionally managed by Jennifer at CottageStays. License #BWSTR25-072."
@@ -132,9 +244,26 @@
     "swimScore": 4,
     "swimType": "Sandy/Lakefront",
     "swimVerdict": "Lake view and lake access. Unforgettable sunsets from the property.",
-    "amenities": ["WiFi", "AC", "Gas Fireplace", "Hot Tub", "King Bed", "Lake View", "Lake Access", "Dog Friendly (1 dog)", "Noise Monitor"],
-    "coordinates": {"lat": 43.564, "lng": -81.698},
-    "driveTimes": {"groceries": "5 min (Bayfield)", "restaurants": "5 min (Bayfield)", "dianaKlaus": "1h 15min"},
+    "amenities": [
+      "WiFi",
+      "AC",
+      "Gas Fireplace",
+      "Hot Tub",
+      "King Bed",
+      "Lake View",
+      "Lake Access",
+      "Dog Friendly (1 dog)",
+      "Noise Monitor"
+    ],
+    "coordinates": {
+      "lat": 43.564,
+      "lng": -81.698
+    },
+    "driveTimes": {
+      "groceries": "5 min (Bayfield)",
+      "restaurants": "5 min (Bayfield)",
+      "dianaKlaus": "1h 15min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "Summer weekly rentals. Contact CottageStays for pricing/availability. Winter cancellation policy is flexible (full refund if weather prevents travel).",
     "notes": "2BR, 1.5 bath, sleeps 5. King bed — great for couples. Hot tub. Bright interiors. Perfect for family adventures or romantic escapes. Max 1 dog allowed. May have outdoor camera. License #BWSTR25-156."
@@ -152,9 +281,29 @@
     "swimScore": 5,
     "swimType": "Sandy/Lakefront",
     "swimVerdict": "Lakefront with lots of beach! Lower sunset deck with seating overlooking lake. Direct lake view and lake access. Paddleboard & lake mat rentals available mid-June to mid-Sept.",
-    "amenities": ["WiFi", "Wood Fireplace", "TV with Roku", "DVD Library", "Propane BBQ", "Outdoor Shower", "Lower Sunset Deck", "Adirondack Chairs", "Outdoor Dining with Umbrella", "Paddleboard Rentals", "Lake Mat Rentals", "Dog Friendly (1 small pet)"],
-    "coordinates": {"lat": 43.568, "lng": -81.700},
-    "driveTimes": {"groceries": "5 min (Bayfield)", "restaurants": "5 min (Bayfield)", "dianaKlaus": "1h 15min"},
+    "amenities": [
+      "WiFi",
+      "Wood Fireplace",
+      "TV with Roku",
+      "DVD Library",
+      "Propane BBQ",
+      "Outdoor Shower",
+      "Lower Sunset Deck",
+      "Adirondack Chairs",
+      "Outdoor Dining with Umbrella",
+      "Paddleboard Rentals",
+      "Lake Mat Rentals",
+      "Dog Friendly (1 small pet)"
+    ],
+    "coordinates": {
+      "lat": 43.568,
+      "lng": -81.7
+    },
+    "driveTimes": {
+      "groceries": "5 min (Bayfield)",
+      "restaurants": "5 min (Bayfield)",
+      "dianaKlaus": "1h 15min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "Summer weekly rentals. $500 security deposit, $75 booking fee, $150 cleaning fee. Linen rental $20/person.",
     "notes": "Vintage lakefront cottage with character. 2BR (both double beds) + pullout sofa. Half bathroom inside + outdoor shower only (no full indoor shower). Wood fireplace — real cottage feel. Lower sunset deck. Parking limited to 2 vehicles. Max 1 small pet. Playpen/highchair available on request. Kitchen: stove, oven, microwave, toaster, drip coffee maker, kettle, fridge."
@@ -172,9 +321,32 @@
     "swimScore": 4,
     "swimType": "Sandy/Private access",
     "swimVerdict": "Private beach access via short walk down the hill. Uncrowded beach. Parking at beach can be arranged for those who can't manage the incline.",
-    "amenities": ["WiFi", "AC", "Satellite TV", "46\" HD TV", "Netflix", "Linens Provided", "Towels Provided", "Washing Machine", "Propane BBQ", "Campfire Pit", "Wrap-Around Deck", "Water Cooler", "Iron & Board", "Hair Dryer", "Dog Friendly"],
-    "coordinates": {"lat": 43.776, "lng": -81.635},
-    "driveTimes": {"groceries": "5 min (general store) / 15 min (Goderich)", "restaurants": "15 min (Goderich)", "dianaKlaus": "1h 30min"},
+    "amenities": [
+      "WiFi",
+      "AC",
+      "Satellite TV",
+      "46\" HD TV",
+      "Netflix",
+      "Linens Provided",
+      "Towels Provided",
+      "Washing Machine",
+      "Propane BBQ",
+      "Campfire Pit",
+      "Wrap-Around Deck",
+      "Water Cooler",
+      "Iron & Board",
+      "Hair Dryer",
+      "Dog Friendly"
+    ],
+    "coordinates": {
+      "lat": 43.776,
+      "lng": -81.635
+    },
+    "driveTimes": {
+      "groceries": "5 min (general store) / 15 min (Goderich)",
+      "restaurants": "15 min (Goderich)",
+      "dianaKlaus": "1h 30min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "Weekly rate C$1,889-2,080. Summer weeks sell out early. Book via secure site at huronbeaches.ca. Cancellation: 30+ days = full refund less $50 fee.",
     "notes": "Step above usual cottage — described as 'conveniences of home with comfort of an excellent hotel.' Queen + double/single bunk beds (sleeps 5 max). Premium mattresses, fine linens & towels PROVIDED (unique among listings). Air conditioned. At end of dead-end road — very quiet. Hosts June & Keith nearby but leave you alone. 2h25min from Toronto. Pet fee C$60. C$400 pre-auth deposit. Also listed on CottagesInCanada (DI-25253) and TripAdvisor."

--- a/data/cottages/new-regions.json
+++ b/data/cottages/new-regions.json
@@ -12,9 +12,27 @@
     "swimScore": 5,
     "swimType": "Sandy",
     "swimVerdict": "50 feet of private sandy beach with gentle sloping entry into Georgian Bay. Crystal clear water, excellent for swimming and snorkeling. Views of Meaford Bluffs and Blue Mountains from the cottage.",
-    "amenities": ["WiFi", "Satellite TV", "Linens Provided", "Washer/Dryer", "BBQ", "Firepit", "2 Kayaks", "Paddle Boat", "Dock", "Full Kitchen"],
-    "coordinates": {"lat": 44.605, "lng": -80.595},
-    "driveTimes": {"groceries": "5 min", "restaurants": "5 min", "dianaKlaus": "3h 15min"},
+    "amenities": [
+      "WiFi",
+      "Satellite TV",
+      "Linens Provided",
+      "Washer/Dryer",
+      "BBQ",
+      "Firepit",
+      "2 Kayaks",
+      "Paddle Boat",
+      "Dock",
+      "Full Kitchen"
+    ],
+    "coordinates": {
+      "lat": 44.605,
+      "lng": -80.595
+    },
+    "driveTimes": {
+      "groceries": "5 min",
+      "restaurants": "5 min",
+      "dianaKlaus": "3h 15min"
+    },
     "julyStatus": "mostly_available",
     "julyNotes": "July 11 appears booked but most of July wide open. Weekly rentals Friday-Friday during summer. Updated March 3, 2026.",
     "imageUrls": [
@@ -39,9 +57,35 @@
     "swimScore": 4,
     "swimType": "Sandy",
     "swimVerdict": "5-minute walk to beautiful Meaford beaches on Georgian Bay. Multiple beaches within walking distance. Not waterfront but very close.",
-    "amenities": ["WiFi", "Central AC", "Smart TV", "Netflix/Disney+", "Dishwasher", "Washer/Dryer", "BBQ (natural gas)", "Firepit", "Bikes Provided", "Games Table", "Air Hockey", "Foosball", "Ping Pong", "Pool Table", "High Chair", "Crib", "Wheelchair Accessible", "Linens Provided"],
-    "coordinates": {"lat": 44.609, "lng": -80.589},
-    "driveTimes": {"groceries": "3 min", "restaurants": "3 min", "dianaKlaus": "3h 15min"},
+    "amenities": [
+      "WiFi",
+      "Central AC",
+      "Smart TV",
+      "Netflix/Disney+",
+      "Dishwasher",
+      "Washer/Dryer",
+      "BBQ (natural gas)",
+      "Firepit",
+      "Bikes Provided",
+      "Games Table",
+      "Air Hockey",
+      "Foosball",
+      "Ping Pong",
+      "Pool Table",
+      "High Chair",
+      "Crib",
+      "Wheelchair Accessible",
+      "Linens Provided"
+    ],
+    "coordinates": {
+      "lat": 44.609,
+      "lng": -80.589
+    },
+    "driveTimes": {
+      "groceries": "3 min",
+      "restaurants": "3 min",
+      "dianaKlaus": "3h 15min"
+    },
     "julyStatus": "mostly_available",
     "julyNotes": "July has scattered bookings but multiple weeks appear available. Calendar updated March 16, 2026. Contact owner for specific July weeks.",
     "imageUrls": [
@@ -66,9 +110,31 @@
     "swimScore": 5,
     "swimType": "Rocky",
     "swimVerdict": "Flat shoreline with shallow entry into remarkably clear Georgian Bay water. Excellent snorkeling. Swim raft provided. Safe for kids with gradual entry. Crystal clear water typical of the Wiarton/Bruce Peninsula area.",
-    "amenities": ["WiFi", "Satellite TV", "Blu-Ray/DVD", "Dishwasher", "Washer/Dryer", "Wood Fireplace", "Wood Stove", "BBQ", "Firepit", "2 Kayaks", "Swim Raft", "Life Jackets", "Muskoka Chairs", "Board Games"],
-    "coordinates": {"lat": 44.73, "lng": -81.05},
-    "driveTimes": {"groceries": "20 min (Wiarton)", "restaurants": "20 min (Wiarton)", "dianaKlaus": "2h 45min"},
+    "amenities": [
+      "WiFi",
+      "Satellite TV",
+      "Blu-Ray/DVD",
+      "Dishwasher",
+      "Washer/Dryer",
+      "Wood Fireplace",
+      "Wood Stove",
+      "BBQ",
+      "Firepit",
+      "2 Kayaks",
+      "Swim Raft",
+      "Life Jackets",
+      "Muskoka Chairs",
+      "Board Games"
+    ],
+    "coordinates": {
+      "lat": 44.73,
+      "lng": -81.05
+    },
+    "driveTimes": {
+      "groceries": "20 min (Wiarton)",
+      "restaurants": "20 min (Wiarton)",
+      "dianaKlaus": "2h 45min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "Contact Cottage Vacations for July 2026 availability. Managed by Ontario's premier rental company (since 1999). Popular property - book early.",
     "imageUrls": [
@@ -93,9 +159,28 @@
     "swimScore": 5,
     "swimType": "Sandy",
     "swimVerdict": "Less than 1-MINUTE WALK to Sauble Beach — 11km of pristine sandy beach on Lake Huron. Warm shallow water, world-class sunsets. One of Ontario's best swimming beaches.",
-    "amenities": ["WiFi", "Portable AC", "Smart TV", "Gas Fireplace", "Pool Table", "Trampoline", "Firepit", "BBQ", "Washer/Dryer", "Full Kitchen", "Dog Friendly (fee)"],
-    "coordinates": {"lat": 44.634, "lng": -81.265},
-    "driveTimes": {"groceries": "5 min", "restaurants": "5 min", "dianaKlaus": "2h 30min"},
+    "amenities": [
+      "WiFi",
+      "Portable AC",
+      "Smart TV",
+      "Gas Fireplace",
+      "Pool Table",
+      "Trampoline",
+      "Firepit",
+      "BBQ",
+      "Washer/Dryer",
+      "Full Kitchen",
+      "Dog Friendly (fee)"
+    ],
+    "coordinates": {
+      "lat": 44.634,
+      "lng": -81.265
+    },
+    "driveTimes": {
+      "groceries": "5 min",
+      "restaurants": "5 min",
+      "dianaKlaus": "2h 30min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "Calendar shows July 2026 — availability not yet fully marked. Contact office at 519-422-1313 for specific weeks. Saturday-Saturday rentals. Families only.",
     "imageUrls": [
@@ -120,9 +205,27 @@
     "swimScore": 5,
     "swimType": "Sandy",
     "swimVerdict": "5-minute walk to Sauble Beach's famous 11km sandy shoreline on Lake Huron. Warm, shallow water perfect for families. World-class sunsets.",
-    "amenities": ["WiFi", "Central AC", "Central Heat", "Dishwasher", "Washer/Dryer", "BBQ", "Firepit", "Full Kitchen", "Blender", "4 Parking Spaces"],
-    "coordinates": {"lat": 44.632, "lng": -81.268},
-    "driveTimes": {"groceries": "5 min", "restaurants": "5 min", "dianaKlaus": "2h 30min"},
+    "amenities": [
+      "WiFi",
+      "Central AC",
+      "Central Heat",
+      "Dishwasher",
+      "Washer/Dryer",
+      "BBQ",
+      "Firepit",
+      "Full Kitchen",
+      "Blender",
+      "4 Parking Spaces"
+    ],
+    "coordinates": {
+      "lat": 44.632,
+      "lng": -81.268
+    },
+    "driveTimes": {
+      "groceries": "5 min",
+      "restaurants": "5 min",
+      "dianaKlaus": "2h 30min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "Calendar shows July 2026 dates. Contact office at 519-422-1313. Sunday-Sunday rentals. Families only. No pets.",
     "imageUrls": [
@@ -147,9 +250,31 @@
     "swimScore": 4,
     "swimType": "Sandy",
     "swimVerdict": "10-minute walk to Lake Huron's sandy beach, plus minutes from Silver Lake shoreline. Two water bodies to choose from. Beach wagon and chairs provided. 2 kayaks + canoe included for water exploration.",
-    "amenities": ["WiFi", "Smart TV", "Gas Fireplace", "BBQ (direct gas)", "Firepit", "2 Kayaks", "Canoe", "Beach Wagon", "Beach Chairs", "Basketball Hoop", "Hammock", "PlayStation 4", "Board Games", "DVD Collection"],
-    "coordinates": {"lat": 44.629, "lng": -81.258},
-    "driveTimes": {"groceries": "8 min", "restaurants": "8 min", "dianaKlaus": "2h 30min"},
+    "amenities": [
+      "WiFi",
+      "Smart TV",
+      "Gas Fireplace",
+      "BBQ (direct gas)",
+      "Firepit",
+      "2 Kayaks",
+      "Canoe",
+      "Beach Wagon",
+      "Beach Chairs",
+      "Basketball Hoop",
+      "Hammock",
+      "PlayStation 4",
+      "Board Games",
+      "DVD Collection"
+    ],
+    "coordinates": {
+      "lat": 44.629,
+      "lng": -81.258
+    },
+    "driveTimes": {
+      "groceries": "8 min",
+      "restaurants": "8 min",
+      "dianaKlaus": "2h 30min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "Calendar shows July 2026. Contact office for availability. Saturday-Saturday rentals. No pets.",
     "imageUrls": [
@@ -174,9 +299,26 @@
     "swimScore": 5,
     "swimType": "Sandy",
     "swimVerdict": "5-minute walk to Port Elgin's beautiful sandy beach on Lake Huron. North Shore Park Splash Pad nearby for kids. Sheltered swimming areas. Stunning sunsets over the lake.",
-    "amenities": ["WiFi", "Smart TV", "Roku/Netflix", "Gas Fireplace", "BBQ", "Firepit", "Full Kitchen", "Fenced Backyard", "Covered Porch"],
-    "coordinates": {"lat": 44.442, "lng": -81.395},
-    "driveTimes": {"groceries": "5 min", "restaurants": "5 min", "dianaKlaus": "2h 15min"},
+    "amenities": [
+      "WiFi",
+      "Smart TV",
+      "Roku/Netflix",
+      "Gas Fireplace",
+      "BBQ",
+      "Firepit",
+      "Full Kitchen",
+      "Fenced Backyard",
+      "Covered Porch"
+    ],
+    "coordinates": {
+      "lat": 44.442,
+      "lng": -81.395
+    },
+    "driveTimes": {
+      "groceries": "5 min",
+      "restaurants": "5 min",
+      "dianaKlaus": "2h 15min"
+    },
     "julyStatus": "mostly_available",
     "julyNotes": "July shows first two weeks may have some bookings, but weeks of July 18-25 and July 25-Aug 1 appear available. Calendar updated Feb 4, 2026. Saturday-Saturday rentals.",
     "imageUrls": [
@@ -201,9 +343,27 @@
     "swimScore": 4,
     "swimType": "Sandy",
     "swimVerdict": "Directly across the road from Miramichi Bay on Lake Huron. Sandy beach access steps away. Located on the Great Lakes Waterfront Trail for walking/biking along the lakeshore.",
-    "amenities": ["WiFi", "TV", "BBQ", "Firepit", "Wood Stove", "Washer/Dryer", "Full Kitchen", "Parking", "Pet Friendly", "Woodland Trail Access"],
-    "coordinates": {"lat": 44.460, "lng": -81.400},
-    "driveTimes": {"groceries": "5 min (Port Elgin or Southampton)", "restaurants": "5 min", "dianaKlaus": "2h 15min"},
+    "amenities": [
+      "WiFi",
+      "TV",
+      "BBQ",
+      "Firepit",
+      "Wood Stove",
+      "Washer/Dryer",
+      "Full Kitchen",
+      "Parking",
+      "Pet Friendly",
+      "Woodland Trail Access"
+    ],
+    "coordinates": {
+      "lat": 44.46,
+      "lng": -81.4
+    },
+    "driveTimes": {
+      "groceries": "5 min (Port Elgin or Southampton)",
+      "restaurants": "5 min",
+      "dianaKlaus": "2h 15min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "No availability calendar displayed on listing. Contact owner directly. Newly renovated four-season cottage.",
     "imageUrls": [
@@ -228,9 +388,24 @@
     "swimScore": 5,
     "swimType": "Sandy",
     "swimVerdict": "1-minute walk to Beach Area 4 — one of the best stretches of Wasaga's 14km of sandy shoreline (longest freshwater beach in the world). Warm, shallow Georgian Bay water. Dog-friendly Beach 3 also within walking distance.",
-    "amenities": ["WiFi (5G)", "AC", "TV", "Full Kitchen", "Firepit", "BBQ", "Parking"],
-    "coordinates": {"lat": 44.516, "lng": -80.010},
-    "driveTimes": {"groceries": "5 min", "restaurants": "2 min (Tim Hortons, McDonald's)", "dianaKlaus": "3h 30min"},
+    "amenities": [
+      "WiFi (5G)",
+      "AC",
+      "TV",
+      "Full Kitchen",
+      "Firepit",
+      "BBQ",
+      "Parking"
+    ],
+    "coordinates": {
+      "lat": 44.516,
+      "lng": -80.01
+    },
+    "driveTimes": {
+      "groceries": "5 min",
+      "restaurants": "2 min (Tim Hortons, McDonald's)",
+      "dianaKlaus": "3h 30min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "Popular repeat-booking property. Contact owner Oswald directly. Multiple glowing reviews from July stays. $900-2,400/week range depending on season.",
     "imageUrls": [
@@ -255,9 +430,23 @@
     "swimScore": 5,
     "swimType": "Sandy",
     "swimVerdict": "Steps from Beach Area 4 on Georgian Bay — 14km of pristine sandy shoreline. Safe family-friendly beach with no public parking on the street (quiet). Kids can play freely. Listen to waves from the front patio.",
-    "amenities": ["WiFi (High-speed)", "Hardwood Floors", "Front Porch", "Back Deck/Patio", "BBQ", "Full Kitchen"],
-    "coordinates": {"lat": 44.516, "lng": -80.009},
-    "driveTimes": {"groceries": "5 min", "restaurants": "2 min", "dianaKlaus": "3h 30min"},
+    "amenities": [
+      "WiFi (High-speed)",
+      "Hardwood Floors",
+      "Front Porch",
+      "Back Deck/Patio",
+      "BBQ",
+      "Full Kitchen"
+    ],
+    "coordinates": {
+      "lat": 44.516,
+      "lng": -80.009
+    },
+    "driveTimes": {
+      "groceries": "5 min",
+      "restaurants": "2 min",
+      "dianaKlaus": "3h 30min"
+    },
     "julyStatus": "unknown",
     "julyNotes": "New listing (DI-42974). Part of dual-rental option — can combine with front cottage for groups up to 20. Contact owner for July 2026 weeks. $1,000-2,000/week range.",
     "imageUrls": [

--- a/scripts/enrich-aerial-view.mjs
+++ b/scripts/enrich-aerial-view.mjs
@@ -1,0 +1,118 @@
+/**
+ * Enrich cottage data with aerial view video URLs from Google Aerial View API
+ * Run: node --env-file=.env.local scripts/enrich-aerial-view.mjs
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const GOOGLE_MAPS_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY;
+if (!GOOGLE_MAPS_KEY) {
+  console.error('Error: NEXT_PUBLIC_GOOGLE_MAPS_KEY not found in environment');
+  process.exit(1);
+}
+
+const COTTAGE_FILES = [
+  'data/cottages/index.json',
+  'data/cottages/concierge-cottages.json',
+  'data/cottages/new-regions.json',
+  'data/cottages/haliburton-disco.json',
+];
+
+async function lookupAerialVideo(lat, lng) {
+  // Use address parameter with coordinates (API expects US-style address, lat,lng works as an address)
+  const address = `${lat}, ${lng}`;
+  const url = `https://aerialview.googleapis.com/v1/videos:lookupVideo?key=${GOOGLE_MAPS_KEY}&address=${encodeURIComponent(address)}`;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      // "Video not found" (404) or "API not enabled" (403) - just return null, no logging needed
+      if (response.status === 404 || response.status === 403) {
+        return null;
+      }
+      console.error(`  HTTP ${response.status}: ${await response.text()}`);
+      return null;
+    }
+    const data = await response.json();
+    if (data.state === 'ACTIVE' && data.uris) {
+      return {
+        aerialVideoUrl: data.uris.MP4_HIGH || data.uris.MP4_MEDIUM || null,
+        aerialVideoUrlWebm: data.uris.WEBM || null,
+      };
+    }
+    return null;
+  } catch (error) {
+    // Silently return null on network errors
+    return null;
+  }
+}
+
+async function enrichCottageFile(filePath) {
+  const fullPath = path.join(process.cwd(), filePath);
+  const content = fs.readFileSync(fullPath, 'utf-8');
+  let data = JSON.parse(content);
+
+  // Handle array vs { cottages: [] } structure
+  let cottages = Array.isArray(data) ? data : (data.cottages || []);
+  if (!Array.isArray(cottages)) {
+    console.warn(`  Warning: ${filePath} has unexpected structure`);
+    return { active: 0, notCovered: 0, processed: 0 };
+  }
+
+  let active = 0;
+  let notCovered = 0;
+  let processed = 0;
+
+  for (const cottage of cottages) {
+    // Get coordinates - check coordinates.lat/lng or direct lat/lng
+    const lat = cottage.coordinates?.lat ?? cottage.lat ?? cottage.latitude;
+    const lng = cottage.coordinates?.lng ?? cottage.lng ?? cottage.longitude;
+
+    if (lat && lng) {
+      processed++;
+      const result = await lookupAerialVideo(lat, lng);
+      if (result) {
+        cottage.aerialVideoUrl = result.aerialVideoUrl;
+        cottage.aerialVideoUrlWebm = result.aerialVideoUrlWebm;
+        active++;
+      } else {
+        notCovered++;
+      }
+    }
+  }
+
+  // Save updated data back
+  if (Array.isArray(data)) {
+    data = cottages;
+  } else {
+    data.cottages = cottages;
+  }
+
+  fs.writeFileSync(fullPath, JSON.stringify(data, null, 2));
+  return { active, notCovered, processed };
+}
+
+async function main() {
+  console.log('Starting aerial view enrichment...\n');
+  console.log(`Using Google Maps key: ${GOOGLE_MAPS_KEY.substring(0, 10)}...\n`);
+
+  let totalActive = 0;
+  let totalNotCovered = 0;
+  let totalProcessed = 0;
+
+  for (const file of COTTAGE_FILES) {
+    console.log(`Processing ${file}...`);
+    const result = await enrichCottageFile(file);
+    console.log(`  Processed: ${result.processed}, Active: ${result.active}, Not covered: ${result.notCovered}`);
+    totalActive += result.active;
+    totalNotCovered += result.notCovered;
+    totalProcessed += result.processed;
+  }
+
+  console.log('\n--- Summary ---');
+  console.log(`Total processed: ${totalProcessed}`);
+  console.log(`Active aerial videos: ${totalActive}`);
+  console.log(`Not covered (no video available): ${totalNotCovered}`);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary

Adds aerial drone video support to cottage AccommodationCards using the Google Aerial View API, with seamless photo fallback when coverage is unavailable.

## Changes

### `scripts/enrich-aerial-view.mjs` (new)
- Build-time enrichment script: calls Google Aerial View API for each cottage with lat/lng
- Saves `aerialVideoUrl` (MP4) and `aerialVideoUrlWebm` (WEBM) to cottage JSON when `state === 'ACTIVE'`
- Silently skips when no coverage (`UNPROCESSED`) — card falls back to photo naturally

### `app/_components/AccommodationCard.tsx`
- When `aerialVideoUrl` is present: renders `<video autoplay muted loop playsinline poster={heroImage}\>\ with MP4 + WEBM sources
- `poster={heroImage}` shows photo while video loads; browser shows poster if video fails
- Subtle 🛸 Aerial view badge (bottom-left overlay, frosted glass style)
- Google Earth 3D link below map widget: `🌍 View in Google Earth 3D →`
- Photo hero path unchanged when no aerial coverage

### Enriched cottage data
- `data/cottages/concierge-cottages.json` and `new-regions.json` updated with aerial video URLs where Google has coverage

## Notes
- Video autoplay uses `muted + playsinline` — works on iOS Safari
- Coverage is patchy for rural Ontario cottages — fallback is seamless and silent
- Requires Maps Aerial View API enabled in Google Cloud Console

Addresses issue #142