### PR TITLE
fix: derive city from Google Places data instead of LLM context

### DIFF
--- a/app/_lib/chat/system-prompt.ts
+++ b/app/_lib/chat/system-prompt.ts
@@ -28,6 +28,7 @@ CRITICAL WORKFLOW — for recommendations:
 1. When a user asks about places, SEARCH THE WEB first for current info
 2. For each specific place you want to recommend, call lookup_place to verify it exists and is operational
 3. After verifying a place is good, call add_to_compass to save it to the user's Compass app
+   IMPORTANT: Set the "city" field to the place's ACTUAL city from the lookup_place address — NOT from the active trip/outing context. A Toronto restaurant is always city="Toronto", even when the active context is a Haliburton trip.
 4. In your response, include LINKS for each place:
    - Compass link: [Place Name](https://compass-ai-agent.vercel.app/placecards/PLACE_ID) — use the place_id from lookup_place
    - Google Maps link: [📍 Map](https://www.google.com/maps/place/?q=place_id:PLACE_ID)

--- a/app/_lib/chat/tools/add-to-compass.ts
+++ b/app/_lib/chat/tools/add-to-compass.ts
@@ -5,6 +5,7 @@
 
 import { setUserData, getUserData } from '../../user-data';
 import type { Discovery, DiscoveryType, UserDiscoveries } from '../../types';
+import { resolveCity } from './resolve-city';
 
 export interface AddToCompassInput {
   name: string;
@@ -32,12 +33,15 @@ export async function addToCompass(
     // Generate unique ID for the discovery
     const discoveryId = `disco_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
+    // Derive city from actual place data, not from LLM context (fixes #187)
+    const resolvedCity = await resolveCity(input.place_id, input.address, input.city);
+
     const discovery: Discovery = {
       id: discoveryId,
       place_id: input.place_id,
       name: input.name,
       address: input.address,
-      city: input.city,
+      city: resolvedCity,
       type: input.category,
       rating: input.rating,
       contextKey: input.contextKey || '',
@@ -65,7 +69,7 @@ export async function addToCompass(
       updatedAt: new Date().toISOString(),
     });
 
-    console.log(`[add_to_compass] ✅ Added "${input.name}" (${input.city}) for user ${userId}`);
+    console.log(`[add_to_compass] ✅ Added "${input.name}" (${resolvedCity}) for user ${userId}`);
 
     // Build response URLs
     const compassUrl = input.place_id
@@ -74,7 +78,7 @@ export async function addToCompass(
     const mapsUrl = input.place_id
       ? `https://www.google.com/maps/place/?q=place_id:${input.place_id}`
       : (input.address
-        ? `https://www.google.com/maps/search/${encodeURIComponent(input.name + ' ' + input.city)}`
+        ? `https://www.google.com/maps/search/${encodeURIComponent(input.name + ' ' + resolvedCity)}`
         : null);
 
     return `✅ Added "${input.name}" to Compass! Links: compass=${compassUrl || 'pending'} maps=${mapsUrl || 'pending'}`;

--- a/app/_lib/chat/tools/resolve-city.ts
+++ b/app/_lib/chat/tools/resolve-city.ts
@@ -1,0 +1,153 @@
+/**
+ * Resolve the actual city for a place from Google Places API data.
+ *
+ * The LLM sometimes sets city from the active trip context (e.g. "Haliburton, Ontario")
+ * instead of the place's real location. This module derives the correct city from:
+ * 1. Google Places API address_components (authoritative)
+ * 2. Parsing the formatted address string (fallback)
+ * 3. Parsing the address field already on the discovery (last resort)
+ *
+ * See: https://github.com/johnely19/compass-v2/issues/187
+ */
+
+interface AddressComponent {
+  longText?: string;
+  shortText?: string;
+  types?: string[];
+}
+
+interface PlaceDetails {
+  addressComponents?: AddressComponent[];
+  formattedAddress?: string;
+}
+
+/**
+ * Extract city from Google Places address components.
+ */
+function cityFromComponents(components: AddressComponent[]): string | null {
+  // Priority: locality > sublocality > administrative_area_level_1
+  for (const type of ['locality', 'sublocality_level_1', 'sublocality', 'postal_town']) {
+    const match = components.find(c => c.types?.includes(type));
+    if (match?.longText) return match.longText;
+  }
+  // For places in boroughs (e.g. Brooklyn → New York)
+  const admin2 = components.find(c => c.types?.includes('administrative_area_level_2'));
+  if (admin2?.longText) return admin2.longText;
+  return null;
+}
+
+/**
+ * Extract state/province from address components.
+ */
+function stateFromComponents(components: AddressComponent[]): string | null {
+  const match = components.find(c => c.types?.includes('administrative_area_level_1'));
+  return match?.longText || null;
+}
+
+/**
+ * Parse city from a formatted address string.
+ * Handles formats like:
+ *   "123 Main St, Toronto, ON M5V 1A1, Canada"
+ *   "456 Broadway, New York, NY 10012, USA"
+ *   "789 Queen St W, Toronto, Ontario, Canada"
+ */
+function cityFromAddress(address: string): string | null {
+  if (!address) return null;
+
+  // Split by comma, trim
+  const parts = address.split(',').map(s => s.trim()).filter(Boolean);
+  if (parts.length < 2) return null;
+
+  // Typical format: [street, city, state/postal, country]
+  // The city is usually the second-to-last part before state+postal or the second part
+  // Strategy: skip the first part (street), look for a part that is a city name
+  // (not a postal code, not a country, not a state abbreviation)
+
+  // For North American addresses: city is typically parts[1] if 3+ parts
+  if (parts.length >= 3) {
+    const candidate = parts[parts.length - 3] || parts[1];
+    // Skip if it looks like a street address (starts with number)
+    if (candidate && !/^\d/.test(candidate)) {
+      // Clean up: remove postal codes that may be appended
+      const cleaned = candidate.replace(/\s+[A-Z]\d[A-Z]\s*\d[A-Z]\d$/i, '').trim(); // CA postal
+      return cleaned || null;
+    }
+  }
+
+  // Fallback: second part
+  if (parts.length >= 2 && !/^\d/.test(parts[1]!)) {
+    return parts[1]!;
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the real city for a place using Google Places API.
+ * Falls back to parsing the address string if API call fails.
+ *
+ * @param placeId - Google Place ID
+ * @param fallbackAddress - Address string to parse as fallback
+ * @param llmCity - City provided by the LLM (used only as last resort)
+ * @returns Resolved city string
+ */
+export async function resolveCity(
+  placeId?: string | null,
+  fallbackAddress?: string | null,
+  llmCity?: string,
+): Promise<string> {
+  // 1. Try Google Places API if we have a place_id
+  if (placeId) {
+    const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+    if (apiKey) {
+      try {
+        const url = `https://places.googleapis.com/v1/places/${placeId}`;
+        const res = await fetch(url, {
+          method: 'GET',
+          headers: {
+            'X-Goog-Api-Key': apiKey,
+            'X-Goog-FieldMask': 'addressComponents,formattedAddress',
+          },
+        });
+        if (res.ok) {
+          const data: PlaceDetails = await res.json();
+
+          // Try address components first (most reliable)
+          if (data.addressComponents?.length) {
+            const city = cityFromComponents(data.addressComponents);
+            const state = stateFromComponents(data.addressComponents);
+            if (city) {
+              const resolved = state ? `${city}, ${state}` : city;
+              console.log(`[resolve-city] place_id=${placeId} → "${resolved}" (from address_components)`);
+              return resolved;
+            }
+          }
+
+          // Try formatted address parsing
+          if (data.formattedAddress) {
+            const city = cityFromAddress(data.formattedAddress);
+            if (city) {
+              console.log(`[resolve-city] place_id=${placeId} → "${city}" (from formattedAddress)`);
+              return city;
+            }
+          }
+        }
+      } catch (e) {
+        console.warn(`[resolve-city] Places API failed for ${placeId}:`, e);
+      }
+    }
+  }
+
+  // 2. Try parsing the fallback address
+  if (fallbackAddress) {
+    const city = cityFromAddress(fallbackAddress);
+    if (city) {
+      console.log(`[resolve-city] → "${city}" (from address string)`);
+      return city;
+    }
+  }
+
+  // 3. Last resort: use LLM-provided city
+  console.log(`[resolve-city] → "${llmCity || 'unknown'}" (from LLM, no better source)`);
+  return llmCity || 'unknown';
+}

--- a/app/_lib/chat/tools/save-discovery.ts
+++ b/app/_lib/chat/tools/save-discovery.ts
@@ -7,6 +7,7 @@
 import { put, list } from '@vercel/blob';
 import { getUserData, setUserData } from '../../user-data';
 import type { Discovery, DiscoveryType, UserDiscoveries } from '../../types';
+import { resolveCity } from './resolve-city';
 
 export interface SaveDiscoveryInput {
   name: string;
@@ -57,12 +58,15 @@ export async function saveDiscovery(userId: string, input: SaveDiscoveryInput): 
   try {
     const discoveryId = `disco_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
+    // Derive city from actual place data, not from LLM context (fixes #187)
+    const resolvedCity = await resolveCity(input.place_id, input.address, input.city);
+
     const discovery: Discovery = {
       id: discoveryId,
       place_id: input.place_id,
       name: input.name,
       address: input.address,
-      city: input.city,
+      city: resolvedCity,
       type: input.type || 'restaurant',
       rating: input.rating,
       contextKey: input.contextKey,
@@ -99,7 +103,7 @@ export async function saveDiscovery(userId: string, input: SaveDiscoveryInput): 
     store[input.contextKey]!.seen![discoveryId] = {
       firstSeen: new Date().toISOString(),
       name: input.name,
-      city: input.city,
+      city: resolvedCity,
       type: input.type || 'restaurant',
     };
 


### PR DESCRIPTION
Addresses issue #187

## Problem
Disco was setting `city: "Haliburton, Ontario"` on discoveries for Toronto (and NYC/Brooklyn) restaurants because the LLM was using the active trip context city instead of the place's actual location. 87 of 269 discoveries had the wrong city.

## Changes
- **New `resolve-city.ts`** utility that derives the real city from:
  1. Google Places API `addressComponents` (locality → admin_area_level_1)
  2. Parsing `formattedAddress` string (fallback)
  3. Parsing the `address` field on the discovery (last resort)
  4. LLM-provided city only as absolute last resort
- **`add-to-compass.ts`** — calls `resolveCity()` before saving a discovery
- **`save-discovery.ts`** — calls `resolveCity()` before saving a discovery and triage entry
- **System prompt** — reinforced that city must come from `lookup_place` address, not active trip context

## Root cause
The `add_to_compass` and `save_discovery` tool implementations trusted the LLM's `city` input directly. When the active context was a Haliburton cottage trip, the LLM would set `city: "Haliburton, Ontario"` for every discovery regardless of where the place actually is.

## Test plan
- TypeScript compiles clean (`tsc --noEmit` passes)
- Smoke test: no new failures (pre-existing 404s for images/manifest)
- To verify end-to-end: create a discovery in Toronto while cottage trip is active → should get `city: "Toronto, Ontario"`, not Haliburton