### PR TITLE
feat: /placecards shows user discoveries, not global index

### DIFF
--- a/app/_components/Nav.tsx
+++ b/app/_components/Nav.tsx
@@ -13,7 +13,7 @@ export default function Nav({ userName, isOwner }: NavProps) {
 
   const links = [
     { href: '/', label: 'Home' },
-    { href: '/placecards', label: 'Places' },
+    { href: '/placecards', label: 'My Places' },
     { href: '/review', label: 'Review' },
     { href: '/hot', label: 'Hot' },
   ];

--- a/app/placecards/PlacecardsBrowseClient.tsx
+++ b/app/placecards/PlacecardsBrowseClient.tsx
@@ -13,29 +13,45 @@ export interface PlaceCardData {
   type: DiscoveryType;
   city: string;
   rating: number | null;
+  contextKey: string;
+  contextLabel?: string;
+  heroImage?: string;
+}
+
+export interface ContextOption {
+  key: string;
+  label: string;
 }
 
 export interface PlacecardsBrowseClientProps {
   cards: PlaceCardData[];
+  adminCards?: PlaceCardData[];
   availableTypes: DiscoveryType[];
+  availableContexts: ContextOption[];
   userId?: string;
+  isOwner?: boolean;
 }
 
 type SortOption = 'name-asc' | 'name-desc' | 'type';
-
-interface FilterState {
-  types: DiscoveryType[];
-  minRating: number | null;
-}
+type TriageFilter = 'all' | 'saved' | 'dismissed' | 'unreviewed';
 
 export default function PlacecardsBrowseClient({
-  cards, userId,
+  cards,
+  adminCards,
   availableTypes,
+  availableContexts,
+  userId,
+  isOwner,
 }: PlacecardsBrowseClientProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedTypes, setSelectedTypes] = useState<DiscoveryType[]>([]);
+  const [selectedContext, setSelectedContext] = useState<string>('');
   const [minRating, setMinRating] = useState<number | null>(null);
   const [sortOption, setSortOption] = useState<SortOption>('name-asc');
+  const [triageFilter] = useState<TriageFilter>('all');
+  const [showAdminView, setShowAdminView] = useState(false);
+
+  const activeCards = showAdminView && adminCards ? adminCards : cards;
 
   const toggleType = useCallback((type: DiscoveryType) => {
     setSelectedTypes((prev) =>
@@ -47,12 +63,17 @@ export default function PlacecardsBrowseClient({
     setSelectedTypes([]);
     setMinRating(null);
     setSearchQuery('');
+    setSelectedContext('');
   }, []);
 
-  const hasActiveFilters = selectedTypes.length > 0 || minRating !== null || searchQuery !== '';
+  const hasActiveFilters =
+    selectedTypes.length > 0 ||
+    minRating !== null ||
+    searchQuery !== '' ||
+    selectedContext !== '';
 
   const filteredCards = useMemo(() => {
-    let result = cards;
+    let result = activeCards;
 
     // Filter by search query (name)
     if (searchQuery) {
@@ -65,6 +86,11 @@ export default function PlacecardsBrowseClient({
     // Filter by type
     if (selectedTypes.length > 0) {
       result = result.filter((card) => selectedTypes.includes(card.type));
+    }
+
+    // Filter by context
+    if (selectedContext) {
+      result = result.filter((card) => card.contextKey === selectedContext);
     }
 
     // Filter by rating
@@ -87,19 +113,48 @@ export default function PlacecardsBrowseClient({
     });
 
     return result;
-  }, [cards, searchQuery, selectedTypes, minRating, sortOption]);
+  }, [activeCards, searchQuery, selectedTypes, selectedContext, minRating, sortOption]);
+
+  // Available types for current view
+  const viewAvailableTypes = useMemo(() => {
+    if (showAdminView && adminCards) {
+      const typeSet = new Set<DiscoveryType>(adminCards.map((c) => c.type));
+      return ALL_TYPES.filter((t) => typeSet.has(t));
+    }
+    return availableTypes;
+  }, [showAdminView, adminCards, availableTypes]);
 
   return (
     <main className="page">
       <div className="page-header">
         <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.6rem' }}>
-          <h1>Places</h1>
+          <h1>My Places</h1>
           <span className="text-muted" style={{ fontSize: '0.85rem', fontWeight: 400 }}>
-            {filteredCards.length === cards.length
-              ? `${cards.length} place cards`
-              : `${filteredCards.length} of ${cards.length}`}
+            {filteredCards.length === activeCards.length
+              ? `${activeCards.length} places`
+              : `${filteredCards.length} of ${activeCards.length}`}
           </span>
         </div>
+
+        {/* Owner admin toggle */}
+        {isOwner && adminCards && (
+          <div style={{ display: 'flex', gap: '0.5rem', marginLeft: 'auto' }}>
+            <button
+              className={`filter-chip ${!showAdminView ? 'filter-chip-active' : ''}`}
+              onClick={() => setShowAdminView(false)}
+              style={{ fontSize: '0.8rem' }}
+            >
+              My Places
+            </button>
+            <button
+              className={`filter-chip ${showAdminView ? 'filter-chip-active' : ''}`}
+              onClick={() => setShowAdminView(true)}
+              style={{ fontSize: '0.8rem' }}
+            >
+              All Cards (admin)
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Filter Bar */}
@@ -115,10 +170,11 @@ export default function PlacecardsBrowseClient({
         </div>
 
         <div className="browse-filters">
+          {/* Type filter */}
           <div className="filter-section">
             <div className="filter-label">Type</div>
             <div className="filter-chips">
-              {availableTypes.map((type) => {
+              {viewAvailableTypes.map((type) => {
                 const meta = getTypeMeta(type);
                 const isActive = selectedTypes.includes(type);
                 return (
@@ -137,6 +193,25 @@ export default function PlacecardsBrowseClient({
           </div>
 
           <div className="filter-section filter-section-row">
+            {/* Context filter (only in user view) */}
+            {!showAdminView && availableContexts.length > 1 && (
+              <div className="filter-group">
+                <label className="filter-label">Context</label>
+                <select
+                  className="filter-select"
+                  value={selectedContext}
+                  onChange={(e) => setSelectedContext(e.target.value)}
+                >
+                  <option value="">All contexts</option>
+                  {availableContexts.map((ctx) => (
+                    <option key={ctx.key} value={ctx.key}>
+                      {ctx.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
             <div className="filter-group">
               <label className="filter-label">Rating</label>
               <select
@@ -176,7 +251,7 @@ export default function PlacecardsBrowseClient({
       {/* Cards Grid */}
       <div className="grid grid-auto">
         {filteredCards.map((card) => (
-          <div key={card.placeId} className="card place-browse-card" style={{ position: 'relative' }}>
+          <div key={`${card.placeId}-${card.contextKey}`} className="card place-browse-card" style={{ position: 'relative' }}>
             <Link href={`/placecards/${card.placeId}`} className="place-browse-card-link">
               <div className="card-body">
                 <h3 className="place-browse-name">{card.name}</h3>
@@ -187,13 +262,18 @@ export default function PlacecardsBrowseClient({
                 {card.rating !== null && (
                   <span className="place-browse-rating">{card.rating.toFixed(1)}★</span>
                 )}
+                {!showAdminView && card.contextLabel && (
+                  <span className="place-browse-context text-muted" style={{ fontSize: '0.75rem', display: 'block', marginTop: '0.25rem' }}>
+                    {card.contextLabel}
+                  </span>
+                )}
               </div>
             </Link>
-            {userId && (
+            {userId && !showAdminView && (
               <div className="place-browse-triage">
                 <TriageButtons
                   userId={userId}
-                  contextKey="radar:toronto-experiences"
+                  contextKey={card.contextKey}
                   placeId={card.placeId}
                   size="sm"
                 />
@@ -205,10 +285,16 @@ export default function PlacecardsBrowseClient({
 
       {filteredCards.length === 0 && (
         <div className="place-grid-empty">
-          <p>No places match your filters.</p>
-          <button className="filter-clear" onClick={clearFilters}>
-            Clear filters
-          </button>
+          {activeCards.length === 0 ? (
+            <p>No places discovered yet. Start a conversation to discover places!</p>
+          ) : (
+            <>
+              <p>No places match your filters.</p>
+              <button className="filter-clear" onClick={clearFilters}>
+                Clear filters
+              </button>
+            </>
+          )}
         </div>
       )}
     </main>

--- a/app/placecards/page.tsx
+++ b/app/placecards/page.tsx
@@ -1,15 +1,21 @@
-import { notFound } from 'next/navigation';
 import type { DiscoveryType } from '../_lib/types';
 import { ALL_TYPES } from '../_lib/discovery-types';
 import { getCurrentUser } from '../_lib/user';
 import { PlaceCardStore } from '../_lib/place-card-store';
+import { getUserDiscoveries, getUserManifest } from '../_lib/user-data';
 import PlacecardsBrowseClient from './PlacecardsBrowseClient';
 
 export const dynamic = 'force-dynamic';
 
-interface IndexEntry {
+interface PlaceCardData {
+  placeId: string;
   name: string;
   type: DiscoveryType;
+  city: string;
+  rating: number | null;
+  contextKey: string;
+  contextLabel?: string;
+  heroImage?: string;
 }
 
 interface CardData {
@@ -31,50 +37,103 @@ function extractRating(summary: string | null): number | null {
   return parseFloat(value);
 }
 
-interface PlaceCardData {
-  placeId: string;
-  name: string;
-  type: DiscoveryType;
-  city: string;
-  rating: number | null;
-}
-
 export default async function PlacecardsPage() {
   const user = await getCurrentUser();
 
-  // Places browse uses the global index — owner only
-  if (!user?.isOwner) {
+  if (!user) {
     return (
       <main className="page">
-        <div className="page-header"><h1>Places</h1></div>
-        <p className="text-muted">Coming soon.</p>
+        <div className="page-header"><h1>My Places</h1></div>
+        <p className="text-muted">Sign in to see your discovered places.</p>
       </main>
     );
   }
 
-  const index = await PlaceCardStore.getIndex();
+  // Load user discoveries and manifest (for context labels)
+  const [discData, manifestData] = await Promise.all([
+    getUserDiscoveries(user.id),
+    getUserManifest(user.id),
+  ]);
 
-  // Build enriched card data with city and rating
-  // Note: During migration, we may fall back to local data for some cards
-  const cards: PlaceCardData[] = await Promise.all(
-    Object.entries(index).map(async ([placeId, entry]) => {
-      const cardData = await PlaceCardStore.getCard(placeId) as CardData | null;
-      const city = cardData?.identity?.city ?? '';
-      const rating = extractRating(cardData?.narrative?.summary ?? null);
+  const discoveries = discData?.discoveries ?? [];
 
-      return {
-        placeId,
-        name: entry.name,
-        type: entry.type,
-        city,
-        rating,
-      };
-    })
-  );
+  // Build context label map from manifest
+  const contextLabels: Record<string, string> = {};
+  if (manifestData?.contexts) {
+    for (const ctx of manifestData.contexts) {
+      contextLabels[ctx.key] = `${ctx.emoji || ''} ${ctx.label}`.trim();
+    }
+  }
 
-  // Get available types from the data
-  const typeSet = new Set<DiscoveryType>(cards.map((c) => c.type));
+  // Build card list from user's actual discoveries
+  // Deduplicate by placeId (keep the most recent discovery per place)
+  const seenPlaceIds = new Map<string, PlaceCardData>();
+
+  for (const d of discoveries) {
+    const placeId = d.place_id || d.id;
+    const contextKey = d.contextKey || 'radar:toronto-experiences';
+    const rating = d.rating != null ? Number(d.rating) : null;
+
+    const card: PlaceCardData = {
+      placeId,
+      name: d.name,
+      type: d.type as DiscoveryType,
+      city: d.city || '',
+      rating: !isNaN(rating!) && rating !== null ? rating : null,
+      contextKey,
+      contextLabel: contextLabels[contextKey] || contextKey,
+      heroImage: d.heroImage,
+    };
+
+    // Keep first occurrence (discoveries are ordered by discoveredAt)
+    if (!seenPlaceIds.has(placeId)) {
+      seenPlaceIds.set(placeId, card);
+    }
+  }
+
+  const userCards = Array.from(seenPlaceIds.values());
+
+  // For owner: also build the global admin cards
+  let adminCards: PlaceCardData[] = [];
+  if (user.isOwner) {
+    const index = await PlaceCardStore.getIndex();
+    adminCards = await Promise.all(
+      Object.entries(index).map(async ([placeId, entry]) => {
+        const cardData = await PlaceCardStore.getCard(placeId) as CardData | null;
+        const city = cardData?.identity?.city ?? '';
+        const rating = extractRating(cardData?.narrative?.summary ?? null);
+        return {
+          placeId,
+          name: entry.name,
+          type: entry.type as DiscoveryType,
+          city,
+          rating,
+          contextKey: 'admin:index',
+          contextLabel: '🗂️ Admin Index',
+        };
+      })
+    );
+  }
+
+  // Get available types from user's data
+  const typeSet = new Set<DiscoveryType>(userCards.map((c) => c.type));
   const availableTypes = ALL_TYPES.filter((t) => typeSet.has(t));
 
-  return <PlacecardsBrowseClient cards={cards} availableTypes={availableTypes} userId={user?.id} />;
+  // Get available contexts from user's data
+  const contextKeys = Array.from(new Set(userCards.map((c) => c.contextKey)));
+  const availableContexts = contextKeys.map(key => ({
+    key,
+    label: contextLabels[key] || key,
+  }));
+
+  return (
+    <PlacecardsBrowseClient
+      cards={userCards}
+      adminCards={user.isOwner ? adminCards : undefined}
+      availableTypes={availableTypes}
+      availableContexts={availableContexts}
+      userId={user.id}
+      isOwner={user.isOwner}
+    />
+  );
 }


### PR DESCRIPTION
## Summary

Addresses issue #166 — Architecture fix: /placecards now shows a user's own discovered places instead of the global place card library.

## Changes

### `app/placecards/page.tsx`
- Replaced `PlaceCardStore.getIndex()` with `getUserDiscoveries(userId)`
- Cards now built from the user's actual discovery records
- Deduplicates by `placeId` (first occurrence wins)
- Loads context labels from `getUserManifest()` to display friendly names
- Owner admin toggle: still builds global admin cards from `PlaceCardStore.getIndex()`
- Non-logged-in users see a friendly 'sign in' message

### `app/placecards/PlacecardsBrowseClient.tsx`
- Added context filter dropdown (only shown when user has multiple contexts)
- Context label displayed on each card
- Admin toggle UI for owners (My Places | All Cards (admin))
- `TriageButtons` now use per-discovery `contextKey` instead of hardcoded `radar:toronto-experiences`
- Empty state for users with zero discoveries guides them to chat
- Updated count label to 'places' (was 'place cards')

### `app/_components/Nav.tsx`
- Renamed 'Places' → 'My Places'

## Success Criteria
- ✅ /placecards shows only discoveries belonging to the current user
- ✅ Cards are filterable by context
- ✅ Count shown matches user's personal discovery count
- ✅ No orphan legacy cards visible to regular users
- ✅ Owner can still access the full index via admin toggle
- ✅ TypeScript build passes clean