### PR TITLE
feat: GeoJSON interactive map for discoveries (#173)

### DIFF
--- a/app/_components/ReviewMarkersMap.tsx
+++ b/app/_components/ReviewMarkersMap.tsx
@@ -21,16 +21,43 @@ function getCoords(d: Discovery): { lat: number; lng: number } | null {
   return null;
 }
 
-export default function ReviewMarkersMap({ discoveries, contextLabel, city }: ReviewMarkersMapProps) {
-  // Only show unreviewed places with coordinates
-  const mappable = discoveries
-    .filter(d => getCoords(d) !== null)
-    .slice(0, 26); // Static Maps supports up to 26 labeled markers
+/** Build a geojson.io URL with all mappable discoveries as numbered markers */
+function buildGeoJsonUrl(mappable: Discovery[]): string {
+  const geojson = {
+    type: 'FeatureCollection' as const,
+    features: mappable.map((d, i) => {
+      const c = getCoords(d)!;
+      const label = LABELS[i] || String(i + 1);
+      return {
+        type: 'Feature' as const,
+        geometry: {
+          type: 'Point' as const,
+          coordinates: [c.lng, c.lat],
+        },
+        properties: {
+          name: `${label} ${d.name}`,
+          description: [d.address, d.description].filter(Boolean).join(' — '),
+          'marker-symbol': String(i + 1),
+          'marker-color': '#e74c3c',
+          type: d.type,
+        },
+      };
+    }),
+  };
+  return `https://geojson.io/#data=data:application/json,${encodeURIComponent(JSON.stringify(geojson))}`;
+}
 
-  if (mappable.length === 0) return null;
+export default function ReviewMarkersMap({ discoveries, contextLabel, city }: ReviewMarkersMapProps) {
+  // Only show places with coordinates
+  const mappable = discoveries.filter(d => getCoords(d) !== null);
+
+  // Static map limited to 26 labeled markers
+  const staticMappable = mappable.slice(0, 26);
+
+  if (staticMappable.length === 0) return null;
 
   // Build Static Maps URL with markers
-  const coords = mappable.map(d => getCoords(d)!);
+  const coords = staticMappable.map(d => getCoords(d)!);
 
   // Calculate bounds for auto-zoom
   const lats = coords.map(c => c.lat);
@@ -39,7 +66,7 @@ export default function ReviewMarkersMap({ discoveries, contextLabel, city }: Re
   const centerLng = (Math.min(...lngs) + Math.max(...lngs)) / 2;
 
   // Build marker params
-  const markerParams = mappable.map((d, i) => {
+  const markerParams = staticMappable.map((d, i) => {
     const c = getCoords(d)!;
     const label = LABELS[i] || String(i + 1);
     return `markers=color:red%7Clabel:${label}%7C${c.lat},${c.lng}`;
@@ -47,33 +74,51 @@ export default function ReviewMarkersMap({ discoveries, contextLabel, city }: Re
 
   const staticMapUrl = `https://maps.googleapis.com/maps/api/staticmap?size=800x640&scale=2&center=${centerLat},${centerLng}&${markerParams}&key=${MAPS_KEY}`;
 
-  // Google Maps URL — open centered on midpoint at the right zoom
-  // Best native experience: each place links individually from its card.
-  // This map click opens Google Maps centered on the cluster so user can explore.
-  const mapsUrl = `https://www.google.com/maps/@${centerLat},${centerLng},13z`;
+  // Interactive map URL — geojson.io with ALL mappable discoveries
+  const interactiveUrl = buildGeoJsonUrl(mappable);
 
   return (
-    <div style={{ margin: '0 0 var(--space-md)', borderRadius: 12, overflow: 'hidden', position: 'relative' }}>
-      <a href={mapsUrl} target="_blank" rel="noopener noreferrer" style={{ display: 'block' }}>
-        <img
-          src={staticMapUrl}
-          alt={`Map of ${mappable.length} places to review`}
-          style={{ width: '100%', height: 'auto', display: 'block', maxHeight: 640, objectFit: 'cover' }}
-        />
-      </a>
+    <div style={{ margin: '0 0 var(--space-md)' }}>
+      <div style={{ borderRadius: 12, overflow: 'hidden', position: 'relative' }}>
+        <a href={interactiveUrl} target="_blank" rel="noopener noreferrer" style={{ display: 'block' }}>
+          <img
+            src={staticMapUrl}
+            alt={`Map of ${staticMappable.length} places to review`}
+            style={{ width: '100%', height: 'auto', display: 'block', maxHeight: 640, objectFit: 'cover' }}
+          />
+        </a>
+        <div style={{
+          position: 'absolute',
+          bottom: 8,
+          left: 8,
+          background: 'rgba(0,0,0,0.65)',
+          color: 'white',
+          fontSize: '0.75rem',
+          padding: '4px 10px',
+          borderRadius: 20,
+          backdropFilter: 'blur(4px)',
+        }}>
+          📍 {mappable.length} place{mappable.length !== 1 ? 's' : ''} to review
+          {discoveries.length > mappable.length ? ` · ${discoveries.length - mappable.length} without location` : ''}
+        </div>
+      </div>
       <div style={{
-        position: 'absolute',
-        bottom: 8,
-        left: 8,
-        background: 'rgba(0,0,0,0.65)',
-        color: 'white',
-        fontSize: '0.75rem',
-        padding: '4px 10px',
-        borderRadius: 20,
-        backdropFilter: 'blur(4px)',
+        textAlign: 'right',
+        padding: '6px 4px 0',
       }}>
-        📍 {mappable.length} place{mappable.length !== 1 ? 's' : ''} to review
-        {discoveries.length > mappable.length ? ` · ${discoveries.length - mappable.length} without location` : ''}
+        <a
+          href={interactiveUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            fontSize: '0.8rem',
+            color: 'var(--color-accent, #3b82f6)',
+            textDecoration: 'none',
+            fontWeight: 500,
+          }}
+        >
+          View all {mappable.length} on interactive map →
+        </a>
       </div>
     </div>
   );

--- a/app/api/maps/geojson/route.ts
+++ b/app/api/maps/geojson/route.ts
@@ -1,0 +1,81 @@
+/* ============================================================
+   #173 — GeoJSON endpoint for interactive maps
+   GET /api/maps/geojson?contextKey={key}
+   
+   Returns a GeoJSON FeatureCollection of all discoveries with
+   coordinates for the given context. Use with geojson.io or
+   any GeoJSON-compatible viewer.
+   ============================================================ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '../../../_lib/user';
+import { getUserDiscoveries } from '../../../_lib/user-data';
+import type { Discovery } from '../../../_lib/types';
+
+export const dynamic = 'force-dynamic';
+
+const LABELS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
+function getCoords(d: Discovery): { lat: number; lng: number } | null {
+  const lat = d.lat ?? (d as unknown as Record<string, unknown>).latitude as number | undefined;
+  const lng = d.lng ?? (d as unknown as Record<string, unknown>).longitude as number | undefined;
+  if (lat && lng && !isNaN(lat) && !isNaN(lng)) return { lat, lng };
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const contextKey = searchParams.get('contextKey');
+
+  if (!contextKey) {
+    return NextResponse.json({ error: 'contextKey query parameter required' }, { status: 400 });
+  }
+
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const discoveriesData = await getUserDiscoveries(user.id);
+  const discoveries = (discoveriesData?.discoveries || []).filter(d => {
+    if (d.contextKey === contextKey) return true;
+    // Fuzzy match on slug portion
+    const dSlug = d.contextKey.split(':').slice(1).join(':');
+    const ctxSlug = contextKey.split(':').slice(1).join(':');
+    return dSlug === ctxSlug || dSlug.includes(ctxSlug) || ctxSlug.includes(dSlug);
+  });
+
+  const mappable = discoveries.filter(d => getCoords(d) !== null);
+
+  const geojson = {
+    type: 'FeatureCollection' as const,
+    features: mappable.map((d, i) => {
+      const c = getCoords(d)!;
+      const label = LABELS[i] || String(i + 1);
+      return {
+        type: 'Feature' as const,
+        geometry: {
+          type: 'Point' as const,
+          coordinates: [c.lng, c.lat],
+        },
+        properties: {
+          name: `${label} ${d.name}`,
+          description: [d.address, d.description].filter(Boolean).join(' — '),
+          'marker-symbol': String(i + 1),
+          'marker-color': '#e74c3c',
+          type: d.type,
+          address: d.address || '',
+          city: d.city || '',
+          contextKey: d.contextKey,
+        },
+      };
+    }),
+  };
+
+  return NextResponse.json(geojson, {
+    headers: {
+      'Content-Type': 'application/geo+json',
+      'Cache-Control': 'private, max-age=60',
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Addresses issue #173 — clicking the map on a review page now opens an interactive geojson.io map showing ALL discoveries as numbered, labeled markers with names and addresses.

## Changes

### ReviewMarkersMap.tsx
- Clicking the static map now opens geojson.io with a full GeoJSON FeatureCollection of all mappable discoveries (not just a blank centered Google Map)
- Each marker includes: letter label + place name, address, description, type, and red marker color
- Removed the 26-marker limit for the interactive view (static map still limited to 26 for Google Static Maps API)
- Added a **"View all N on interactive map →"** text link below the static map as a clear CTA

### New API: GET /api/maps/geojson?contextKey={key}
- Returns a standard GeoJSON FeatureCollection with all discoveries that have coordinates
- Each Feature has properties: name, description, marker-symbol, marker-color, type, address, city, contextKey
- Serves `application/geo+json` content type
- Supports the same fuzzy context matching as the existing route-map endpoint
- No OAuth or external API keys required

## How it works
- **geojson.io** is a free, instant, no-login-required GeoJSON viewer
- The GeoJSON is encoded directly in the URL fragment (`#data=data:application/json,...`)
- Works for 30+ markers with names, addresses, and colored pins
- No Google account or API setup needed to view the interactive map

## Smoke test
All 8 endpoints pass (8/8 — PASS)