### PR TITLE
chore: remove leftover Blob import and upsertCard from PlaceCardStore

### DIFF
--- a/app/_lib/place-card-store.ts
+++ b/app/_lib/place-card-store.ts
@@ -5,7 +5,6 @@
    No Blob for place cards — edit card.json, commit, deploy done.
    ============================================================ */
 
-import { put } from '@vercel/blob';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import type { DiscoveryType } from './types';
@@ -79,17 +78,5 @@ export class PlaceCardStore {
       .sort((a, b) => a.name.localeCompare(b.name));
   }
 
-  /** Write a card to Blob (requires server-side token).
-   *  NOTE: This is kept for user data only (discoveries, triage, chat, etc.).
-   *  Place cards are filesystem-only and should NOT be written here.
-   */
-  static async upsertCard(placeId: string, card: Record<string, unknown>): Promise<void> {
-    await put(`place-cards/${placeId}/card.json`, JSON.stringify(card, null, 2), {
-      access: 'public',
-      contentType: 'application/json',
-      addRandomSuffix: false,
-    });
-    // Invalidate index cache
-    PlaceCardStore.indexCache = null;
-  }
 }
+


### PR DESCRIPTION
## Summary

Finishes the cleanup from issue #153 — addresses issue #153.

The core Blob-to-filesystem migration was done in PR #157. This PR removes the remaining dead code that was left behind:

- **Remove `put` import** from `@vercel/blob` in `place-card-store.ts`
- **Remove `upsertCard` method** which was still writing to `place-cards/{id}/card.json` in Blob (unused, but confusing)

`PlaceCardStore` is now fully filesystem-only with zero Blob dependencies. All reads come from `data/placecards/{id}/card.json` in the git repo.

## What's unchanged
- `getCard()`, `getManifest()`, `getIndex()`, `searchCards()` — all filesystem, all good
- User data Blob paths (discoveries, triage, chat, etc.) — untouched, in other files
- Place photo Blob storage — untouched, in `image-url.ts` and photo routes
- Morning Vercel Sync cron — already disabled in jobs.json per #153