### PR TITLE
feat: eliminate Blob layer for place cards, filesystem only

### DIFF
--- a/app/_lib/place-card-store.ts
+++ b/app/_lib/place-card-store.ts
@@ -5,7 +5,6 @@
    No Blob for place cards — edit card.json, commit, deploy done.
    ============================================================ */
 
-import { put } from '@vercel/blob';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import type { DiscoveryType } from './types';
@@ -77,19 +76,5 @@ export class PlaceCardStore {
       })
       .map(([placeId, v]) => ({ placeId, name: v.name, type: v.type }))
       .sort((a, b) => a.name.localeCompare(b.name));
-  }
-
-  /** Write a card to Blob (requires server-side token).
-   *  NOTE: This is kept for user data only (discoveries, triage, chat, etc.).
-   *  Place cards are filesystem-only and should NOT be written here.
-   */
-  static async upsertCard(placeId: string, card: Record<string, unknown>): Promise<void> {
-    await put(`place-cards/${placeId}/card.json`, JSON.stringify(card, null, 2), {
-      access: 'public',
-      contentType: 'application/json',
-      addRandomSuffix: false,
-    });
-    // Invalidate index cache
-    PlaceCardStore.indexCache = null;
   }
 }


### PR DESCRIPTION
## Summary

Eliminates the Blob storage layer for place cards, making the filesystem the single source of truth.

Addresses issue #153

## Changes

### PlaceCardStore (`app/_lib/place-card-store.ts`)
- Removed `put` import from `@vercel/blob` (no longer needed for place cards)
- Removed `upsertCard()` method — place cards are committed to git and deployed via Vercel, no Blob writes needed
- `getCard()` and `getManifest()` already read from filesystem (confirmed correct)

### Cron
- "Morning Vercel Sync (Place Cards)" cron was already disabled (`enabled: false`) — confirming that job is permanently disabled per this issue

## What stays in Blob (unchanged)
- `users/{id}/discoveries.json`
- `users/{id}/manifest.json`
- `users/{id}/triage.json`
- `users/{id}/chat.json`
- `users/{id}/preferences.json`
- `users/{id}/profile.json`
- `place-photos/{id}/*` (images)

## Result
Edit `card.json` → git commit → Vercel deploys → immediately correct. No sync step, no stale data.