### PR TITLE
feat: /placecards shows user's own discoveries (#166)

### DIFF
--- a/app/_components/Nav.tsx
+++ b/app/_components/Nav.tsx
@@ -13,7 +13,7 @@ export default function Nav({ userName, isOwner }: NavProps) {
 
   const links = [
     { href: '/', label: 'Home' },
-    { href: '/placecards', label: 'Places' },
+    { href: '/placecards', label: 'My Places' },
     { href: '/review', label: 'Review' },
     { href: '/hot', label: 'Hot' },
   ];

--- a/app/globals.css
+++ b/app/globals.css
@@ -4361,6 +4361,76 @@ body {
   justify-content: flex-end;
 }
 
+/* Context label on place cards */
+.place-browse-context {
+  display: inline-block;
+  margin-top: 4px;
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  background: var(--color-surface-2, rgba(0,0,0,0.04));
+  border-radius: 10px;
+  padding: 1px 7px;
+}
+
+/* Context filter pill bar */
+.context-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.context-pill {
+  padding: 4px 12px;
+  border-radius: 20px;
+  border: 1px solid var(--color-border, #ddd);
+  background: transparent;
+  font-size: 0.8rem;
+  cursor: pointer;
+  color: var(--color-text);
+  transition: background 0.12s, border-color 0.12s;
+}
+
+.context-pill:hover {
+  background: var(--color-surface-2, #f5f5f5);
+}
+
+.context-pill-active {
+  background: var(--color-accent, #1a73e8);
+  border-color: var(--color-accent, #1a73e8);
+  color: #fff;
+}
+
+/* Admin view toggle */
+.admin-view-toggle {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--color-border, #ddd);
+  border-radius: 6px;
+  overflow: hidden;
+  font-size: 0.8rem;
+}
+
+.admin-toggle-btn {
+  padding: 4px 12px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: background 0.12s;
+}
+
+.admin-toggle-btn:hover {
+  background: var(--color-surface-2, #f5f5f5);
+}
+
+.admin-toggle-btn.active {
+  background: var(--color-surface-2, #f0f0f0);
+  color: var(--color-text);
+  font-weight: 500;
+}
+
 /* ── Hot page place cards with images ── */
 .hot-place-card {
   position: relative;

--- a/app/placecards/PlacecardsBrowseClient.tsx
+++ b/app/placecards/PlacecardsBrowseClient.tsx
@@ -13,29 +13,42 @@ export interface PlaceCardData {
   type: DiscoveryType;
   city: string;
   rating: number | null;
+  contextKey: string;
+  heroImage?: string | null;
+}
+
+export interface ContextItem {
+  key: string;
+  label: string;
 }
 
 export interface PlacecardsBrowseClientProps {
   cards: PlaceCardData[];
   availableTypes: DiscoveryType[];
+  availableContexts?: ContextItem[];
+  contextLabels?: Record<string, string>;
   userId?: string;
+  isOwner?: boolean;
+  adminViewAll?: boolean;
 }
 
 type SortOption = 'name-asc' | 'name-desc' | 'type';
 
-interface FilterState {
-  types: DiscoveryType[];
-  minRating: number | null;
-}
-
 export default function PlacecardsBrowseClient({
-  cards, userId,
+  cards,
+  userId,
   availableTypes,
+  availableContexts = [],
+  contextLabels = {},
+  isOwner = false,
+  adminViewAll = false,
 }: PlacecardsBrowseClientProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedTypes, setSelectedTypes] = useState<DiscoveryType[]>([]);
+  const [selectedContext, setSelectedContext] = useState<string>('');
   const [minRating, setMinRating] = useState<number | null>(null);
   const [sortOption, setSortOption] = useState<SortOption>('name-asc');
+  const viewMode = adminViewAll ? 'all' : 'mine';
 
   const toggleType = useCallback((type: DiscoveryType) => {
     setSelectedTypes((prev) =>
@@ -47,14 +60,24 @@ export default function PlacecardsBrowseClient({
     setSelectedTypes([]);
     setMinRating(null);
     setSearchQuery('');
+    setSelectedContext('');
   }, []);
 
-  const hasActiveFilters = selectedTypes.length > 0 || minRating !== null || searchQuery !== '';
+  const hasActiveFilters =
+    selectedTypes.length > 0 ||
+    minRating !== null ||
+    searchQuery !== '' ||
+    selectedContext !== '';
 
   const filteredCards = useMemo(() => {
     let result = cards;
 
-    // Filter by search query (name)
+    // Context filter
+    if (selectedContext) {
+      result = result.filter((card) => card.contextKey === selectedContext);
+    }
+
+    // Search query (name)
     if (searchQuery) {
       const query = searchQuery.toLowerCase();
       result = result.filter((card) =>
@@ -62,12 +85,12 @@ export default function PlacecardsBrowseClient({
       );
     }
 
-    // Filter by type
+    // Type filter
     if (selectedTypes.length > 0) {
       result = result.filter((card) => selectedTypes.includes(card.type));
     }
 
-    // Filter by rating
+    // Rating filter
     if (minRating !== null) {
       result = result.filter((card) => card.rating !== null && card.rating >= minRating);
     }
@@ -87,18 +110,58 @@ export default function PlacecardsBrowseClient({
     });
 
     return result;
-  }, [cards, searchQuery, selectedTypes, minRating, sortOption]);
+  }, [cards, searchQuery, selectedTypes, minRating, sortOption, selectedContext]);
+
+  const countLabel =
+    filteredCards.length === cards.length
+      ? `${cards.length} place${cards.length === 1 ? '' : 's'}`
+      : `${filteredCards.length} of ${cards.length} places`;
 
   return (
     <main className="page">
       <div className="page-header">
-        <h1>Places</h1>
-        <p className="text-muted">
-          {filteredCards.length === cards.length
-            ? `${cards.length} place cards`
-            : `${filteredCards.length} of ${cards.length} place cards`}
-        </p>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+          <h1>{adminViewAll ? 'All Cards (admin)' : 'My Places'}</h1>
+          {isOwner && (
+            <div className="admin-view-toggle">
+              <Link
+                href="/placecards"
+                className={`admin-toggle-btn ${viewMode === 'mine' ? 'active' : ''}`}
+              >
+                My Places
+              </Link>
+              <Link
+                href="/placecards?view=all"
+                className={`admin-toggle-btn ${viewMode === 'all' ? 'active' : ''}`}
+              >
+                All Cards (admin)
+              </Link>
+            </div>
+          )}
+        </div>
+        <p className="text-muted">{countLabel}</p>
       </div>
+
+      {/* Context filter pills */}
+      {availableContexts.length > 0 && (
+        <div className="context-filter-bar">
+          <button
+            className={`context-pill ${selectedContext === '' ? 'context-pill-active' : ''}`}
+            onClick={() => setSelectedContext('')}
+          >
+            All contexts
+          </button>
+          {availableContexts.map((ctx) => (
+            <button
+              key={ctx.key}
+              className={`context-pill ${selectedContext === ctx.key ? 'context-pill-active' : ''}`}
+              onClick={() => setSelectedContext(ctx.key === selectedContext ? '' : ctx.key)}
+            >
+              {ctx.label}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Filter Bar */}
       <div className="browse-controls">
@@ -106,7 +169,7 @@ export default function PlacecardsBrowseClient({
           <input
             type="text"
             className="browse-search-input"
-            placeholder="Search places..."
+            placeholder="Search my places..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
           />
@@ -173,35 +236,48 @@ export default function PlacecardsBrowseClient({
 
       {/* Cards Grid */}
       <div className="grid grid-auto">
-        {filteredCards.map((card) => (
-          <div key={card.placeId} className="card place-browse-card" style={{ position: 'relative' }}>
-            <Link href={`/placecards/${card.placeId}`} className="place-browse-card-link">
-              <div className="card-body">
-                <h3 className="place-browse-name">{card.name}</h3>
-                <TypeBadge type={card.type} />
-                {card.city && (
-                  <span className="place-browse-city">{card.city}</span>
-                )}
-                {card.rating !== null && (
-                  <span className="place-browse-rating">{card.rating.toFixed(1)}★</span>
-                )}
-              </div>
-            </Link>
-            {userId && (
-              <div className="place-browse-triage">
-                <TriageButtons
-                  userId={userId}
-                  contextKey="radar:toronto-experiences"
-                  placeId={card.placeId}
-                  size="sm"
-                />
-              </div>
-            )}
-          </div>
-        ))}
+        {filteredCards.map((card) => {
+          const ctxLabel = contextLabels[card.contextKey];
+          return (
+            <div key={card.placeId} className="card place-browse-card" style={{ position: 'relative' }}>
+              <Link href={`/placecards/${card.placeId}`} className="place-browse-card-link">
+                <div className="card-body">
+                  <h3 className="place-browse-name">{card.name}</h3>
+                  <TypeBadge type={card.type} />
+                  {card.city && (
+                    <span className="place-browse-city">{card.city}</span>
+                  )}
+                  {card.rating !== null && (
+                    <span className="place-browse-rating">{card.rating.toFixed(1)}★</span>
+                  )}
+                  {ctxLabel && !selectedContext && (
+                    <span className="place-browse-context">{ctxLabel}</span>
+                  )}
+                </div>
+              </Link>
+              {userId && (
+                <div className="place-browse-triage">
+                  <TriageButtons
+                    userId={userId}
+                    contextKey={card.contextKey}
+                    placeId={card.placeId}
+                    size="sm"
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
 
-      {filteredCards.length === 0 && (
+      {filteredCards.length === 0 && cards.length === 0 && (
+        <div className="place-grid-empty">
+          <p>You haven&apos;t discovered any places yet.</p>
+          <p className="text-muted">Start a chat to explore places and they&apos;ll appear here.</p>
+        </div>
+      )}
+
+      {filteredCards.length === 0 && cards.length > 0 && (
         <div className="place-grid-empty">
           <p>No places match your filters.</p>
           <button className="filter-clear" onClick={clearFilters}>

--- a/app/placecards/page.tsx
+++ b/app/placecards/page.tsx
@@ -1,80 +1,132 @@
-import { notFound } from 'next/navigation';
 import type { DiscoveryType } from '../_lib/types';
 import { ALL_TYPES } from '../_lib/discovery-types';
 import { getCurrentUser } from '../_lib/user';
 import { PlaceCardStore } from '../_lib/place-card-store';
+import { getUserDiscoveries, getUserManifest } from '../_lib/user-data';
 import PlacecardsBrowseClient from './PlacecardsBrowseClient';
+import type { PlaceCardData } from './PlacecardsBrowseClient';
 
 export const dynamic = 'force-dynamic';
 
-interface IndexEntry {
-  name: string;
-  type: DiscoveryType;
-}
-
 interface CardData {
-  identity?: {
-    city?: string | null;
-  };
-  narrative?: {
-    summary?: string | null;
-  };
+  identity?: { city?: string | null };
+  narrative?: { summary?: string | null };
 }
 
-// Extract rating from summary string (e.g., "5.0★" or "4.5★")
 function extractRating(summary: string | null): number | null {
   if (!summary) return null;
   const match = summary.match(/(\d+\.?\d*)\s*★/);
-  if (!match) return null;
-  const value = match[1];
-  if (!value) return null;
-  return parseFloat(value);
+  if (!match || !match[1]) return null;
+  return parseFloat(match[1]);
 }
 
-interface PlaceCardData {
-  placeId: string;
-  name: string;
-  type: DiscoveryType;
-  city: string;
-  rating: number | null;
+interface PageProps {
+  searchParams: Promise<{ view?: string }>;
 }
 
-export default async function PlacecardsPage() {
+export default async function PlacecardsPage({ searchParams }: PageProps) {
   const user = await getCurrentUser();
 
-  // Places browse uses the global index — owner only
-  if (!user?.isOwner) {
+  if (!user) {
     return (
       <main className="page">
-        <div className="page-header"><h1>Places</h1></div>
-        <p className="text-muted">Coming soon.</p>
+        <div className="page-header"><h1>My Places</h1></div>
+        <p className="text-muted">Sign in to see your places.</p>
       </main>
     );
   }
 
-  const index = await PlaceCardStore.getIndex();
+  const isOwner = user.isOwner ?? false;
+  const params = await searchParams;
+  const viewAll = isOwner && params?.view === 'all';
 
-  // Build enriched card data with city and rating
-  // Note: During migration, we may fall back to local data for some cards
-  const cards: PlaceCardData[] = await Promise.all(
-    Object.entries(index).map(async ([placeId, entry]) => {
-      const cardData = await PlaceCardStore.getCard(placeId) as CardData | null;
-      const city = cardData?.identity?.city ?? '';
-      const rating = extractRating(cardData?.narrative?.summary ?? null);
+  if (viewAll) {
+    // Admin: show global index
+    const index = await PlaceCardStore.getIndex();
+    const cards: PlaceCardData[] = await Promise.all(
+      Object.entries(index).map(async ([placeId, entry]) => {
+        const cardData = await PlaceCardStore.getCard(placeId) as CardData | null;
+        const city = cardData?.identity?.city ?? '';
+        const rating = extractRating(cardData?.narrative?.summary ?? null);
+        return {
+          placeId,
+          name: (entry as { name: string }).name,
+          type: (entry as { type: DiscoveryType }).type,
+          city,
+          rating,
+          contextKey: '',
+          heroImage: null,
+        };
+      })
+    );
+    const typeSet = new Set<DiscoveryType>(cards.map((c) => c.type));
+    const availableTypes = ALL_TYPES.filter((t) => typeSet.has(t));
+    return (
+      <PlacecardsBrowseClient
+        cards={cards}
+        availableTypes={availableTypes}
+        availableContexts={[]}
+        contextLabels={{}}
+        userId={user.id}
+        isOwner={isOwner}
+        adminViewAll={true}
+      />
+    );
+  }
 
-      return {
-        placeId,
-        name: entry.name,
-        type: entry.type,
-        city,
-        rating,
-      };
-    })
-  );
+  // Normal: load user's discoveries and manifest (for context labels)
+  const [discData, manifestData] = await Promise.all([
+    getUserDiscoveries(user.id),
+    getUserManifest(user.id),
+  ]);
 
-  // Get available types from the data
-  const typeSet = new Set<DiscoveryType>(cards.map((c) => c.type));
+  const discoveries = discData?.discoveries ?? [];
+  const contexts = manifestData?.contexts ?? [];
+
+  // Build context label map
+  const contextLabels: Record<string, string> = {};
+  for (const ctx of contexts) {
+    contextLabels[ctx.key] = `${ctx.emoji ?? ''} ${ctx.label}`.trim();
+  }
+
+  // Build card list from user's own discoveries
+  const cards: PlaceCardData[] = discoveries.map((d) => ({
+    placeId: d.place_id || d.id,
+    name: d.name,
+    type: d.type as DiscoveryType,
+    city: d.city ?? '',
+    rating: d.rating ?? null,
+    contextKey: d.contextKey,
+    heroImage: d.heroImage ?? null,
+  }));
+
+  // Deduplicate by placeId (keep first occurrence)
+  const seen = new Set<string>();
+  const uniqueCards = cards.filter((c) => {
+    if (seen.has(c.placeId)) return false;
+    seen.add(c.placeId);
+    return true;
+  });
+
+  // Get available types from actual data
+  const typeSet = new Set<DiscoveryType>(uniqueCards.map((c) => c.type));
   const availableTypes = ALL_TYPES.filter((t) => typeSet.has(t));
 
-  return <PlacecardsBrowseClient cards={cards} availableTypes={availableTypes} userId={user?.id} />;
+  // Available contexts (only those that appear in user's discoveries)
+  const contextKeySet = new Set(uniqueCards.map((c) => c.contextKey));
+  const availableContexts = contexts
+    .filter((ctx) => contextKeySet.has(ctx.key))
+    .map((ctx) => ({ key: ctx.key, label: `${ctx.emoji ?? ''} ${ctx.label}`.trim() }));
+
+  return (
+    <PlacecardsBrowseClient
+      cards={uniqueCards}
+      availableTypes={availableTypes}
+      availableContexts={availableContexts}
+      contextLabels={contextLabels}
+      userId={user.id}
+      isOwner={isOwner}
+      adminViewAll={false}
+    />
+  );
 }


### PR DESCRIPTION
## Summary

Addresses issue #166 — architecturally fixes the /placecards page to show a user's personal discoveries instead of the global legacy index.

## Changes

### `app/placecards/page.tsx`
- Removed `PlaceCardStore.getIndex()` from the browse page
- Reads from `getUserDiscoveries(user.id)` + `getUserManifest(user.id)` instead
- Builds card list from user's own discoveries (deduped by placeId)
- Passes context metadata (labels, available contexts) to client
- Owner admin path: `?view=all` still serves global index, clearly labelled

### `app/placecards/PlacecardsBrowseClient.tsx`
- Renamed page title: `Places` → `My Places`
- Added **context filter bar** — pill buttons to filter by trip/outing/radar context
- `TriageButtons` now uses `card.contextKey` (was hardcoded to `radar:toronto-experiences`)
- Shows context label on each card when no context filter is active
- Owner sees `My Places | All Cards (admin)` toggle in header
- Empty state handles no discoveries vs. no filter match separately

### `app/_components/Nav.tsx`
- Changed nav label: `Places` → `My Places`

### `app/globals.css`
- Added styles: `.context-filter-bar`, `.context-pill`, `.context-pill-active`, `.place-browse-context`, `.admin-view-toggle`, `.admin-toggle-btn`

## Result
- /placecards shows only discoveries belonging to the current user
- Cards are filterable by context
- No orphan legacy cards visible to regular users
- Owner can access full index via `?view=all` admin toggle
- Count shown reflects the user's personal discovery list