### PR TITLE
feat: /placecards shows user's own discoveries, not global library (#166)

### DIFF
--- a/app/_components/Nav.tsx
+++ b/app/_components/Nav.tsx
@@ -13,7 +13,7 @@ export default function Nav({ userName, isOwner }: NavProps) {
 
   const links = [
     { href: '/', label: 'Home' },
-    { href: '/placecards', label: 'Places' },
+    { href: '/placecards', label: 'My Places' },
     { href: '/review', label: 'Review' },
     { href: '/hot', label: 'Hot' },
   ];

--- a/app/globals.css
+++ b/app/globals.css
@@ -4359,6 +4359,41 @@ body {
 .place-browse-triage {
   display: flex;
   justify-content: flex-end;
+  padding: 0 var(--space-sm) var(--space-sm);
+}
+
+/* ── My Places hero thumbnail ── */
+.place-browse-hero-link {
+  display: block;
+}
+
+.place-browse-hero {
+  width: 100%;
+  height: 120px;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+}
+
+/* ── My Places context-grouped layout ── */
+.my-places-grouped {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.my-places-context-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.my-places-context-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  padding-bottom: var(--space-xs);
+  border-bottom: 1px solid var(--card-border);
+}
 
 /* ── Hot page place cards with images ── */
 .hot-place-card {

--- a/app/placecards/MyPlacesClient.tsx
+++ b/app/placecards/MyPlacesClient.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import { useState, useMemo, useCallback, useEffect } from 'react';
+import Link from 'next/link';
+import type { DiscoveryType } from '../_lib/types';
+import { getTypeMeta } from '../_lib/discovery-types';
+import { getTriageState } from '../_lib/triage';
+import TypeBadge from '../_components/TypeBadge';
+import TriageButtons from '../_components/TriageButtons';
+import type { MyPlaceCard } from './page';
+
+interface ContextOption {
+  key: string;
+  label: string;
+  emoji: string;
+}
+
+interface MyPlacesClientProps {
+  cards: MyPlaceCard[];
+  contextOptions: ContextOption[];
+  userId: string;
+  isOwner: boolean;
+  totalDiscoveries: number;
+}
+
+type TriageFilter = 'all' | 'unreviewed' | 'saved' | 'dismissed';
+type SortOption = 'name-asc' | 'name-desc' | 'rating' | 'context';
+
+export default function MyPlacesClient({
+  cards,
+  contextOptions,
+  userId,
+  isOwner,
+  totalDiscoveries,
+}: MyPlacesClientProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedContext, setSelectedContext] = useState<string | null>(null);
+  const [triageFilter, setTriageFilter] = useState<TriageFilter>('all');
+  const [sortOption, setSortOption] = useState<SortOption>('name-asc');
+  const [, setRefresh] = useState(0);
+
+  // Re-render on triage changes
+  useEffect(() => {
+    const handler = () => setRefresh(n => n + 1);
+    window.addEventListener('triage-changed', handler);
+    return () => window.removeEventListener('triage-changed', handler);
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setSelectedContext(null);
+    setTriageFilter('all');
+    setSearchQuery('');
+  }, []);
+
+  const hasActiveFilters = selectedContext !== null || triageFilter !== 'all' || searchQuery !== '';
+
+  const filteredCards = useMemo(() => {
+    let result = cards;
+
+    // Search
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(c =>
+        c.name.toLowerCase().includes(q) || c.city.toLowerCase().includes(q)
+      );
+    }
+
+    // Context filter
+    if (selectedContext) {
+      result = result.filter(c => c.contextKey === selectedContext);
+    }
+
+    // Triage filter
+    if (triageFilter !== 'all') {
+      result = result.filter(c => {
+        const state = getTriageState(userId, c.contextKey, c.placeId);
+        if (triageFilter === 'unreviewed') return state === 'unreviewed' || state === 'resurfaced';
+        return state === triageFilter;
+      });
+    }
+
+    // Sort
+    result = [...result].sort((a, b) => {
+      switch (sortOption) {
+        case 'name-asc':
+          return a.name.localeCompare(b.name);
+        case 'name-desc':
+          return b.name.localeCompare(a.name);
+        case 'rating':
+          return (b.rating ?? 0) - (a.rating ?? 0);
+        case 'context':
+          return a.contextKey.localeCompare(b.contextKey) || a.name.localeCompare(b.name);
+        default:
+          return 0;
+      }
+    });
+
+    return result;
+  }, [cards, searchQuery, selectedContext, triageFilter, sortOption, userId]);
+
+  // Group by context for display
+  const groupedByContext = useMemo(() => {
+    if (sortOption !== 'context' && !selectedContext) return null;
+    const groups = new Map<string, MyPlaceCard[]>();
+    for (const card of filteredCards) {
+      const existing = groups.get(card.contextKey) || [];
+      existing.push(card);
+      groups.set(card.contextKey, existing);
+    }
+    return groups;
+  }, [filteredCards, sortOption, selectedContext]);
+
+  const contextLabel = (key: string) => {
+    const opt = contextOptions.find(c => c.key === key);
+    return opt ? `${opt.emoji} ${opt.label}` : key;
+  };
+
+  return (
+    <main className="page">
+      <div className="page-header">
+        <h1>My Places</h1>
+        <p className="text-muted">
+          {filteredCards.length === cards.length
+            ? `${cards.length} discoveries`
+            : `${filteredCards.length} of ${cards.length} discoveries`}
+        </p>
+      </div>
+
+      {/* ── Filter Bar ── */}
+      <div className="browse-controls">
+        {/* Search */}
+        <div className="browse-search">
+          <input
+            type="text"
+            className="browse-search-input"
+            placeholder="Search your places..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+        </div>
+
+        <div className="browse-filters">
+          {/* Context filter */}
+          {contextOptions.length > 1 && (
+            <div className="filter-section">
+              <div className="filter-label">Context</div>
+              <div className="filter-chips">
+                {contextOptions.map(ctx => (
+                  <button
+                    key={ctx.key}
+                    className={`filter-chip ${selectedContext === ctx.key ? 'filter-chip-active' : ''}`}
+                    onClick={() => setSelectedContext(
+                      selectedContext === ctx.key ? null : ctx.key
+                    )}
+                  >
+                    <span className="filter-chip-icon">{ctx.emoji}</span>
+                    <span className="filter-chip-label">{ctx.label}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Triage + Sort row */}
+          <div className="filter-section filter-section-row">
+            <div className="filter-group">
+              <label className="filter-label">Status</label>
+              <select
+                className="filter-select"
+                value={triageFilter}
+                onChange={(e) => setTriageFilter(e.target.value as TriageFilter)}
+              >
+                <option value="all">All</option>
+                <option value="unreviewed">Unreviewed</option>
+                <option value="saved">Saved</option>
+                <option value="dismissed">Dismissed</option>
+              </select>
+            </div>
+
+            <div className="filter-group">
+              <label className="filter-label">Sort</label>
+              <select
+                className="filter-select"
+                value={sortOption}
+                onChange={(e) => setSortOption(e.target.value as SortOption)}
+              >
+                <option value="name-asc">Name (A-Z)</option>
+                <option value="name-desc">Name (Z-A)</option>
+                <option value="rating">Rating</option>
+                <option value="context">By Context</option>
+              </select>
+            </div>
+
+            {hasActiveFilters && (
+              <button className="filter-clear" onClick={clearFilters}>
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Cards Grid ── */}
+      {sortOption === 'context' && groupedByContext ? (
+        // Grouped by context
+        <div className="my-places-grouped">
+          {[...groupedByContext.entries()].map(([ctxKey, ctxCards]) => (
+            <div key={ctxKey} className="my-places-context-group">
+              <h2 className="my-places-context-heading">{contextLabel(ctxKey)}</h2>
+              <div className="grid grid-auto">
+                {ctxCards.map(card => (
+                  <PlaceCard key={`${card.placeId}-${card.contextKey}`} card={card} userId={userId} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        // Flat grid
+        <div className="grid grid-auto">
+          {filteredCards.map(card => (
+            <PlaceCard key={`${card.placeId}-${card.contextKey}`} card={card} userId={userId} />
+          ))}
+        </div>
+      )}
+
+      {filteredCards.length === 0 && (
+        <div className="place-grid-empty">
+          <p>{hasActiveFilters ? 'No places match your filters.' : 'No discoveries yet.'}</p>
+          {hasActiveFilters && (
+            <button className="filter-clear" onClick={clearFilters}>
+              Clear filters
+            </button>
+          )}
+        </div>
+      )}
+    </main>
+  );
+}
+
+/* ── Individual Place Card ── */
+function PlaceCard({ card, userId }: { card: MyPlaceCard; userId: string }) {
+  const contextParam = encodeURIComponent(card.contextKey);
+
+  return (
+    <div className="card place-browse-card" style={{ position: 'relative' }}>
+      {/* Hero image thumbnail */}
+      {card.heroImage && (
+        <Link
+          href={`/placecards/${card.placeId}?context=${contextParam}`}
+          className="place-browse-hero-link"
+        >
+          <div
+            className="place-browse-hero"
+            style={{
+              backgroundImage: `url(${card.heroImage})`,
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+            }}
+          />
+        </Link>
+      )}
+
+      <Link href={`/placecards/${card.placeId}?context=${contextParam}`} className="place-browse-card-link">
+        <div className="card-body">
+          <h3 className="place-browse-name">{card.name}</h3>
+          <TypeBadge type={card.type} />
+          {card.city && (
+            <span className="place-browse-city">{card.city}</span>
+          )}
+          {card.rating !== null && (
+            <span className="place-browse-rating">{card.rating.toFixed(1)}★</span>
+          )}
+        </div>
+      </Link>
+
+      <div className="place-browse-triage">
+        <TriageButtons
+          userId={userId}
+          contextKey={card.contextKey}
+          placeId={card.placeId}
+          size="sm"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/placecards/page.tsx
+++ b/app/placecards/page.tsx
@@ -1,80 +1,84 @@
-import { notFound } from 'next/navigation';
-import type { DiscoveryType } from '../_lib/types';
-import { ALL_TYPES } from '../_lib/discovery-types';
 import { getCurrentUser } from '../_lib/user';
-import { PlaceCardStore } from '../_lib/place-card-store';
-import PlacecardsBrowseClient from './PlacecardsBrowseClient';
+import { getUserDiscoveries } from '../_lib/user-data';
+import { getUserManifest } from '../_lib/user-data';
+import type { DiscoveryType, Context } from '../_lib/types';
+import MyPlacesClient from './MyPlacesClient';
 
 export const dynamic = 'force-dynamic';
 
-interface IndexEntry {
-  name: string;
-  type: DiscoveryType;
-}
-
-interface CardData {
-  identity?: {
-    city?: string | null;
-  };
-  narrative?: {
-    summary?: string | null;
-  };
-}
-
-// Extract rating from summary string (e.g., "5.0★" or "4.5★")
-function extractRating(summary: string | null): number | null {
-  if (!summary) return null;
-  const match = summary.match(/(\d+\.?\d*)\s*★/);
-  if (!match) return null;
-  const value = match[1];
-  if (!value) return null;
-  return parseFloat(value);
-}
-
-interface PlaceCardData {
+export interface MyPlaceCard {
   placeId: string;
   name: string;
   type: DiscoveryType;
   city: string;
   rating: number | null;
+  contextKey: string;
+  heroImage: string | null;
 }
 
 export default async function PlacecardsPage() {
   const user = await getCurrentUser();
 
-  // Places browse uses the global index — owner only
-  if (!user?.isOwner) {
+  if (!user) {
     return (
       <main className="page">
-        <div className="page-header"><h1>Places</h1></div>
-        <p className="text-muted">Coming soon.</p>
+        <div className="page-header"><h1>My Places</h1></div>
+        <p className="text-muted">Sign in to see your discoveries.</p>
       </main>
     );
   }
 
-  const index = await PlaceCardStore.getIndex();
+  // Get user's discoveries
+  const discData = await getUserDiscoveries(user.id);
+  const discoveries = discData?.discoveries ?? [];
 
-  // Build enriched card data with city and rating
-  // Note: During migration, we may fall back to local data for some cards
-  const cards: PlaceCardData[] = await Promise.all(
-    Object.entries(index).map(async ([placeId, entry]) => {
-      const cardData = await PlaceCardStore.getCard(placeId) as CardData | null;
-      const city = cardData?.identity?.city ?? '';
-      const rating = extractRating(cardData?.narrative?.summary ?? null);
+  // Get user's contexts for filter labels
+  const manifestData = await getUserManifest(user.id);
+  const contexts: Context[] = manifestData?.contexts ?? [];
 
-      return {
-        placeId,
-        name: entry.name,
-        type: entry.type,
-        city,
-        rating,
-      };
-    })
+  // Build card list from user's actual discoveries
+  // Deduplicate by placeId (keep first occurrence — most recent context)
+  const seen = new Set<string>();
+  const cards: MyPlaceCard[] = [];
+
+  for (const d of discoveries) {
+    const placeId = d.place_id || d.id;
+    // Allow same place in different contexts (unique by placeId + contextKey)
+    const dedupeKey = `${placeId}::${d.contextKey}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    cards.push({
+      placeId,
+      name: d.name,
+      type: d.type as DiscoveryType,
+      city: d.city || '',
+      rating: d.rating ?? null,
+      contextKey: d.contextKey,
+      heroImage: d.heroImage ?? null,
+    });
+  }
+
+  // Get unique context keys from discoveries
+  const contextKeysInUse = [...new Set(cards.map(c => c.contextKey))];
+
+  // Build context options for the filter (only contexts that have discoveries)
+  const contextOptions = contextKeysInUse.map(key => {
+    const ctx = contexts.find(c => c.key === key);
+    return {
+      key,
+      label: ctx?.label || key.replace(/^(trip|outing|radar):/, '').replace(/-/g, ' '),
+      emoji: ctx?.emoji || '📍',
+    };
+  });
+
+  return (
+    <MyPlacesClient
+      cards={cards}
+      contextOptions={contextOptions}
+      userId={user.id}
+      isOwner={user.isOwner ?? false}
+      totalDiscoveries={discoveries.length}
+    />
   );
-
-  // Get available types from the data
-  const typeSet = new Set<DiscoveryType>(cards.map((c) => c.type));
-  const availableTypes = ALL_TYPES.filter((t) => typeSet.has(t));
-
-  return <PlacecardsBrowseClient cards={cards} availableTypes={availableTypes} userId={user?.id} />;
 }


### PR DESCRIPTION
## Architecture: /placecards page — user discoveries, not global library

Addresses issue #166

### The change

The /placecards page now reads from **user discoveries** instead of the global PlaceCardStore index.

```
Before: PlaceCardStore.getIndex() → 497 global cards (228 orphans)
After:  getUserDiscoveries(userId) → only user's own discovered places
```

### What's new

**1. Server page (`page.tsx`):**
- Reads `getUserDiscoveries(userId)` and `getUserManifest(userId)`
- Builds card list from user's actual discoveries
- Deduplicates by placeId + contextKey
- Passes context options for filtering

**2. New client component (`MyPlacesClient.tsx`):**
- **Context filter** — filter by trip/outing/radar context (chip buttons)
- **Triage filter** — All / Unreviewed / Saved / Dismissed
- **Sort options** — Name, Rating, By Context (grouped display)
- **Hero image thumbnails** on cards
- **Context-aware triage** — triage buttons use the correct contextKey per card
- **Search** by name or city
- **Grouped view** — when sorted by context, cards group under context headings

**3. Nav label:** 'Places' → 'My Places'

**4. CSS additions:** Hero thumbnails, context group headings, triage fix

### What's preserved
- `/placecards/[placeId]` detail page unchanged (still uses PlaceCardStore for rich data lookup)
- Filesystem card data stays as a cache
- Old `PlacecardsBrowseClient.tsx` kept (not imported, can be removed later)

### Build: clean ✅
### Smoke test: 8/8 passed ✅