### PR TITLE
feat: add streaming support for real-time chat responses (#194)

### DIFF
--- a/app/_components/ChatWidget.tsx
+++ b/app/_components/ChatWidget.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect, useMemo } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import type { ChatMessage } from '../_lib/types';
 
 /**
@@ -9,7 +9,6 @@ import type { ChatMessage } from '../_lib/types';
  */
 function renderMarkdown(text: string): string {
   let html = text
-    // Escape HTML
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
@@ -17,13 +16,13 @@ function renderMarkdown(text: string): string {
     .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
     // Bare URLs
     .replace(/(^|[\s(])(https?:\/\/[^\s)<]+)/g, '$1<a href="$2" target="_blank" rel="noopener noreferrer">$2</a>')
-    // Bold: **text** or __text__
+    // Bold
     .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
     .replace(/__([^_]+)__/g, '<strong>$1</strong>')
-    // Italic: *text* or _text_
+    // Italic
     .replace(/\*([^*]+)\*/g, '<em>$1</em>')
     .replace(/_([^_]+)_/g, '<em>$1</em>')
-    // Inline code: `text`
+    // Inline code
     .replace(/`([^`]+)`/g, '<code>$1</code>')
     // Line breaks
     .replace(/\n/g, '<br/>');
@@ -31,14 +30,28 @@ function renderMarkdown(text: string): string {
   return html;
 }
 
+/** Friendly labels for tool calls */
+const TOOL_LABELS: Record<string, string> = {
+  'web-search': '🔍 Searching the web…',
+  'lookup-place': '📍 Looking up a place…',
+  'save-discovery': '💾 Saving discovery…',
+  'add-to-compass': '🧭 Adding to your Compass…',
+  'update-trip': '✈️ Updating trip…',
+  'create-context': '📋 Creating context…',
+};
+
 export default function ChatWidget() {
   const [isOpen, setIsOpen] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
+  const [streaming, setStreaming] = useState(false);
+  const [streamContent, setStreamContent] = useState('');
+  const [toolStatus, setToolStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   // Load chat history on first open
   useEffect(() => {
@@ -47,10 +60,10 @@ export default function ChatWidget() {
     }
   }, [isOpen]);
 
-  // Auto-scroll to bottom on new messages
+  // Auto-scroll to bottom on new messages or stream updates
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
+  }, [messages, streamContent, toolStatus]);
 
   // Focus input when opening
   useEffect(() => {
@@ -73,13 +86,67 @@ export default function ChatWidget() {
     }
   }
 
+  /**
+   * Process an SSE stream from the chat API.
+   */
+  const processStream = useCallback(async (response: Response) => {
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('No response body');
+
+    const decoder = new TextDecoder();
+    let accumulated = '';
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Process complete SSE lines
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || ''; // keep incomplete line in buffer
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.slice(6).trim();
+          if (data === '[DONE]') continue;
+
+          try {
+            const parsed = JSON.parse(data);
+
+            if (parsed.content) {
+              accumulated += parsed.content;
+              setStreamContent(accumulated);
+              setToolStatus(null); // clear tool status when content starts flowing
+            }
+
+            if (parsed.tool) {
+              const label = TOOL_LABELS[parsed.tool] || `⚙️ Using ${parsed.tool}…`;
+              setToolStatus(label);
+            }
+          } catch {
+            // skip non-JSON lines
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    return accumulated;
+  }, []);
+
   async function handleSend(e: React.FormEvent) {
     e.preventDefault();
     const trimmed = input.trim();
-    if (!trimmed || loading) return;
+    if (!trimmed || loading || streaming) return;
 
     setError(null);
     setLoading(true);
+    setStreamContent('');
+    setToolStatus(null);
 
     // Add user message immediately
     const userMessage: ChatMessage = {
@@ -90,6 +157,9 @@ export default function ChatWidget() {
     setMessages((prev) => [...prev, userMessage]);
     setInput('');
 
+    // Create abort controller for this request
+    abortRef.current = new AbortController();
+
     try {
       const res = await fetch('/api/chat', {
         method: 'POST',
@@ -98,26 +168,59 @@ export default function ChatWidget() {
           message: trimmed,
           history: messages,
         }),
+        signal: abortRef.current.signal,
       });
 
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
       }
 
-      const data = await res.json();
+      const contentType = res.headers.get('content-type') || '';
 
-      // Add assistant response
-      const assistantMessage: ChatMessage = {
-        role: 'assistant',
-        content: data.reply,
-        timestamp: new Date().toISOString(),
-      };
-      setMessages((prev) => [...prev, assistantMessage]);
+      if (contentType.includes('text/event-stream')) {
+        // Streaming response
+        setLoading(false);
+        setStreaming(true);
+
+        const fullReply = await processStream(res);
+
+        // Add completed message to history
+        if (fullReply) {
+          const assistantMessage: ChatMessage = {
+            role: 'assistant',
+            content: fullReply,
+            timestamp: new Date().toISOString(),
+          };
+          setMessages((prev) => [...prev, assistantMessage]);
+        }
+
+        setStreamContent('');
+        setStreaming(false);
+        setToolStatus(null);
+      } else {
+        // Non-streaming JSON response (fallback)
+        const data = await res.json();
+        const assistantMessage: ChatMessage = {
+          role: 'assistant',
+          content: data.reply,
+          timestamp: new Date().toISOString(),
+        };
+        setMessages((prev) => [...prev, assistantMessage]);
+        setLoading(false);
+      }
     } catch (e) {
-      console.error('[chat] Send failed:', e);
-      setError('Failed to send. Try again?');
-    } finally {
+      if (e instanceof Error && e.name === 'AbortError') {
+        // User cancelled — no error
+      } else {
+        console.error('[chat] Send failed:', e);
+        setError('Failed to send. Try again?');
+      }
       setLoading(false);
+      setStreaming(false);
+      setStreamContent('');
+      setToolStatus(null);
+    } finally {
+      abortRef.current = null;
     }
   }
 
@@ -145,7 +248,7 @@ export default function ChatWidget() {
           </div>
 
           <div className="chat-messages">
-            {messages.length === 0 && !loading && (
+            {messages.length === 0 && !loading && !streaming && (
               <div className="chat-empty">
                 <p>Hey! I&apos;m your Compass Concierge.</p>
                 <p>Ask me about restaurants, places to visit, or help planning your next trip.</p>
@@ -168,6 +271,27 @@ export default function ChatWidget() {
               </div>
             ))}
 
+            {/* Streaming response in progress */}
+            {streaming && streamContent && (
+              <div className="chat-message chat-message-assistant">
+                <div
+                  className="chat-message-content"
+                  dangerouslySetInnerHTML={{ __html: renderMarkdown(streamContent) }}
+                />
+                <span className="chat-stream-cursor" />
+              </div>
+            )}
+
+            {/* Tool-use indicator */}
+            {toolStatus && (
+              <div className="chat-message chat-message-assistant">
+                <div className="chat-message-content chat-tool-status">
+                  {toolStatus}
+                </div>
+              </div>
+            )}
+
+            {/* Initial loading dots (before first token) */}
             {loading && (
               <div className="chat-message chat-message-assistant">
                 <div className="chat-message-content chat-loading">
@@ -193,12 +317,12 @@ export default function ChatWidget() {
               placeholder="Ask me anything..."
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              disabled={loading}
+              disabled={loading || streaming}
             />
             <button
               type="submit"
               className="chat-send"
-              disabled={loading || !input.trim()}
+              disabled={loading || streaming || !input.trim()}
             >
               ➤
             </button>

--- a/app/_lib/chat/user-context.ts
+++ b/app/_lib/chat/user-context.ts
@@ -1,0 +1,78 @@
+/**
+ * Build a user-context system message for the OpenClaw Concierge agent.
+ *
+ * This replaces the old monolithic system prompt — the Concierge agent's
+ * personality and tool definitions now live in OpenClaw's agent config.
+ * We only need to inject who the user is, their preferences, and active contexts
+ * so the agent can personalize its responses.
+ */
+
+import type { UserPreferences, UserManifest, Context } from '../types';
+
+interface UserLike {
+  id: string;
+  code: string;
+  city?: string;
+  name?: string;
+}
+
+interface ProfileLike {
+  city?: string;
+  name?: string;
+}
+
+interface RecentDiscovery {
+  name: string;
+  type: string;
+  city: string;
+}
+
+export function buildUserContext(
+  user: UserLike,
+  profile: ProfileLike | null,
+  preferences: UserPreferences | null,
+  manifest: UserManifest | null,
+  recentDiscoveries: RecentDiscovery[],
+): string {
+  const parts: string[] = [];
+
+  // User identity
+  const city = profile?.city || user.city || 'unknown';
+  const name = profile?.name || user.name || user.code;
+  parts.push(`## User\nName: ${name}\nCode: ${user.code}\nHome city: ${city}`);
+
+  // Preferences (Layer 1)
+  if (preferences) {
+    const prefLines: string[] = [];
+    if (preferences.interests?.length) prefLines.push(`Interests: ${preferences.interests.join(', ')}`);
+    if (preferences.cuisines?.length) prefLines.push(`Cuisines: ${preferences.cuisines.join(', ')}`);
+    if (preferences.vibes?.length) prefLines.push(`Vibes: ${preferences.vibes.join(', ')}`);
+    if (preferences.avoidances?.length) prefLines.push(`Avoids: ${preferences.avoidances.join(', ')}`);
+    if (prefLines.length > 0) {
+      parts.push(`## Preferences\n${prefLines.join('\n')}`);
+    }
+  }
+
+  // Active contexts (trips, outings, radars)
+  const activeContexts = manifest?.contexts?.filter((c: Context) => c.active) || [];
+  if (activeContexts.length > 0) {
+    const ctxLines = activeContexts.map((ctx: Context) => {
+      const dates = ctx.dates ? ` (${ctx.dates})` : '';
+      const focus = ctx.focus?.length ? ` — Focus: ${ctx.focus.join(', ')}` : '';
+      return `- ${ctx.emoji || '📍'} ${ctx.label}${dates}${focus}  [key: ${ctx.key}]`;
+    });
+    parts.push(`## Active Contexts\n${ctxLines.join('\n')}`);
+  } else {
+    parts.push(`## Contexts\nNo active trips, outings, or radars.`);
+  }
+
+  // Recent discoveries
+  if (recentDiscoveries.length > 0) {
+    const discLines = recentDiscoveries.map(
+      (d) => `- ${d.name} (${d.type}) — ${d.city}`,
+    );
+    parts.push(`## Recent Discoveries\n${discLines.join('\n')}`);
+  }
+
+  return parts.join('\n\n');
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,21 +1,116 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getCurrentUser } from '../../_lib/user';
 import { getUserProfile, getUserPreferences, getUserManifest, getUserDiscoveries } from '../../_lib/user-data';
-import { sendChatMessage } from '../../_lib/chat/anthropic-client';
 import { persistChatData, getChatHistory } from '../../_lib/chat/persistence';
-import type { ChatMessage, UserPreferences, UserManifest, Discovery } from '../../_lib/types';
+import { buildUserContext } from '../../_lib/chat/user-context';
+import { sendChatMessage as sendAnthropicFallback } from '../../_lib/chat/anthropic-client';
+import type { ChatMessage, Discovery } from '../../_lib/types';
 
-interface ChatContext {
-  userCode: string;
-  userCity: string;
-  preferences: UserPreferences | null;
-  manifest: UserManifest | null;
-  recentDiscoveries: Array<{ name: string; type: string; city: string }>;
+const OPENCLAW_TIMEOUT_MS = 90_000; // longer timeout for streaming — tool calls can take time
+
+interface OpenClawMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+/**
+ * Stream chat completions from the OpenClaw Gateway via SSE.
+ * Returns a ReadableStream or null if gateway is unavailable.
+ */
+async function streamOpenClaw(
+  messages: OpenClawMessage[],
+  userId: string,
+): Promise<Response | null> {
+  const gatewayUrl = process.env.OPENCLAW_GATEWAY_URL;
+  const gatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+
+  if (!gatewayUrl || !gatewayToken) return null;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), OPENCLAW_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(`${gatewayUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${gatewayToken}`,
+        'x-openclaw-agent-id': 'concierge',
+        'x-openclaw-scopes': 'operator.read,operator.write',
+        'x-openclaw-session-key': `compass:user:${userId}`,
+      },
+      body: JSON.stringify({
+        model: 'openclaw/concierge',
+        messages,
+        stream: true,
+      }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    if (!res.ok) {
+      console.error('[chat/openclaw] Gateway error:', res.status, await res.text().catch(() => ''));
+      return null;
+    }
+
+    return res;
+  } catch (err: unknown) {
+    clearTimeout(timeout);
+    if (err instanceof Error && err.name === 'AbortError') {
+      console.warn('[chat/openclaw] Gateway timeout after', OPENCLAW_TIMEOUT_MS, 'ms');
+    } else {
+      console.error('[chat/openclaw] Gateway unreachable:', err instanceof Error ? err.message : err);
+    }
+    return null;
+  }
+}
+
+/**
+ * Non-streaming OpenClaw fallback (used if stream: true isn't supported).
+ */
+async function callOpenClawSync(
+  messages: OpenClawMessage[],
+  userId: string,
+): Promise<string | null> {
+  const gatewayUrl = process.env.OPENCLAW_GATEWAY_URL;
+  const gatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+
+  if (!gatewayUrl || !gatewayToken) return null;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30_000);
+
+  try {
+    const res = await fetch(`${gatewayUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${gatewayToken}`,
+        'x-openclaw-agent-id': 'concierge',
+        'x-openclaw-scopes': 'operator.read,operator.write',
+        'x-openclaw-session-key': `compass:user:${userId}`,
+      },
+      body: JSON.stringify({
+        model: 'openclaw/concierge',
+        messages,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) return null;
+
+    const data = await res.json();
+    return data?.choices?.[0]?.message?.content ?? null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export async function POST(request: NextRequest) {
   try {
-    // Get current user from cookie
     const user = await getCurrentUser();
     if (!user) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
@@ -27,42 +122,136 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'message is required' }, { status: 400 });
     }
 
-    // Load user data from blob
-    const profile = await getUserProfile(user.id);
-    const preferences = await getUserPreferences(user.id);
-    const manifest = await getUserManifest(user.id);
-    const discoveries = await getUserDiscoveries(user.id);
+    // Load user data in parallel
+    const [profile, preferences, manifest, discoveries] = await Promise.all([
+      getUserProfile(user.id),
+      getUserPreferences(user.id),
+      getUserManifest(user.id),
+      getUserDiscoveries(user.id),
+    ]);
 
-    // Build chat context for system prompt
     const recentDiscoveries = (discoveries?.discoveries || [])
-      .sort((a, b) => new Date(b.discoveredAt).getTime() - new Date(a.discoveredAt).getTime())
+      .sort((a: Discovery, b: Discovery) => new Date(b.discoveredAt).getTime() - new Date(a.discoveredAt).getTime())
       .slice(0, 5)
       .map((d: Discovery) => ({ name: d.name, type: d.type, city: d.city }));
 
-    const context: ChatContext = {
-      userCode: user.code,
-      userCity: profile?.city || user.city || '',
-      preferences,
-      manifest,
-      recentDiscoveries,
-    };
+    const history: ChatMessage[] = clientHistory || (await getChatHistory(user.id));
 
-    // Get chat history from blob if not provided by client
-    const history = clientHistory || (await getChatHistory(user.id));
+    // Cap history at last 20 messages, truncate long content
+    const MAX_CONTENT = 2000;
+    const trimmedHistory: OpenClawMessage[] = (history || []).slice(-20).map((msg: ChatMessage) => ({
+      role: (msg.role === 'user' ? 'user' : 'assistant') as 'user' | 'assistant',
+      content:
+        typeof msg.content === 'string' && msg.content.length > MAX_CONTENT
+          ? msg.content.slice(0, MAX_CONTENT) + '…'
+          : msg.content,
+    }));
 
-    // Send message to Claude
-    const { reply, messageId } = await sendChatMessage(
-      {
-        message,
-        userId: user.id,
+    const systemContent = buildUserContext(user, profile, preferences, manifest, recentDiscoveries);
+
+    const openclawMessages: OpenClawMessage[] = [
+      { role: 'system', content: systemContent },
+      ...trimmedHistory,
+      { role: 'user', content: message },
+    ];
+
+    // Try streaming from OpenClaw Gateway
+    const streamRes = await streamOpenClaw(openclawMessages, user.id);
+
+    if (streamRes?.body) {
+      // Proxy SSE stream to the browser, collecting full text for persistence
+      const encoder = new TextEncoder();
+      const decoder = new TextDecoder();
+      let fullReply = '';
+      const messageId = `${Date.now()}-concierge`;
+
+      const readable = new ReadableStream({
+        async start(controller) {
+          const reader = streamRes.body!.getReader();
+
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+
+              const chunk = decoder.decode(value, { stream: true });
+
+              // Parse SSE lines to extract content deltas
+              const lines = chunk.split('\n');
+              for (const line of lines) {
+                if (line.startsWith('data: ')) {
+                  const data = line.slice(6).trim();
+                  if (data === '[DONE]') {
+                    // Send our own [DONE] marker
+                    controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
+                    continue;
+                  }
+
+                  try {
+                    const parsed = JSON.parse(data);
+                    const delta = parsed?.choices?.[0]?.delta;
+                    if (delta?.content) {
+                      fullReply += delta.content;
+                      // Forward the SSE event to the browser
+                      controller.enqueue(encoder.encode(`data: ${JSON.stringify({ content: delta.content, messageId })}\n\n`));
+                    }
+                    // Surface tool-use status so UI can show "searching..." etc.
+                    if (delta?.tool_calls) {
+                      const toolName = delta.tool_calls[0]?.function?.name;
+                      if (toolName) {
+                        controller.enqueue(encoder.encode(`data: ${JSON.stringify({ tool: toolName, messageId })}\n\n`));
+                      }
+                    }
+                  } catch {
+                    // Not valid JSON — skip
+                  }
+                }
+              }
+            }
+          } catch (err) {
+            console.error('[chat/stream] Stream read error:', err);
+          } finally {
+            controller.close();
+            // Persist completed chat
+            if (fullReply) {
+              persistChatData(user.id, message, fullReply, messageId, history).catch(() => {});
+            }
+          }
+        },
+      });
+
+      return new Response(readable, {
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+          'X-Message-Id': messageId,
+        },
+      });
+    }
+
+    // Fallback: try non-streaming OpenClaw, then direct Anthropic
+    console.warn('[chat] OpenClaw streaming unavailable, trying sync fallback');
+    let reply = await callOpenClawSync(openclawMessages, user.id);
+
+    if (reply === null) {
+      console.warn('[chat] OpenClaw unavailable, falling back to direct Anthropic');
+      const context = {
         userCode: user.code,
-        history,
-      },
-      context,
-    );
+        userCity: profile?.city || user.city || '',
+        preferences,
+        manifest,
+        recentDiscoveries,
+      };
+      const fallback = await sendAnthropicFallback(
+        { message, userId: user.id, userCode: user.code, history },
+        context,
+      );
+      reply = fallback.reply;
+    }
 
-    // Persist chat (fire-and-forget with timeout)
-    persistChatData(user.id, message, reply, messageId, history).catch(() => {});
+    const messageId = `${Date.now()}-concierge`;
+    persistChatData(user.id, message, reply!, messageId, history).catch(() => {});
 
     return NextResponse.json({ reply, messageId });
   } catch (err) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -992,6 +992,34 @@ a:hover {
   cursor: not-allowed;
 }
 
+/* Streaming cursor — blinking caret after streamed text */
+.chat-stream-cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background: var(--color-text-secondary, #999);
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  animation: blink-cursor 0.8s steps(2) infinite;
+}
+
+@keyframes blink-cursor {
+  0% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* Tool-use status indicator */
+.chat-tool-status {
+  font-style: italic;
+  opacity: 0.8;
+  animation: pulse-tool 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse-tool {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
+}
+
 @media (max-width: 640px) {
   .chat-panel {
     width: calc(100vw - var(--space-lg) * 2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -617,9 +617,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -635,9 +632,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -655,9 +649,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -673,9 +664,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -693,9 +681,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -711,9 +696,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -731,9 +713,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -750,9 +729,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -768,9 +744,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -794,9 +767,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -818,9 +788,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -844,9 +811,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -868,9 +832,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -894,9 +855,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -919,9 +877,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -943,9 +898,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1156,9 +1108,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1174,9 +1123,6 @@
       "integrity": "sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1194,9 +1140,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1212,9 +1155,6 @@
       "integrity": "sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1802,9 +1742,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1819,9 +1756,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1836,9 +1770,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1853,9 +1784,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1870,9 +1798,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1887,9 +1812,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1904,9 +1826,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1921,9 +1840,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
## What

Adds SSE streaming support to the Compass Concierge chat, so responses render word-by-word in real-time instead of waiting for the full response.

Addresses issue #194.

## Changes

### API Route (`app/api/chat/route.ts`)
- **Streaming via OpenClaw Gateway**: Sets `stream: true` in the chat completions request and proxies the SSE stream directly to the browser
- **SSE parsing**: Extracts content deltas from OpenAI-compatible streaming chunks, forwards them as simplified `{content, messageId}` events
- **Tool-use visibility**: Surfaces tool call names (web-search, lookup-place, etc.) as SSE events so the UI can show status indicators
- **Persistence**: Collects the full reply text during streaming for chat history persistence
- **Triple fallback**: Streaming OpenClaw → sync OpenClaw → direct Anthropic
- **Added `user-context.ts`**: Builds user context system message for OpenClaw (from #193 work)

### ChatWidget (`app/_components/ChatWidget.tsx`)
- **Stream processing**: Reads SSE stream with `ReadableStream` reader, accumulates content progressively
- **Live rendering**: Renders markdown as it streams in, with a blinking cursor at the insertion point
- **Tool status indicators**: Shows friendly messages like "🔍 Searching the web…" during tool-use pauses
- **Loading → streaming transition**: Typing dots shown until first token, then switches to streaming view
- **Abort support**: `AbortController` for cancellation
- **Fallback compatible**: Handles both streaming (`text/event-stream`) and non-streaming (`application/json`) responses

### CSS
- Blinking cursor animation for streaming text
- Pulsing animation for tool-use status indicators

## Testing
- TypeScript: clean `tsc --noEmit`
- Build: clean `next build`
- Smoke test: 8/8 endpoints pass