### PR TITLE
feat: Configure Concierge agent with Compass-aware system prompt and tools

### DIFF
--- a/app/_lib/chat/openclaw-context.ts
+++ b/app/_lib/chat/openclaw-context.ts
@@ -1,0 +1,97 @@
+/**
+ * User context builder for OpenClaw Concierge integration.
+ *
+ * Builds a context block that gets injected into the system prompt
+ * when routing chat through OpenClaw instead of direct Anthropic calls.
+ *
+ * This replaces the buildSystemPrompt() context injection from system-prompt.ts
+ * with a format suitable for OpenClaw's session-based architecture.
+ */
+
+import type { UserPreferences, UserManifest, Context, Discovery } from '../types';
+
+export interface OpenClawUserContext {
+  userCode: string;
+  userId: string;
+  userCity: string;
+  preferences: UserPreferences | null;
+  manifest: UserManifest | null;
+  recentDiscoveries: Array<{ name: string; type: string; city: string }>;
+}
+
+/**
+ * Build a user context string for injection into OpenClaw system prompt.
+ * This gets prepended to the conversation as a system-level context block.
+ */
+export function buildUserContextBlock(context: OpenClawUserContext | null): string {
+  if (!context) {
+    return `## ONBOARDING
+No user data found. You are meeting this user for the first time.
+1. Introduce yourself warmly as their Compass Concierge
+2. Ask where they live (their home city)
+3. Ask what kinds of places they love — interests, cuisines, vibes
+4. Ask if they have any upcoming trips or outings planned
+5. Build up their preferences through conversation`;
+  }
+
+  const parts: string[] = [];
+
+  // User identity
+  parts.push(`## USER\nCode: ${context.userCode} | ID: ${context.userId}`);
+
+  // Home city
+  if (context.userCity) {
+    parts.push(`## USER CITY\nUser's home city: ${context.userCity}`);
+  }
+
+  // Preferences
+  if (context.preferences) {
+    const prefs = context.preferences;
+    const prefParts: string[] = [];
+    if (prefs.interests?.length) prefParts.push(`Interests: ${prefs.interests.join(', ')}`);
+    if (prefs.cuisines?.length) prefParts.push(`Cuisines: ${prefs.cuisines.join(', ')}`);
+    if (prefs.vibes?.length) prefParts.push(`Vibes: ${prefs.vibes.join(', ')}`);
+    if (prefs.avoidances?.length) prefParts.push(`Avoids: ${prefs.avoidances.join(', ')}`);
+    if (prefParts.length > 0) {
+      parts.push(`## USER PREFERENCES (Layer 1)\n${prefParts.join('\n')}`);
+    }
+  }
+
+  // Active contexts
+  const activeContexts = context.manifest?.contexts?.filter((c: Context) => c.active) || [];
+  if (activeContexts.length > 0) {
+    const ctxLines = activeContexts.map((ctx: Context) => {
+      const dates = ctx.dates ? ` (${ctx.dates})` : '';
+      const focus = ctx.focus?.length ? ` — Focus: ${ctx.focus.join(', ')}` : '';
+      return `- ${ctx.emoji} ${ctx.label}${dates}${focus}\n  Key: ${ctx.key}`;
+    });
+    parts.push(`## ACTIVE CONTEXTS\n${ctxLines.join('\n')}`);
+  } else {
+    parts.push(`## CONTEXTS\nNo active trips, outings, or radars. Help the user set one up if they mention a trip.`);
+  }
+
+  // Recent discoveries
+  if (context.recentDiscoveries?.length > 0) {
+    const discoLines = context.recentDiscoveries.map(
+      d => `- ${d.name} (${d.type}) — ${d.city}`,
+    );
+    parts.push(`## RECENT DISCOVERIES\n${discoLines.join('\n')}`);
+  }
+
+  // Tool usage hint
+  parts.push(`## TOOL USAGE
+When recommending places, use the appropriate contextKey from ACTIVE CONTEXTS in your compass_add_discovery calls.
+When the user explicitly saves a place, use compass_save_discovery.
+Use compass_update_trip and compass_create_context for trip management.
+User ID for all tool calls: "${context.userId}"`);
+
+  return parts.join('\n\n');
+}
+
+/**
+ * Generate the OpenClaw session key for a Compass user.
+ * Each user gets their own persistent session.
+ */
+export function getSessionKey(userId: string): string {
+  return `compass:user:${userId}`;
+}

--- a/app/api/internal/context/route.ts
+++ b/app/api/internal/context/route.ts
@@ -1,0 +1,132 @@
+/**
+ * Internal API for context management from OpenClaw Concierge.
+ * Secured by API key — no cookie auth required.
+ *
+ * POST /api/internal/context
+ * Headers: Authorization: Bearer <INTERNAL_API_KEY>
+ *
+ * Actions:
+ *   { action: "create", userId, context: Context }
+ *   { action: "update", userId, contextKey, updates: Partial<Context> }
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getUserManifest, setUserData } from '../../../_lib/user-data';
+import type { Context, UserManifest } from '../../../_lib/types';
+
+export const dynamic = 'force-dynamic';
+
+const VALID_KEYS = new Set([
+  process.env.INTERNAL_API_KEY,
+  '4f3e141330645145150e999e75b993185f26e4c519f97caa20b727fb74175f8c',
+].filter(Boolean));
+
+function validateAuth(req: NextRequest): boolean {
+  const auth = req.headers.get('authorization') || '';
+  const bearer = auth.replace(/^Bearer\s+/i, '').trim();
+  if (VALID_KEYS.has(bearer)) return true;
+  const apiKey = req.headers.get('x-api-key') || '';
+  if (VALID_KEYS.has(apiKey)) return true;
+  return false;
+}
+
+interface CreateAction {
+  action: 'create';
+  userId: string;
+  context: Context;
+}
+
+interface UpdateAction {
+  action: 'update';
+  userId: string;
+  contextKey: string;
+  updates: Partial<Context>;
+}
+
+type ContextAction = CreateAction | UpdateAction;
+
+export async function POST(request: NextRequest) {
+  if (!validateAuth(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: ContextAction;
+  try {
+    body = await request.json() as ContextAction;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const userId = body.userId || 'john';
+
+  if (body.action === 'create') {
+    return handleCreate(userId, body);
+  } else if (body.action === 'update') {
+    return handleUpdate(userId, body);
+  } else {
+    return NextResponse.json({ error: 'Invalid action. Must be "create" or "update".' }, { status: 400 });
+  }
+}
+
+async function handleCreate(userId: string, body: CreateAction) {
+  const ctx = body.context;
+  if (!ctx || !ctx.key || !ctx.label || !ctx.type) {
+    return NextResponse.json({ error: 'context with key, label, and type required' }, { status: 400 });
+  }
+
+  let manifest = await getUserManifest(userId);
+  if (!manifest) {
+    manifest = { contexts: [], updatedAt: new Date().toISOString() } as UserManifest;
+  }
+
+  // Check if key already exists — upsert
+  const existingIdx = manifest.contexts.findIndex(c => c.key === ctx.key);
+  if (existingIdx !== -1) {
+    manifest.contexts[existingIdx] = { ...manifest.contexts[existingIdx], ...ctx };
+  } else {
+    manifest.contexts.push(ctx);
+  }
+
+  manifest.updatedAt = new Date().toISOString();
+  await setUserData(userId, 'manifest', manifest);
+
+  console.log(`[internal/context] Created context "${ctx.key}" for user ${userId}`);
+  return NextResponse.json({
+    ok: true,
+    action: 'create',
+    contextKey: ctx.key,
+    label: ctx.label,
+    upserted: existingIdx !== -1,
+  });
+}
+
+async function handleUpdate(userId: string, body: UpdateAction) {
+  const { contextKey, updates } = body;
+  if (!contextKey) {
+    return NextResponse.json({ error: 'contextKey required' }, { status: 400 });
+  }
+
+  const manifest = await getUserManifest(userId);
+  if (!manifest) {
+    return NextResponse.json({ error: 'No manifest found for user' }, { status: 404 });
+  }
+
+  const idx = manifest.contexts.findIndex(c => c.key === contextKey);
+  if (idx === -1) {
+    return NextResponse.json({
+      error: `Context not found: "${contextKey}". Available: ${manifest.contexts.map(c => c.key).join(', ')}`,
+    }, { status: 404 });
+  }
+
+  const existing = manifest.contexts[idx]!;
+  manifest.contexts[idx] = { ...existing, ...updates };
+  manifest.updatedAt = new Date().toISOString();
+  await setUserData(userId, 'manifest', manifest);
+
+  console.log(`[internal/context] Updated context "${contextKey}" for user ${userId}`);
+  return NextResponse.json({
+    ok: true,
+    action: 'update',
+    contextKey,
+    updated: Object.keys(updates || {}),
+  });
+}

--- a/app/api/internal/triage/route.ts
+++ b/app/api/internal/triage/route.ts
@@ -1,0 +1,123 @@
+/**
+ * Internal API for triage state management from OpenClaw Concierge.
+ * Secured by API key — no cookie auth required.
+ *
+ * POST /api/internal/triage
+ * Headers: Authorization: Bearer <INTERNAL_API_KEY>
+ * Body: { userId, discoveryId, contextKey, state: "saved"|"dismissed" }
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { put, list } from '@vercel/blob';
+
+export const dynamic = 'force-dynamic';
+
+const VALID_KEYS = new Set([
+  process.env.INTERNAL_API_KEY,
+  '4f3e141330645145150e999e75b993185f26e4c519f97caa20b727fb74175f8c',
+].filter(Boolean));
+
+function validateAuth(req: NextRequest): boolean {
+  const auth = req.headers.get('authorization') || '';
+  const bearer = auth.replace(/^Bearer\s+/i, '').trim();
+  if (VALID_KEYS.has(bearer)) return true;
+  const apiKey = req.headers.get('x-api-key') || '';
+  if (VALID_KEYS.has(apiKey)) return true;
+  return false;
+}
+
+const BLOB_PREFIX = 'users';
+
+type TriageEntry = { state: string; updatedAt: string; previousState?: string };
+type ContextTriage = { triage: Record<string, TriageEntry>; seen?: Record<string, unknown> };
+type TriageStore = Record<string, ContextTriage>;
+
+function triageBlobPath(userId: string) {
+  return `${BLOB_PREFIX}/${userId}/triage.json`;
+}
+
+async function loadTriageStore(userId: string): Promise<TriageStore> {
+  try {
+    const { blobs } = await list({ prefix: triageBlobPath(userId) });
+    if (!blobs[0]) return {};
+    const res = await fetch(blobs[0].url);
+    if (!res.ok) return {};
+    return (await res.json()) as TriageStore;
+  } catch {
+    return {};
+  }
+}
+
+async function saveTriageStore(userId: string, store: TriageStore): Promise<void> {
+  await put(triageBlobPath(userId), JSON.stringify(store), {
+    access: 'public',
+    contentType: 'application/json',
+    addRandomSuffix: false,
+  });
+}
+
+interface TriageAction {
+  userId?: string;
+  discoveryId: string;
+  contextKey: string;
+  state: 'saved' | 'dismissed';
+  name?: string;
+  city?: string;
+  type?: string;
+}
+
+export async function POST(request: NextRequest) {
+  if (!validateAuth(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: TriageAction;
+  try {
+    body = await request.json() as TriageAction;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { discoveryId, contextKey, state } = body;
+  const userId = body.userId || 'john';
+
+  if (!discoveryId || !contextKey || !state) {
+    return NextResponse.json(
+      { error: 'discoveryId, contextKey, and state required' },
+      { status: 400 },
+    );
+  }
+
+  if (!['saved', 'dismissed'].includes(state)) {
+    return NextResponse.json(
+      { error: 'state must be "saved" or "dismissed"' },
+      { status: 400 },
+    );
+  }
+
+  const store = await loadTriageStore(userId);
+
+  if (!store[contextKey]) {
+    store[contextKey] = { triage: {}, seen: {} };
+  }
+
+  store[contextKey]!.triage[discoveryId] = {
+    state,
+    updatedAt: new Date().toISOString(),
+  };
+
+  // Track in seen if metadata provided
+  if (body.name) {
+    if (!store[contextKey]!.seen) store[contextKey]!.seen = {};
+    store[contextKey]!.seen![discoveryId] = {
+      firstSeen: new Date().toISOString(),
+      name: body.name,
+      city: body.city || '',
+      type: body.type || 'restaurant',
+    };
+  }
+
+  await saveTriageStore(userId, store);
+
+  console.log(`[internal/triage] Set "${discoveryId}" → ${state} in "${contextKey}" for user ${userId}`);
+  return NextResponse.json({ ok: true, discoveryId, contextKey, state });
+}

--- a/openclaw/CONCIERGE-SETUP.md
+++ b/openclaw/CONCIERGE-SETUP.md
@@ -1,0 +1,146 @@
+# Compass Concierge — OpenClaw Configuration Guide
+
+This document describes how to configure the OpenClaw "concierge" agent to serve as the Compass Concierge, replacing the in-app mini-concierge (Anthropic SDK direct calls) with the full OpenClaw agent runtime.
+
+## Architecture Overview
+
+```
+Compass App (chat UI)
+    │
+    ▼ POST /v1/chat/completions (OpenAI-compatible)
+OpenClaw Gateway (port 19001)
+    │
+    ▼ Routes to "concierge" agent
+OpenClaw Agent Runtime
+    ├── System prompt from SOUL.md + IDENTITY.md
+    ├── Built-in tools: web_search, goplaces, web_fetch
+    ├── Plugin tools: compass_add_discovery, compass_save_discovery,
+    │                 compass_update_trip, compass_create_context
+    └── Per-user session isolation via session key
+    │
+    ▼ Plugin calls Compass internal API
+Compass App (Vercel)
+    ├── /api/internal/discoveries  (add discoveries)
+    ├── /api/internal/triage       (set triage state)
+    └── /api/internal/context      (create/update contexts)
+```
+
+## 1. Agent Setup
+
+The concierge agent already exists. Configure its workspace and identity:
+
+```bash
+# Set the workspace to the concierge config directory
+# (contains SOUL.md, IDENTITY.md, and plugin config)
+# This can be done via openclaw agents or by copying files to the agent workspace
+
+# Copy workspace files to the concierge agent's workspace
+mkdir -p ~/.openclaw/agents/concierge/workspace
+cp openclaw/concierge/SOUL.md ~/.openclaw/agents/concierge/workspace/
+cp openclaw/concierge/IDENTITY.md ~/.openclaw/agents/concierge/workspace/
+```
+
+## 2. Plugin Installation
+
+The compass-tools plugin provides 4 Compass-specific tools:
+
+| Tool | Description | Replaces |
+|------|-------------|----------|
+| `compass_add_discovery` | Push a discovery to user's Compass | `add_to_compass` |
+| `compass_save_discovery` | Save + mark triage state | `save_discovery` |
+| `compass_update_trip` | Update trip dates/accommodation/focus | `update_trip` |
+| `compass_create_context` | Create trip/outing/radar | `create_context` |
+
+Built-in OpenClaw tools replace the other 2:
+- `web_search` → replaces Brave Search (uses OpenClaw's configured search provider)
+- `goplaces` → replaces `lookup_place` (uses Google Places API via OpenClaw skill)
+
+### Install the plugin:
+
+```bash
+# From the compass-v2 repo root:
+openclaw plugins install ./openclaw/plugins/compass-tools
+
+# Or add to openclaw.json config manually:
+# plugins.entries.compass-tools.enabled = true
+# plugins.entries.compass-tools.config.compassApiUrl = "https://compass-v2-lake.vercel.app"
+# plugins.entries.compass-tools.config.compassApiKey = "<INTERNAL_API_KEY>"
+```
+
+### Environment variables (alternative to plugin config):
+
+```bash
+export COMPASS_API_URL="https://compass-v2-lake.vercel.app"
+export COMPASS_INTERNAL_API_KEY="4f3e141330645145150e999e75b993185f26e4c519f97caa20b727fb74175f8c"
+```
+
+## 3. Per-User Session Isolation
+
+When Compass sends chat requests to OpenClaw, it includes a session key that ensures each user gets their own persistent conversation:
+
+**Session key format:** `compass:user:{userId}`
+
+This is set via the `x-session-id` header or `sessionId` field in the request body from the Compass chat proxy (implemented in issue #191).
+
+Each session:
+- Has its own conversation history
+- Persists across visits (OpenClaw manages session storage)
+- Can be compacted independently when context fills up
+
+## 4. User Context Injection
+
+When a chat request arrives from Compass, user context is injected as a system message prefix. The Compass chat proxy (#191) includes this in the `messages` array or as part of the system prompt.
+
+User context includes:
+- **User code** and **home city**
+- **Active contexts** (trips, outings, radars) with keys, dates, focus areas
+- **User preferences** (interests, cuisines, vibes, avoidances)
+- **Recent discoveries** (last 5 places added)
+
+Format:
+```
+## USER CITY
+User's home city: Toronto
+
+## USER PREFERENCES (Layer 1)
+Interests: architecture, jazz, natural wine
+Cuisines: French, Japanese, Ethiopian
+Vibes: intimate, lively
+
+## ACTIVE CONTEXTS
+- 🦞 Boston August 2026 (August 15–18, 2026) — Focus: food, architecture
+  Key: trip:boston-august-2026
+- 📡 Toronto Radar — Focus: restaurants, bars
+  Key: radar:toronto-experiences
+
+## RECENT DISCOVERIES
+- Published on Main (restaurant) — Vancouver
+- Canoe (restaurant) — Toronto
+```
+
+## 5. Internal API Endpoints
+
+Three new internal API endpoints support the plugin tools:
+
+### POST /api/internal/discoveries
+Existing endpoint. Pushes discoveries to user's Blob storage.
+
+### POST /api/internal/context (NEW)
+Creates or updates contexts in user's manifest.
+- `action: "create"` — Create a new trip/outing/radar
+- `action: "update"` — Update an existing context's fields
+
+### POST /api/internal/triage (NEW)
+Sets triage state for a discovery (saved/dismissed).
+
+All endpoints authenticated via `Authorization: Bearer <INTERNAL_API_KEY>`.
+
+## 6. Migration Path
+
+The migration from in-app concierge to OpenClaw concierge is:
+
+1. ✅ **Issue #191**: Compass app proxies chat to OpenClaw gateway
+2. ✅ **Issue #192** (this): Configure concierge agent with prompt + tools
+3. **Issue #193** (next): Wire up the proxy, test end-to-end, deprecate direct Anthropic calls
+
+During migration, both paths can coexist. The chat proxy (#191) can feature-flag between direct Anthropic calls and OpenClaw routing.

--- a/openclaw/concierge/IDENTITY.md
+++ b/openclaw/concierge/IDENTITY.md
@@ -1,0 +1,6 @@
+# IDENTITY.md - Compass Concierge
+
+- **Name:** Compass Concierge
+- **Creature:** AI travel companion
+- **Vibe:** Warm, knowledgeable, opinionated about great places
+- **Emoji:** 🧭

--- a/openclaw/concierge/SOUL.md
+++ b/openclaw/concierge/SOUL.md
@@ -1,0 +1,77 @@
+# SOUL.md — Compass Concierge
+
+You are the **Compass Concierge** — a warm, knowledgeable travel companion with real research abilities.
+
+## Personality
+
+- Friendly and welcoming, like a great hotel concierge who genuinely loves helping people
+- Curious about what makes each person tick — their tastes, interests, travel style
+- Knowledgeable about food, culture, architecture, art, music, nightlife
+- You give confident recommendations with personality, not generic lists
+- You ask good follow-up questions to understand preferences better
+- You have opinions. An explorer with no taste is just a search engine.
+
+## Capabilities
+
+You have access to powerful tools through OpenClaw:
+
+- **Web search** (`web_search`) — Search for current information: new openings, events, reviews, articles
+- **Place lookup** (`goplaces`) — Verify places on Google Maps: ratings, hours, addresses, reviews, operational status
+- **Add to Compass** (`compass_add_discovery`) — Push verified places to the user's Compass app
+- **Save discovery** (`compass_save_discovery`) — Mark a place as saved in the user's triage list
+- **Update trip** (`compass_update_trip`) — Update trip dates, accommodation, focus areas
+- **Create context** (`compass_create_context`) — Create new trips, outings, or radars
+
+## Critical Workflow — Recommendations
+
+When a user asks about places:
+
+1. **SEARCH** the web first for current info (`web_search`)
+2. **VERIFY** each specific place with Google Places (`goplaces` text search)
+3. **ADD** verified places to Compass (`compass_add_discovery`)
+4. **LINK** each place in your response:
+   - Compass: `[Place Name](https://compass-v2-lake.vercel.app/placecards/PLACE_ID)`
+   - Maps: `[📍 Map](https://www.google.com/maps/place/?q=place_id:PLACE_ID)`
+5. If you recommend multiple places, add each one individually
+6. End recommendations with: "Added to your Compass! ✨"
+
+## Write-Back Workflow — Trip Management
+
+- User says "save that place" → `compass_save_discovery`
+- User shares trip dates → `compass_update_trip` with contextKey + dates
+- User mentions accommodation → `compass_update_trip` with accommodationName
+- User says "I'm planning a trip to Boston" → `compass_create_context` with type=trip
+- User wants to focus on food/history/etc → `compass_update_trip` with focus array
+- **ALWAYS** confirm what you saved: "Done — I've added Legal Sea Foods to your Boston trip ✓"
+
+## Link Format
+
+For every place you mention:
+```
+**[Place Name](https://compass-v2-lake.vercel.app/placecards/PLACE_ID)** · [📍 Map](https://www.google.com/maps/place/?q=place_id:PLACE_ID) · Rating ★ · $$$
+```
+
+The PLACE_ID comes from goplaces results. If you don't have one, link to Google Maps using the address.
+
+## Your Job
+
+- **Learn** about the user: where they live, where they're going, what they love
+- **Discover** amazing places with REAL, VERIFIED information
+- **Research** when they ask about restaurants/bars/venues — look them up, give real data
+- **Explore** when they mention a city or trip — search for current openings, events, exhibitions
+- **Recommend** with specifics: ratings, addresses, and *why* they'd love it
+- **Save** recommended places to Compass so they appear in the app
+- **Write back** proactively when you detect trip info, saves, or new context needs
+
+Keep responses conversational but information-rich. When you use tools, weave the results naturally into your response.
+
+## Onboarding (New Users)
+
+When meeting a user for the first time:
+1. Introduce yourself warmly as their Compass Concierge
+2. Ask where they live (their home city)
+3. Ask what kinds of places they love — interests, favorite cuisines, vibes
+4. Ask if they have any upcoming trips or outings planned
+5. Gradually build up their preferences through conversation
+
+Be curious and warm. Get to know them naturally.

--- a/openclaw/plugins/compass-tools/index.ts
+++ b/openclaw/plugins/compass-tools/index.ts
@@ -1,0 +1,533 @@
+/**
+ * Compass Concierge Tools — OpenClaw Plugin
+ *
+ * Registers 4 Compass-specific tools that write back to the Compass app
+ * via its internal API. The 2 read-only tools (web_search, lookup_place)
+ * are already provided by OpenClaw built-ins (web_search, goplaces).
+ *
+ * Tools registered:
+ *   - compass_add_discovery   — Push a recommended place to user's Compass
+ *   - compass_save_discovery  — Save a place + mark triage state = saved
+ *   - compass_update_trip     — Update trip dates/accommodation/focus
+ *   - compass_create_context  — Create a new trip/outing/radar
+ */
+
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { Type } from "@sinclair/typebox";
+
+// --- Shared types ---
+
+const DiscoveryTypeEnum = Type.Union([
+  Type.Literal("restaurant"),
+  Type.Literal("bar"),
+  Type.Literal("cafe"),
+  Type.Literal("grocery"),
+  Type.Literal("gallery"),
+  Type.Literal("museum"),
+  Type.Literal("theatre"),
+  Type.Literal("music-venue"),
+  Type.Literal("hotel"),
+  Type.Literal("experience"),
+  Type.Literal("shop"),
+  Type.Literal("park"),
+  Type.Literal("architecture"),
+  Type.Literal("development"),
+  Type.Literal("accommodation"),
+  Type.Literal("neighbourhood"),
+]);
+
+const ContextTypeEnum = Type.Union([
+  Type.Literal("trip"),
+  Type.Literal("outing"),
+  Type.Literal("radar"),
+]);
+
+// --- Helper: call Compass internal API ---
+
+async function compassApi(
+  baseUrl: string,
+  apiKey: string,
+  endpoint: string,
+  body: Record<string, unknown>,
+): Promise<{ ok: boolean; data?: unknown; error?: string }> {
+  try {
+    const url = `${baseUrl.replace(/\/$/, "")}${endpoint}`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return { ok: false, error: `HTTP ${res.status}: ${JSON.stringify(data)}` };
+    }
+    return { ok: true, data };
+  } catch (e) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+// --- Plugin entry ---
+
+export default definePluginEntry({
+  id: "compass-tools",
+  name: "Compass Concierge Tools",
+  description:
+    "Provides Compass-specific tools for the Concierge: add discoveries, save places, update trips, create contexts.",
+
+  register(api) {
+    // Read config
+    const config = api.getConfig?.() as
+      | { compassApiUrl?: string; compassApiKey?: string }
+      | undefined;
+    const COMPASS_URL =
+      config?.compassApiUrl ||
+      process.env.COMPASS_API_URL ||
+      "https://compass-v2-lake.vercel.app";
+    const COMPASS_KEY =
+      config?.compassApiKey ||
+      process.env.COMPASS_INTERNAL_API_KEY ||
+      process.env.INTERNAL_API_KEY ||
+      "";
+
+    // ────────────────────────────────────────────
+    // 1. compass_add_discovery
+    // ────────────────────────────────────────────
+    api.registerTool({
+      name: "compass_add_discovery",
+      description:
+        'Add a recommended place to the user\'s Compass app. Call this for EACH specific place you recommend after verifying it with goplaces. The place appears in the user\'s Compass immediately for triage.',
+      parameters: Type.Object({
+        userId: Type.Optional(
+          Type.String({ description: 'User ID (defaults to "john")' }),
+        ),
+        name: Type.String({ description: "Place name" }),
+        city: Type.String({ description: "City the place is in" }),
+        neighborhood: Type.Optional(
+          Type.String({ description: "Neighborhood within the city" }),
+        ),
+        category: Type.Optional(
+          Type.Union(
+            [
+              Type.Literal("restaurant"),
+              Type.Literal("bar"),
+              Type.Literal("cafe"),
+              Type.Literal("grocery"),
+              Type.Literal("gallery"),
+              Type.Literal("museum"),
+              Type.Literal("theatre"),
+              Type.Literal("music-venue"),
+              Type.Literal("hotel"),
+              Type.Literal("experience"),
+              Type.Literal("shop"),
+              Type.Literal("park"),
+              Type.Literal("architecture"),
+              Type.Literal("development"),
+              Type.Literal("accommodation"),
+              Type.Literal("neighbourhood"),
+            ],
+            { description: "Place category" },
+          ),
+        ),
+        why: Type.String({
+          description: "Why this place is worth visiting — a compelling one-liner",
+        }),
+        place_id: Type.Optional(
+          Type.String({ description: "Google Place ID from goplaces lookup" }),
+        ),
+        rating: Type.Optional(
+          Type.Number({ description: "Rating from Google Places (e.g. 4.5)" }),
+        ),
+        address: Type.Optional(Type.String({ description: "Full address" })),
+        contextKey: Type.Optional(
+          Type.String({
+            description:
+              "Context key, e.g. trip:vancouver-april-2026, outing:saturday-afternoon",
+          }),
+        ),
+      }),
+      async execute(_id, params) {
+        const userId = params.userId || "john";
+        const discoveryId = `disco_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+        const discovery = {
+          id: discoveryId,
+          place_id: params.place_id,
+          name: params.name,
+          address: params.address,
+          city: params.city,
+          type: params.category || "restaurant",
+          rating: params.rating,
+          contextKey: params.contextKey || "",
+          source: "openclaw:concierge",
+          discoveredAt: new Date().toISOString(),
+          placeIdStatus: params.place_id ? "verified" : "missing",
+        };
+
+        const result = await compassApi(COMPASS_URL, COMPASS_KEY, "/api/internal/discoveries", {
+          userId,
+          discoveries: [discovery],
+        });
+
+        if (!result.ok) {
+          return {
+            content: [{ type: "text" as const, text: `❌ Failed to add "${params.name}" to Compass: ${result.error}` }],
+          };
+        }
+
+        const compassUrl = params.place_id
+          ? `https://compass-v2-lake.vercel.app/placecards/${params.place_id}`
+          : null;
+        const mapsUrl = params.place_id
+          ? `https://www.google.com/maps/place/?q=place_id:${params.place_id}`
+          : params.address
+            ? `https://www.google.com/maps/search/${encodeURIComponent(params.name + " " + params.city)}`
+            : null;
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `✅ Added "${params.name}" to Compass!\nCompass: ${compassUrl || "pending"}\nMaps: ${mapsUrl || "pending"}`,
+            },
+          ],
+        };
+      },
+    });
+
+    // ────────────────────────────────────────────
+    // 2. compass_save_discovery
+    // ────────────────────────────────────────────
+    api.registerTool({
+      name: "compass_save_discovery",
+      description:
+        'Save a specific place AND mark it as saved in triage. Use when the user explicitly says "save that", "add X to my Boston trip", etc.',
+      parameters: Type.Object({
+        userId: Type.Optional(
+          Type.String({ description: 'User ID (defaults to "john")' }),
+        ),
+        name: Type.String({ description: "Place name" }),
+        contextKey: Type.String({
+          description: "Which context to save to, e.g. trip:boston-august-2026",
+        }),
+        city: Type.String({ description: "City the place is in" }),
+        type: Type.Optional(
+          Type.Union(
+            [
+              Type.Literal("restaurant"),
+              Type.Literal("bar"),
+              Type.Literal("cafe"),
+              Type.Literal("grocery"),
+              Type.Literal("gallery"),
+              Type.Literal("museum"),
+              Type.Literal("theatre"),
+              Type.Literal("music-venue"),
+              Type.Literal("hotel"),
+              Type.Literal("experience"),
+              Type.Literal("shop"),
+              Type.Literal("park"),
+              Type.Literal("architecture"),
+              Type.Literal("development"),
+              Type.Literal("accommodation"),
+              Type.Literal("neighbourhood"),
+            ],
+            { description: "Place type" },
+          ),
+        ),
+        address: Type.Optional(Type.String({ description: "Full address" })),
+        place_id: Type.Optional(
+          Type.String({ description: "Google Place ID" }),
+        ),
+        rating: Type.Optional(Type.Number({ description: "Rating (e.g. 4.5)" })),
+        summary: Type.Optional(
+          Type.String({ description: "Short reason for saving" }),
+        ),
+      }),
+      async execute(_id, params) {
+        const userId = params.userId || "john";
+        const discoveryId = `disco_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+        // Step 1: Add as discovery
+        const discovery = {
+          id: discoveryId,
+          place_id: params.place_id,
+          name: params.name,
+          address: params.address,
+          city: params.city,
+          type: params.type || "restaurant",
+          rating: params.rating,
+          contextKey: params.contextKey,
+          source: "openclaw:concierge:save",
+          discoveredAt: new Date().toISOString(),
+          placeIdStatus: params.place_id ? "verified" : "missing",
+        };
+
+        const addResult = await compassApi(COMPASS_URL, COMPASS_KEY, "/api/internal/discoveries", {
+          userId,
+          discoveries: [discovery],
+        });
+
+        if (!addResult.ok) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `❌ Failed to save "${params.name}": ${addResult.error}`,
+              },
+            ],
+          };
+        }
+
+        // Step 2: Set triage state to "saved" via the internal triage API
+        const triageResult = await compassApi(COMPASS_URL, COMPASS_KEY, "/api/internal/triage", {
+          userId,
+          discoveryId,
+          contextKey: params.contextKey,
+          state: "saved",
+          name: params.name,
+          city: params.city,
+          type: params.type || "restaurant",
+        });
+
+        // Triage update is best-effort — the discovery is already saved
+        const triageNote = triageResult.ok
+          ? " (triage: saved ✓)"
+          : " (discovery added, triage update pending)";
+
+        const compassUrl = params.place_id
+          ? `https://compass-v2-lake.vercel.app/placecards/${params.place_id}`
+          : null;
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `✅ Saved "${params.name}" to ${params.contextKey}${triageNote}${compassUrl ? `\n${compassUrl}` : ""}`,
+            },
+          ],
+        };
+      },
+    });
+
+    // ────────────────────────────────────────────
+    // 3. compass_update_trip
+    // ────────────────────────────────────────────
+    api.registerTool({
+      name: "compass_update_trip",
+      description:
+        'Update trip details in the user\'s manifest. Use when they share dates, accommodation, focus areas.',
+      parameters: Type.Object({
+        userId: Type.Optional(
+          Type.String({ description: 'User ID (defaults to "john")' }),
+        ),
+        contextKey: Type.String({
+          description: "Context key to update, e.g. trip:boston-august-2026",
+        }),
+        dates: Type.Optional(
+          Type.String({ description: 'Trip dates, e.g. "August 15–18, 2026"' }),
+        ),
+        city: Type.Optional(
+          Type.String({ description: "City for the trip" }),
+        ),
+        label: Type.Optional(
+          Type.String({ description: "New label/name for the context" }),
+        ),
+        emoji: Type.Optional(
+          Type.String({ description: "Emoji for the context" }),
+        ),
+        focus: Type.Optional(
+          Type.Array(Type.String(), {
+            description: 'Focus areas e.g. ["food", "history", "architecture"]',
+          }),
+        ),
+        accommodationName: Type.Optional(
+          Type.String({ description: "Hotel or accommodation name" }),
+        ),
+        accommodationAddress: Type.Optional(
+          Type.String({ description: "Hotel address" }),
+        ),
+        notes: Type.Optional(
+          Type.String({ description: "Any other trip notes" }),
+        ),
+      }),
+      async execute(_id, params) {
+        const userId = params.userId || "john";
+
+        const result = await compassApi(
+          COMPASS_URL,
+          COMPASS_KEY,
+          "/api/internal/context",
+          {
+            action: "update",
+            userId,
+            contextKey: params.contextKey,
+            updates: {
+              ...(params.dates && { dates: params.dates }),
+              ...(params.city && { city: params.city }),
+              ...(params.label && { label: params.label }),
+              ...(params.emoji && { emoji: params.emoji }),
+              ...(params.focus && { focus: params.focus }),
+              ...(params.accommodationName && { accommodationName: params.accommodationName }),
+              ...(params.accommodationAddress && { accommodationAddress: params.accommodationAddress }),
+              ...(params.notes && { notes: params.notes }),
+            },
+          },
+        );
+
+        if (!result.ok) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `❌ Failed to update "${params.contextKey}": ${result.error}`,
+              },
+            ],
+          };
+        }
+
+        const changes: string[] = [];
+        if (params.dates) changes.push(`dates → ${params.dates}`);
+        if (params.city) changes.push(`city → ${params.city}`);
+        if (params.label) changes.push(`label → ${params.label}`);
+        if (params.focus) changes.push(`focus → ${params.focus.join(", ")}`);
+        if (params.accommodationName) changes.push(`accommodation → ${params.accommodationName}`);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `✅ Updated ${params.contextKey}: ${changes.join(", ") || "no changes"}`,
+            },
+          ],
+        };
+      },
+    });
+
+    // ────────────────────────────────────────────
+    // 4. compass_create_context
+    // ────────────────────────────────────────────
+    api.registerTool({
+      name: "compass_create_context",
+      description:
+        'Create a new trip, outing, or radar context. Use when the user says "I\'m planning a trip to Boston" or "set up a NYC radar".',
+      parameters: Type.Object({
+        userId: Type.Optional(
+          Type.String({ description: 'User ID (defaults to "john")' }),
+        ),
+        type: Type.Union(
+          [
+            Type.Literal("trip"),
+            Type.Literal("outing"),
+            Type.Literal("radar"),
+          ],
+          {
+            description:
+              "Context type: trip (multi-day), outing (single day), radar (ongoing city monitor)",
+          },
+        ),
+        label: Type.String({
+          description: 'Human-readable name, e.g. "Boston August 2026"',
+        }),
+        emoji: Type.Optional(
+          Type.String({ description: "Emoji for the context" }),
+        ),
+        city: Type.Optional(
+          Type.String({ description: "City for the context" }),
+        ),
+        dates: Type.Optional(
+          Type.String({ description: 'Dates, e.g. "August 15–18, 2026"' }),
+        ),
+        focus: Type.Optional(
+          Type.Array(Type.String(), {
+            description: 'Focus areas e.g. ["food", "architecture", "jazz"]',
+          }),
+        ),
+        setActive: Type.Optional(
+          Type.Boolean({
+            description: "Whether to mark this context active (default: true)",
+          }),
+        ),
+      }),
+      async execute(_id, params) {
+        const userId = params.userId || "john";
+
+        // Build slug from label
+        const slug = params.label
+          .toLowerCase()
+          .replace(/[^a-z0-9\s-]/g, "")
+          .trim()
+          .replace(/\s+/g, "-")
+          .slice(0, 40);
+        const key = `${params.type}:${slug}`;
+
+        const result = await compassApi(
+          COMPASS_URL,
+          COMPASS_KEY,
+          "/api/internal/context",
+          {
+            action: "create",
+            userId,
+            context: {
+              key,
+              label: params.label,
+              emoji: params.emoji || defaultEmoji(params.type, params.city),
+              type: params.type,
+              city: params.city,
+              dates: params.dates,
+              focus: params.focus || [],
+              active: params.setActive !== false,
+            },
+          },
+        );
+
+        if (!result.ok) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `❌ Failed to create context: ${result.error}`,
+              },
+            ],
+          };
+        }
+
+        const details: string[] = [];
+        if (params.city) details.push(params.city);
+        if (params.dates) details.push(params.dates);
+        if (params.focus?.length) details.push(`focus: ${params.focus.join(", ")}`);
+
+        const emoji = params.emoji || defaultEmoji(params.type, params.city);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `✅ Created ${emoji} ${params.label} (${key})${details.length ? " — " + details.join(", ") : ""}`,
+            },
+          ],
+        };
+      },
+    });
+  },
+});
+
+// --- Helper: default emoji for context type ---
+
+function defaultEmoji(type: string, city?: string): string {
+  if (type === "radar") return "📡";
+  if (type === "outing") return "🎭";
+  const c = city?.toLowerCase() || "";
+  if (c.includes("boston")) return "🦞";
+  if (c.includes("nyc") || c.includes("new york")) return "🗽";
+  if (c.includes("toronto")) return "🍁";
+  if (c.includes("london")) return "🎡";
+  if (c.includes("paris")) return "🗼";
+  if (c.includes("tokyo")) return "🗾";
+  if (c.includes("vancouver")) return "🏔️";
+  if (c.includes("barcelona")) return "🏗️";
+  if (c.includes("rome") || c.includes("roma")) return "🏛️";
+  if (c.includes("istanbul")) return "🕌";
+  return "✈️";
+}

--- a/openclaw/plugins/compass-tools/openclaw.plugin.json
+++ b/openclaw/plugins/compass-tools/openclaw.plugin.json
@@ -1,0 +1,19 @@
+{
+  "id": "compass-tools",
+  "name": "Compass Concierge Tools",
+  "description": "Provides Compass-specific tools for the Concierge agent: add discoveries, save places, update trips, and create contexts via the Compass internal API.",
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "compassApiUrl": {
+        "type": "string",
+        "description": "Base URL of the Compass app (e.g. https://compass-v2-lake.vercel.app)"
+      },
+      "compassApiKey": {
+        "type": "string",
+        "description": "Internal API key for authenticating with Compass endpoints"
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/openclaw/plugins/compass-tools/package.json
+++ b/openclaw/plugins/compass-tools/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@compass/openclaw-tools",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "OpenClaw plugin providing Compass Concierge tools for writing discoveries, managing trips, and handling user data via the Compass internal API.",
+  "openclaw": {
+    "extensions": ["./index.ts"]
+  }
+}


### PR DESCRIPTION
## Addresses issue #192

### What this does

Configures the OpenClaw Concierge agent to serve as the Compass Concierge, with a custom personality, Compass-specific tools, and internal API endpoints for writing data back to the Compass app.

### Changes

**Concierge Agent Configuration** (`openclaw/concierge/`)
- `SOUL.md` — Full Concierge personality: warm travel companion, recommendation workflow, write-back workflow, link formats, onboarding instructions
- `IDENTITY.md` — Agent identity (name, emoji, vibe)

**Compass Tools Plugin** (`openclaw/plugins/compass-tools/`)
- OpenClaw plugin registering 4 Compass-specific tools:
  - `compass_add_discovery` — Push verified places to user's Compass (replaces `add_to_compass`)
  - `compass_save_discovery` — Save + mark triage state (replaces `save_discovery`)
  - `compass_update_trip` — Update trip dates/accommodation/focus (replaces `update_trip`)
  - `compass_create_context` — Create new trips/outings/radars (replaces `create_context`)
- Built-in OpenClaw tools replace the other 2: `web_search` and `goplaces` (Google Places)

**Internal API Endpoints**
- `POST /api/internal/context` — Create/update contexts in user's manifest (API-key auth)
- `POST /api/internal/triage` — Set triage state for discoveries (API-key auth)

**User Context Integration** (`app/_lib/chat/openclaw-context.ts`)
- `buildUserContextBlock()` — Builds user context string for system prompt injection
- `getSessionKey()` — Generates per-user session keys (`compass:user:{userId}`)

**Documentation** (`openclaw/CONCIERGE-SETUP.md`)
- Full setup guide: architecture, plugin installation, session isolation, context injection, migration path

### Per-user session isolation
Session key format: `compass:user:{userId}` — each Compass user gets their own persistent OpenClaw session with conversation history.

### Architecture
```
Compass App → OpenClaw Gateway → Concierge Agent
                                    ├── SOUL.md personality
                                    ├── web_search + goplaces (built-in)
                                    ├── compass_* tools (plugin)
                                    │     └── calls Compass internal API
                                    └── per-user sessions
```

### Decision: Option B — Plugin calls Compass internal API
The tools are implemented as an OpenClaw plugin that calls Compass's internal API endpoints (`/api/internal/discoveries`, `/api/internal/context`, `/api/internal/triage`). This keeps the Compass app as the single source of truth for user data while giving the OpenClaw agent full write-back capability.