### PR TITLE
fix: move triage hydration to root layout so it runs on every page

### DIFF
--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import type { Context, Discovery } from '../_lib/types';
-import { getContextCounts, hydrateFromServer } from '../_lib/triage';
+import { getContextCounts } from '../_lib/triage';
 import PlaceGrid from './PlaceGrid';
 import BriefingBanner from './BriefingBanner';
 import Twemoji from './Twemoji';
@@ -125,14 +125,7 @@ export default function HomeClient({
     return () => window.removeEventListener('triage-changed', handler);
   }, []);
 
-  // Hydrate triage from Blob on first mount — syncs cross-device state into localStorage
-  useEffect(() => {
-    hydrateFromServer(userId).then(() => {
-      // After hydration, trigger a re-render so counts reflect remote state
-      setTriageVersion((v) => v + 1);
-    }).catch(() => {/* network errors are non-fatal */});
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userId]);
+  // Triage hydration now handled by <TriageHydrator> in root layout
 
   if (contexts.length === 0) {
     return (

--- a/app/_components/TriageHydrator.tsx
+++ b/app/_components/TriageHydrator.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+import { hydrateFromServer } from '../_lib/triage';
+
+/**
+ * Hydrates triage state from Blob → localStorage on every page load.
+ * Renders nothing — just runs the side effect once per mount.
+ * Placed in root layout so it fires on ALL pages, not just Home.
+ */
+export default function TriageHydrator({ userId }: { userId: string }) {
+  useEffect(() => {
+    hydrateFromServer(userId).then(() => {
+      // Signal all listening components to re-render with fresh triage data
+      window.dispatchEvent(new CustomEvent('triage-changed', { detail: { userId } }));
+    }).catch(() => {/* network errors are non-fatal */});
+  }, [userId]);
+
+  return null;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { getCurrentUser } from "./_lib/user";
 import Nav from "./_components/Nav";
 import ChatWidget from "./_components/ChatWidget";
+import TriageHydrator from "./_components/TriageHydrator";
 import "./globals.css";
 
 import type { Viewport } from "next";
@@ -32,6 +33,7 @@ export default async function RootLayout({
           userName={user?.name}
           isOwner={user?.isOwner}
         />
+        {user && <TriageHydrator userId={user.id} />}
         {children}
         {user && <ChatWidget />}
       </body>


### PR DESCRIPTION
## Summary

Moves `hydrateFromServer()` from `HomeClient` to a new `<TriageHydrator>` component in the root layout, so triage state is synced from Blob → localStorage on **every** page load — not just the home page.

### Changes
- **New:** `app/_components/TriageHydrator.tsx` — lightweight client component that calls `hydrateFromServer()` on mount and dispatches `triage-changed` event when done
- **Modified:** `app/layout.tsx` — renders `<TriageHydrator>` for authenticated users
- **Modified:** `app/_components/HomeClient.tsx` — removed hydration logic (now handled by layout)

### What this fixes
- Server-side saves (from agents, Disco, other devices) now appear on review pages without visiting home first
- Saved tab count is correct on direct navigation to review pages
- No stale localStorage after Blob updates

Addresses issue #207