### PR TITLE
feat: /placecards shows user discoveries, not global index (#166)

### DIFF
--- a/app/_components/Nav.tsx
+++ b/app/_components/Nav.tsx
@@ -13,7 +13,7 @@ export default function Nav({ userName, isOwner }: NavProps) {
 
   const links = [
     { href: '/', label: 'Home' },
-    { href: '/placecards', label: 'Places' },
+    { href: '/placecards', label: 'My Places' },
     { href: '/review', label: 'Review' },
     { href: '/hot', label: 'Hot' },
   ];

--- a/app/placecards/PlacecardsBrowseClient.tsx
+++ b/app/placecards/PlacecardsBrowseClient.tsx
@@ -13,29 +13,43 @@ export interface PlaceCardData {
   type: DiscoveryType;
   city: string;
   rating: number | null;
+  contextKey: string;
+  contextLabel: string;
+  heroImage?: string;
+}
+
+export interface ContextOption {
+  key: string;
+  label: string;
 }
 
 export interface PlacecardsBrowseClientProps {
   cards: PlaceCardData[];
   availableTypes: DiscoveryType[];
+  availableContexts: ContextOption[];
   userId?: string;
+  isOwner?: boolean;
+  adminCards?: PlaceCardData[];
 }
 
+type TriageFilter = 'all' | 'unreviewed' | 'saved' | 'dismissed';
 type SortOption = 'name-asc' | 'name-desc' | 'type';
-
-interface FilterState {
-  types: DiscoveryType[];
-  minRating: number | null;
-}
+type ViewMode = 'my-places' | 'admin';
 
 export default function PlacecardsBrowseClient({
-  cards, userId,
+  cards,
   availableTypes,
+  availableContexts,
+  userId,
+  isOwner,
+  adminCards,
 }: PlacecardsBrowseClientProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedTypes, setSelectedTypes] = useState<DiscoveryType[]>([]);
+  const [selectedContext, setSelectedContext] = useState<string>('');
   const [minRating, setMinRating] = useState<number | null>(null);
   const [sortOption, setSortOption] = useState<SortOption>('name-asc');
+  const [viewMode, setViewMode] = useState<ViewMode>('my-places');
 
   const toggleType = useCallback((type: DiscoveryType) => {
     setSelectedTypes((prev) =>
@@ -45,34 +59,39 @@ export default function PlacecardsBrowseClient({
 
   const clearFilters = useCallback(() => {
     setSelectedTypes([]);
+    setSelectedContext('');
     setMinRating(null);
     setSearchQuery('');
   }, []);
 
-  const hasActiveFilters = selectedTypes.length > 0 || minRating !== null || searchQuery !== '';
+  const hasActiveFilters = selectedTypes.length > 0 || selectedContext !== '' || minRating !== null || searchQuery !== '';
+
+  // Use admin cards when in admin view mode
+  const activeCards = viewMode === 'admin' && adminCards ? adminCards : cards;
 
   const filteredCards = useMemo(() => {
-    let result = cards;
+    let result = activeCards;
 
-    // Filter by search query (name)
     if (searchQuery) {
       const query = searchQuery.toLowerCase();
       result = result.filter((card) =>
-        card.name.toLowerCase().includes(query)
+        card.name.toLowerCase().includes(query) ||
+        card.city.toLowerCase().includes(query)
       );
     }
 
-    // Filter by type
+    if (selectedContext) {
+      result = result.filter((card) => card.contextKey === selectedContext);
+    }
+
     if (selectedTypes.length > 0) {
       result = result.filter((card) => selectedTypes.includes(card.type));
     }
 
-    // Filter by rating
     if (minRating !== null) {
       result = result.filter((card) => card.rating !== null && card.rating >= minRating);
     }
 
-    // Sort
     result = [...result].sort((a, b) => {
       switch (sortOption) {
         case 'name-asc':
@@ -87,18 +106,27 @@ export default function PlacecardsBrowseClient({
     });
 
     return result;
-  }, [cards, searchQuery, selectedTypes, minRating, sortOption]);
+  }, [activeCards, searchQuery, selectedContext, selectedTypes, minRating, sortOption]);
 
   return (
     <main className="page">
       <div className="page-header">
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.6rem' }}>
-          <h1>Places</h1>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.6rem', flexWrap: 'wrap' }}>
+          <h1>{viewMode === 'admin' ? 'All Cards (Admin)' : 'My Places'}</h1>
           <span className="text-muted" style={{ fontSize: '0.85rem', fontWeight: 400 }}>
-            {filteredCards.length === cards.length
-              ? `${cards.length} place cards`
-              : `${filteredCards.length} of ${cards.length}`}
+            {filteredCards.length === activeCards.length
+              ? `${activeCards.length} places`
+              : `${filteredCards.length} of ${activeCards.length}`}
           </span>
+          {isOwner && adminCards && (
+            <button
+              className="filter-chip"
+              style={{ marginLeft: 'auto', fontSize: '0.75rem' }}
+              onClick={() => setViewMode(viewMode === 'my-places' ? 'admin' : 'my-places')}
+            >
+              {viewMode === 'my-places' ? '🔧 Admin view' : '← My Places'}
+            </button>
+          )}
         </div>
       </div>
 
@@ -115,6 +143,25 @@ export default function PlacecardsBrowseClient({
         </div>
 
         <div className="browse-filters">
+          {/* Context filter — only in my-places mode with multiple contexts */}
+          {viewMode === 'my-places' && availableContexts.length > 1 && (
+            <div className="filter-section filter-section-row">
+              <div className="filter-group">
+                <label className="filter-label">Context</label>
+                <select
+                  className="filter-select"
+                  value={selectedContext}
+                  onChange={(e) => setSelectedContext(e.target.value)}
+                >
+                  <option value="">All contexts</option>
+                  {availableContexts.map((ctx) => (
+                    <option key={ctx.key} value={ctx.key}>{ctx.label}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          )}
+
           <div className="filter-section">
             <div className="filter-label">Type</div>
             <div className="filter-chips">
@@ -187,13 +234,18 @@ export default function PlacecardsBrowseClient({
                 {card.rating !== null && (
                   <span className="place-browse-rating">{card.rating.toFixed(1)}★</span>
                 )}
+                {viewMode === 'my-places' && card.contextLabel && (
+                  <span className="place-browse-context text-muted" style={{ fontSize: '0.75rem', display: 'block', marginTop: '0.25rem' }}>
+                    {card.contextLabel}
+                  </span>
+                )}
               </div>
             </Link>
-            {userId && (
+            {userId && card.contextKey && (
               <div className="place-browse-triage">
                 <TriageButtons
                   userId={userId}
-                  contextKey="radar:toronto-experiences"
+                  contextKey={card.contextKey}
                   placeId={card.placeId}
                   size="sm"
                 />
@@ -205,10 +257,21 @@ export default function PlacecardsBrowseClient({
 
       {filteredCards.length === 0 && (
         <div className="place-grid-empty">
-          <p>No places match your filters.</p>
-          <button className="filter-clear" onClick={clearFilters}>
-            Clear filters
-          </button>
+          {activeCards.length === 0 ? (
+            <div>
+              <p>No places discovered yet.</p>
+              <p className="text-muted" style={{ fontSize: '0.85rem' }}>
+                Chat with Compass to start discovering places — they'll appear here.
+              </p>
+            </div>
+          ) : (
+            <div>
+              <p>No places match your filters.</p>
+              <button className="filter-clear" onClick={clearFilters}>
+                Clear filters
+              </button>
+            </div>
+          )}
         </div>
       )}
     </main>

--- a/app/placecards/page.tsx
+++ b/app/placecards/page.tsx
@@ -1,80 +1,108 @@
-import { notFound } from 'next/navigation';
 import type { DiscoveryType } from '../_lib/types';
 import { ALL_TYPES } from '../_lib/discovery-types';
 import { getCurrentUser } from '../_lib/user';
+import { getUserDiscoveries, getUserManifest } from '../_lib/user-data';
 import { PlaceCardStore } from '../_lib/place-card-store';
 import PlacecardsBrowseClient from './PlacecardsBrowseClient';
 
 export const dynamic = 'force-dynamic';
 
-interface IndexEntry {
-  name: string;
-  type: DiscoveryType;
-}
-
-interface CardData {
-  identity?: {
-    city?: string | null;
-  };
-  narrative?: {
-    summary?: string | null;
-  };
-}
-
-// Extract rating from summary string (e.g., "5.0★" or "4.5★")
-function extractRating(summary: string | null): number | null {
-  if (!summary) return null;
-  const match = summary.match(/(\d+\.?\d*)\s*★/);
-  if (!match) return null;
-  const value = match[1];
-  if (!value) return null;
-  return parseFloat(value);
-}
-
-interface PlaceCardData {
+export interface PlaceCardData {
   placeId: string;
   name: string;
   type: DiscoveryType;
   city: string;
   rating: number | null;
+  contextKey: string;
+  contextLabel: string;
+  heroImage?: string;
 }
 
 export default async function PlacecardsPage() {
   const user = await getCurrentUser();
 
-  // Places browse uses the global index — owner only
-  if (!user?.isOwner) {
+  if (!user) {
     return (
       <main className="page">
-        <div className="page-header"><h1>Places</h1></div>
-        <p className="text-muted">Coming soon.</p>
+        <div className="page-header"><h1>My Places</h1></div>
+        <p className="text-muted">Sign in to see your discovered places.</p>
       </main>
     );
   }
 
-  const index = await PlaceCardStore.getIndex();
+  // Load user discoveries and context manifest in parallel
+  const [discData, manifest] = await Promise.all([
+    getUserDiscoveries(user.id),
+    getUserManifest(user.id),
+  ]);
 
-  // Build enriched card data with city and rating
-  // Note: During migration, we may fall back to local data for some cards
-  const cards: PlaceCardData[] = await Promise.all(
-    Object.entries(index).map(async ([placeId, entry]) => {
-      const cardData = await PlaceCardStore.getCard(placeId) as CardData | null;
-      const city = cardData?.identity?.city ?? '';
-      const rating = extractRating(cardData?.narrative?.summary ?? null);
+  const discoveries = discData?.discoveries ?? [];
 
-      return {
-        placeId,
-        name: entry.name,
-        type: entry.type,
-        city,
-        rating,
-      };
-    })
-  );
+  // Build context label lookup from manifest
+  const contextLabels: Record<string, string> = {};
+  if (manifest?.contexts) {
+    for (const ctx of manifest.contexts) {
+      contextLabels[ctx.key] = `${ctx.emoji || '📋'} ${ctx.label}`;
+    }
+  }
 
-  // Get available types from the data
+  // Deduplicate by place_id (first occurrence wins)
+  const seen = new Set<string>();
+  const cards: PlaceCardData[] = [];
+
+  for (const d of discoveries) {
+    const placeId = d.place_id || d.id;
+    if (seen.has(placeId)) continue;
+    seen.add(placeId);
+
+    cards.push({
+      placeId,
+      name: d.name,
+      type: d.type,
+      city: d.city || '',
+      rating: d.rating ?? null,
+      contextKey: d.contextKey,
+      contextLabel: contextLabels[d.contextKey] || d.contextKey,
+      heroImage: d.heroImage,
+    });
+  }
+
+  // Get available types from user's data
   const typeSet = new Set<DiscoveryType>(cards.map((c) => c.type));
   const availableTypes = ALL_TYPES.filter((t) => typeSet.has(t));
 
-  return <PlacecardsBrowseClient cards={cards} availableTypes={availableTypes} userId={user?.id} />;
+  // Get unique contexts for filtering
+  const contextSet = new Map<string, string>();
+  for (const c of cards) {
+    if (!contextSet.has(c.contextKey)) {
+      contextSet.set(c.contextKey, c.contextLabel);
+    }
+  }
+  const availableContexts = Array.from(contextSet.entries()).map(([key, label]) => ({ key, label }));
+
+  // Owner admin: build global card list for the admin toggle
+  let adminCards: PlaceCardData[] | undefined;
+  if (user.isOwner) {
+    const index = await PlaceCardStore.getIndex();
+    adminCards = Object.entries(index).map(([placeId, entry]) => ({
+      placeId,
+      name: entry.name,
+      type: entry.type as DiscoveryType,
+      city: '',
+      rating: null,
+      contextKey: '',
+      contextLabel: '',
+    }));
+  }
+
+  return (
+    <PlacecardsBrowseClient
+      cards={cards}
+      availableTypes={availableTypes}
+      availableContexts={availableContexts}
+      userId={user.id}
+      isOwner={user.isOwner}
+      adminCards={adminCards}
+    />
+  );
 }


### PR DESCRIPTION
## Summary

Addresses issue #166 — The /placecards page now shows a user's own discovered places instead of browsing the global place card library.

## Changes

### `app/placecards/page.tsx`
- Replaced `PlaceCardStore.getIndex()` with `getUserDiscoveries(userId)`
- Cards built from user's actual discovery records, deduplicated by placeId
- Context labels loaded from `getUserManifest()` for friendly display
- Owner admin toggle: global card index available via admin view for debugging
- Non-logged-in users see a friendly sign-in message

### `app/placecards/PlacecardsBrowseClient.tsx`
- Context filter dropdown (shown when user has multiple contexts)
- Context label displayed on each card
- Admin toggle for owners: My Places ↔ All Cards (admin)
- `TriageButtons` use per-discovery `contextKey` instead of hardcoded value
- Empty state guides users to chat for discovering places
- Search now also matches city name
- Count label updated to 'places'

### `app/_components/Nav.tsx`
- Renamed 'Places' → 'My Places'

## Success Criteria
- ✅ /placecards shows only discoveries belonging to the current user
- ✅ Cards filterable by context
- ✅ Count matches user's personal discovery count
- ✅ No orphan legacy cards visible to regular users
- ✅ Owner can access full index via admin toggle
- ✅ Build passes clean
- ✅ Smoke test: 8/8 pass