### PR TITLE
feat: proxy /api/chat through OpenClaw Gateway with Anthropic fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Compass V2 — Required Environment Variables
+
+# Vercel Blob storage (read/write token)
+BLOB_READ_WRITE_TOKEN=
+
+# Public Blob base URL for image resolution (CRITICAL — images break without this)
+NEXT_PUBLIC_BLOB_BASE_URL=https://your-blob-id.public.blob.vercel-storage.com
+
+# Anthropic API key for concierge chat (used as fallback when OpenClaw is down)
+ANTHROPIC_API_KEY=
+
+# OpenClaw Gateway — proxy chat through Concierge agent
+# When set, /api/chat routes through OpenClaw first; falls back to direct Anthropic if unavailable
+OPENCLAW_GATEWAY_URL=https://johns-mac-mini.tail7b8c49.ts.net
+OPENCLAW_GATEWAY_TOKEN=
+
+# Briefing ingest token (for Charlie's cron)
+BRIEFING_INGEST_TOKEN=compass-briefing-2026

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/app/_lib/chat/user-context.ts
+++ b/app/_lib/chat/user-context.ts
@@ -1,0 +1,78 @@
+/**
+ * Build a user-context system message for the OpenClaw Concierge agent.
+ *
+ * This replaces the old monolithic system prompt — the Concierge agent's
+ * personality and tool definitions now live in OpenClaw's agent config.
+ * We only need to inject who the user is, their preferences, and active contexts
+ * so the agent can personalize its responses.
+ */
+
+import type { UserPreferences, UserManifest, Context } from '../types';
+
+interface UserLike {
+  id: string;
+  code: string;
+  city?: string;
+  name?: string;
+}
+
+interface ProfileLike {
+  city?: string;
+  name?: string;
+}
+
+interface RecentDiscovery {
+  name: string;
+  type: string;
+  city: string;
+}
+
+export function buildUserContext(
+  user: UserLike,
+  profile: ProfileLike | null,
+  preferences: UserPreferences | null,
+  manifest: UserManifest | null,
+  recentDiscoveries: RecentDiscovery[],
+): string {
+  const parts: string[] = [];
+
+  // User identity
+  const city = profile?.city || user.city || 'unknown';
+  const name = profile?.name || user.name || user.code;
+  parts.push(`## User\nName: ${name}\nCode: ${user.code}\nHome city: ${city}`);
+
+  // Preferences (Layer 1)
+  if (preferences) {
+    const prefLines: string[] = [];
+    if (preferences.interests?.length) prefLines.push(`Interests: ${preferences.interests.join(', ')}`);
+    if (preferences.cuisines?.length) prefLines.push(`Cuisines: ${preferences.cuisines.join(', ')}`);
+    if (preferences.vibes?.length) prefLines.push(`Vibes: ${preferences.vibes.join(', ')}`);
+    if (preferences.avoidances?.length) prefLines.push(`Avoids: ${preferences.avoidances.join(', ')}`);
+    if (prefLines.length > 0) {
+      parts.push(`## Preferences\n${prefLines.join('\n')}`);
+    }
+  }
+
+  // Active contexts (trips, outings, radars)
+  const activeContexts = manifest?.contexts?.filter((c: Context) => c.active) || [];
+  if (activeContexts.length > 0) {
+    const ctxLines = activeContexts.map((ctx: Context) => {
+      const dates = ctx.dates ? ` (${ctx.dates})` : '';
+      const focus = ctx.focus?.length ? ` — Focus: ${ctx.focus.join(', ')}` : '';
+      return `- ${ctx.emoji || '📍'} ${ctx.label}${dates}${focus}  [key: ${ctx.key}]`;
+    });
+    parts.push(`## Active Contexts\n${ctxLines.join('\n')}`);
+  } else {
+    parts.push(`## Contexts\nNo active trips, outings, or radars.`);
+  }
+
+  // Recent discoveries
+  if (recentDiscoveries.length > 0) {
+    const discLines = recentDiscoveries.map(
+      (d) => `- ${d.name} (${d.type}) — ${d.city}`,
+    );
+    parts.push(`## Recent Discoveries\n${discLines.join('\n')}`);
+  }
+
+  return parts.join('\n\n');
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,16 +1,69 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getCurrentUser } from '../../_lib/user';
 import { getUserProfile, getUserPreferences, getUserManifest, getUserDiscoveries } from '../../_lib/user-data';
-import { sendChatMessage } from '../../_lib/chat/anthropic-client';
 import { persistChatData, getChatHistory } from '../../_lib/chat/persistence';
-import type { ChatMessage, UserPreferences, UserManifest, Discovery } from '../../_lib/types';
+import { buildUserContext } from '../../_lib/chat/user-context';
+import { sendChatMessage as sendAnthropicFallback } from '../../_lib/chat/anthropic-client';
+import type { ChatMessage, Discovery } from '../../_lib/types';
 
-interface ChatContext {
-  userCode: string;
-  userCity: string;
-  preferences: UserPreferences | null;
-  manifest: UserManifest | null;
-  recentDiscoveries: Array<{ name: string; type: string; city: string }>;
+const OPENCLAW_TIMEOUT_MS = 30_000;
+
+interface OpenClawMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+/**
+ * Call the OpenClaw Gateway, returning the assistant reply text.
+ * Returns null if unreachable / timed out so the caller can fall back.
+ */
+async function callOpenClaw(
+  messages: OpenClawMessage[],
+  userId: string,
+): Promise<string | null> {
+  const gatewayUrl = process.env.OPENCLAW_GATEWAY_URL;
+  const gatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+
+  if (!gatewayUrl || !gatewayToken) return null;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), OPENCLAW_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(`${gatewayUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${gatewayToken}`,
+        'x-openclaw-agent-id': 'concierge',
+        'x-openclaw-session-key': `compass:user:${userId}`,
+      },
+      body: JSON.stringify({
+        model: 'openclaw/concierge',
+        messages,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      console.error('[chat/openclaw] Gateway error:', res.status, await res.text().catch(() => ''));
+      return null;
+    }
+
+    // OpenAI-compatible response shape
+    const data = await res.json();
+    const choice = data?.choices?.[0];
+    return choice?.message?.content ?? null;
+  } catch (err: unknown) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      console.warn('[chat/openclaw] Gateway timeout after', OPENCLAW_TIMEOUT_MS, 'ms');
+    } else {
+      console.error('[chat/openclaw] Gateway unreachable:', err instanceof Error ? err.message : err);
+    }
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export async function POST(request: NextRequest) {
@@ -28,38 +81,68 @@ export async function POST(request: NextRequest) {
     }
 
     // Load user data from blob
-    const profile = await getUserProfile(user.id);
-    const preferences = await getUserPreferences(user.id);
-    const manifest = await getUserManifest(user.id);
-    const discoveries = await getUserDiscoveries(user.id);
+    const [profile, preferences, manifest, discoveries] = await Promise.all([
+      getUserProfile(user.id),
+      getUserPreferences(user.id),
+      getUserManifest(user.id),
+      getUserDiscoveries(user.id),
+    ]);
 
-    // Build chat context for system prompt
+    // Build recent discoveries summary
     const recentDiscoveries = (discoveries?.discoveries || [])
-      .sort((a, b) => new Date(b.discoveredAt).getTime() - new Date(a.discoveredAt).getTime())
+      .sort((a: Discovery, b: Discovery) => new Date(b.discoveredAt).getTime() - new Date(a.discoveredAt).getTime())
       .slice(0, 5)
       .map((d: Discovery) => ({ name: d.name, type: d.type, city: d.city }));
 
-    const context: ChatContext = {
-      userCode: user.code,
-      userCity: profile?.city || user.city || '',
+    // Get chat history from blob if not provided by client
+    const history: ChatMessage[] = clientHistory || (await getChatHistory(user.id));
+
+    // Cap history at last 20 messages and truncate long content
+    const MAX_CONTENT = 2000;
+    const trimmedHistory: OpenClawMessage[] = (history || []).slice(-20).map((msg: ChatMessage) => ({
+      role: (msg.role === 'user' ? 'user' : 'assistant') as 'user' | 'assistant',
+      content:
+        typeof msg.content === 'string' && msg.content.length > MAX_CONTENT
+          ? msg.content.slice(0, MAX_CONTENT) + '…'
+          : msg.content,
+    }));
+
+    // Build user context system message
+    const systemContent = buildUserContext(
+      user,
+      profile,
       preferences,
       manifest,
       recentDiscoveries,
-    };
-
-    // Get chat history from blob if not provided by client
-    const history = clientHistory || (await getChatHistory(user.id));
-
-    // Send message to Claude
-    const { reply, messageId } = await sendChatMessage(
-      {
-        message,
-        userId: user.id,
-        userCode: user.code,
-        history,
-      },
-      context,
     );
+
+    // Assemble messages for OpenClaw (OpenAI-compatible format)
+    const openclawMessages: OpenClawMessage[] = [
+      { role: 'system', content: systemContent },
+      ...trimmedHistory,
+      { role: 'user', content: message },
+    ];
+
+    // Try OpenClaw Gateway first, fall back to direct Anthropic
+    let reply = await callOpenClaw(openclawMessages, user.id);
+
+    if (reply === null) {
+      console.warn('[chat] OpenClaw unavailable, falling back to direct Anthropic');
+      const context = {
+        userCode: user.code,
+        userCity: profile?.city || user.city || '',
+        preferences,
+        manifest,
+        recentDiscoveries,
+      };
+      const fallback = await sendAnthropicFallback(
+        { message, userId: user.id, userCode: user.code, history },
+        context,
+      );
+      reply = fallback.reply;
+    }
+
+    const messageId = `${Date.now()}-concierge`;
 
     // Persist chat (fire-and-forget with timeout)
     persistChatData(user.id, message, reply, messageId, history).catch(() => {});


### PR DESCRIPTION
Addresses issue #193

## What changed

Rewrites `/api/chat` to proxy through the OpenClaw Gateway instead of calling Anthropic directly.

### Architecture
- **Primary path:** POST to OpenClaw Gateway `/v1/chat/completions` with OpenAI-compatible format
- **Fallback:** If Gateway is unreachable or times out (30s), falls back to the existing direct Anthropic client
- **User context:** Injected as a system message via new `buildUserContext()` helper (user profile, preferences, active contexts, recent discoveries)

### Files changed
- `app/api/chat/route.ts` — main rewrite: OpenClaw proxy + fallback logic
- `app/_lib/chat/user-context.ts` — new helper to build user context system message
- `.env.example` — documents `OPENCLAW_GATEWAY_URL` and `OPENCLAW_GATEWAY_TOKEN`
- `.gitignore` — allow `.env.example` through the `.env*` ignore pattern

### What's preserved
- All existing chat tools (`app/_lib/chat/tools/`) and `anthropic-client.ts` remain intact as fallback
- Chat persistence unchanged
- No breaking changes — works identically to before if Gateway env vars are not set

### New Vercel env vars needed
- `OPENCLAW_GATEWAY_URL` — e.g. `https://johns-mac-mini.tail7b8c49.ts.net`
- `OPENCLAW_GATEWAY_TOKEN` — Gateway auth token

### Smoke test
All pre-existing failures only (triage 404s, data quality). No 5xx errors. No regressions.