### PR TITLE
feat: Persistent bottom chat bar (#209)

### DIFF
--- a/app/_components/ChatWidget.module.css
+++ b/app/_components/ChatWidget.module.css
@@ -1,0 +1,651 @@
+/* ============================================================
+   ChatWidget - Premium Bottom Bar Design
+   Telegram/Discord style persistent chat with frosted glass
+   ============================================================ */
+
+/* ---- CSS Variables for Chat ---- */
+.chat-widget {
+  --chat-z-index: 150;
+  --chat-collapsed-height: 64px;
+  --chat-border-radius: 20px;
+  --chat-transition: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ---- Container ---- */
+.chatRoot {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: var(--chat-z-index);
+  pointer-events: none;
+}
+
+.chatRoot > * {
+  pointer-events: auto;
+}
+
+/* ---- Collapsed State ---- */
+.chatCollapsed {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  padding-bottom: calc(var(--space-sm) + env(safe-area-inset-bottom, 0px));
+  background: linear-gradient(135deg, rgba(30, 30, 35, 0.95) 0%, rgba(20, 20, 25, 0.98) 100%);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow:
+    0 -4px 20px rgba(0, 0, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  cursor: pointer;
+  transition: transform var(--transition-base) var(--chat-transition),
+              box-shadow var(--transition-base) var(--chat-transition);
+}
+
+.chatCollapsed:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 -6px 24px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 0 0 1px rgba(37, 99, 235, 0.3);
+}
+
+/* Accent glow line at top */
+.chatCollapsed::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg,
+    transparent 0%,
+    rgba(37, 99, 235, 0.6) 20%,
+    rgba(37, 99, 235, 0.8) 50%,
+    rgba(37, 99, 235, 0.6) 80%,
+    transparent 100%);
+  border-radius: var(--chat-border-radius) var(--chat-border-radius) 0 0;
+}
+
+/* ---- Collapsed Input Section ---- */
+.chatCollapsedInput {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.chatCollapsedField {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 24px;
+  padding: 10px 16px;
+  color: var(--text-primary, #f3f4f6);
+  font-size: 0.9rem;
+  outline: none;
+  transition: all var(--transition-fast) var(--chat-transition);
+}
+
+.chatCollapsedField::placeholder {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.chatCollapsedField:focus {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(37, 99, 235, 0.5);
+}
+
+.chatCollapsedSend {
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: white;
+  font-size: 1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast) var(--chat-transition);
+  box-shadow: 0 2px 8px rgba(37, 99, 235, 0.3);
+}
+
+.chatCollapsedSend:hover:not(:disabled) {
+  transform: scale(1.05);
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.4);
+}
+
+.chatCollapsedSend:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ---- Last Message Preview ---- */
+.chatPreview {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  min-width: 0;
+  padding: 0 var(--space-sm);
+}
+
+.chatPreviewIcon {
+  font-size: 1.2rem;
+  flex-shrink: 0;
+}
+
+.chatPreviewText {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 180px;
+}
+
+.chatPreviewPlaceholder {
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 0.85rem;
+}
+
+/* ---- Expanded State ---- */
+.chatExpanded {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 65vh;
+  max-height: 600px;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg,
+    rgba(30, 30, 35, 0.98) 0%,
+    rgba(20, 20, 25, 0.99) 100%);
+  border-top-left-radius: var(--chat-border-radius);
+  border-top-right-radius: var(--chat-border-radius);
+  box-shadow:
+    0 -8px 40px rgba(0, 0, 0, 0.5),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  transform: translateY(0);
+  transition: transform var(--transition-base) var(--chat-transition),
+              height var(--transition-base) var(--chat-transition);
+}
+
+.chatExpanded::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg,
+    transparent 0%,
+    rgba(37, 99, 235, 0.8) 20%,
+    rgba(37, 99, 235, 1) 50%,
+    rgba(37, 99, 235, 0.8) 80%,
+    transparent 100%);
+  border-radius: var(--chat-border-radius) var(--chat-border-radius) 0 0;
+}
+
+/* ---- Drag Handle ---- */
+.chatDragHandle {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-xs) 0;
+  cursor: grab;
+}
+
+.chatDragHandleBar {
+  width: 40px;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 2px;
+  transition: background var(--transition-fast);
+}
+
+.chatDragHandle:hover .chatDragHandleBar {
+  background: rgba(255, 255, 255, 0.4);
+}
+
+/* ---- Header ---- */
+.chatHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.chatHeaderTitle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.chatHeaderIcon {
+  font-size: 1.2rem;
+}
+
+.chatHeaderText {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.chatHeaderClose {
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.9rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast) var(--chat-transition);
+}
+
+.chatHeaderClose:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: white;
+}
+
+/* ---- Messages Area ---- */
+.chatMessages {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  scroll-behavior: smooth;
+}
+
+/* Scrollbar styling */
+.chatMessages::-webkit-scrollbar {
+  width: 6px;
+}
+
+.chatMessages::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.chatMessages::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 3px;
+}
+
+.chatMessages::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+/* ---- Empty State ---- */
+.chatEmpty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: var(--space-xl);
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.chatEmptyIcon {
+  font-size: 2.5rem;
+  margin-bottom: var(--space-md);
+  opacity: 0.6;
+}
+
+.chatEmptyTitle {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.8);
+  margin-bottom: var(--space-xs);
+}
+
+.chatEmptyText {
+  font-size: 0.9rem;
+  line-height: 1.5;
+  max-width: 280px;
+}
+
+/* ---- Individual Messages ---- */
+.chatMessage {
+  display: flex;
+  flex-direction: column;
+  max-width: 85%;
+  animation: message-appear 0.2s var(--chat-transition);
+}
+
+@keyframes message-appear {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.chatMessageUser {
+  align-self: flex-end;
+  align-items: flex-end;
+}
+
+.chatMessageAssistant {
+  align-self: flex-start;
+  align-items: flex-start;
+}
+
+/* ---- Message Bubbles ---- */
+.chatBubble {
+  padding: var(--space-sm) var(--space-md);
+  border-radius: 18px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.chatBubbleUser {
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: white;
+  border-bottom-right-radius: 4px;
+  box-shadow: 0 2px 8px rgba(37, 99, 235, 0.3);
+}
+
+.chatBubbleAssistant {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.9);
+  border-bottom-left-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* ---- Message Timestamp ---- */
+.chatTimestamp {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.35);
+  margin-top: 2px;
+  padding: 0 var(--space-xs);
+}
+
+/* ---- Markdown Content Styling ---- */
+.chatMarkdown {
+  /* Ensure proper spacing for markdown elements */
+}
+
+.chatMarkdown p {
+  margin: 0;
+}
+
+.chatMarkdown p + p {
+  margin-top: var(--space-xs);
+}
+
+.chatMarkdown a {
+  color: #60a5fa;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.chatMarkdown a:hover {
+  color: #93c5fd;
+}
+
+.chatBubbleUser .chatMarkdown a {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.chatMarkdown strong {
+  font-weight: 600;
+}
+
+.chatMarkdown em {
+  font-style: italic;
+}
+
+.chatMarkdown code {
+  background: rgba(0, 0, 0, 0.2);
+  padding: 1px 4px;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+.chatMarkdown ul,
+.chatMarkdown ol {
+  margin: var(--space-xs) 0;
+  padding-left: 1.2em;
+}
+
+.chatMarkdown li {
+  margin: 2px 0;
+}
+
+/* ---- Streaming Response ---- */
+.chatStreaming {
+  display: flex;
+  flex-direction: column;
+  max-width: 85%;
+  align-self: flex-start;
+}
+
+.chatStreamCursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background: rgba(255, 255, 255, 0.7);
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  animation: cursor-blink 0.8s steps(2) infinite;
+}
+
+@keyframes cursor-blink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+/* ---- Tool Status Indicator ---- */
+.chatToolStatus {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-sm);
+  font-size: 0.8rem;
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.5);
+  animation: tool-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes tool-pulse {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 0.8; }
+}
+
+/* ---- Typing Indicator ---- */
+.chatTyping {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-sm);
+}
+
+.chatTypingDot {
+  width: 8px;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.4);
+  border-radius: 50%;
+  animation: typing-bounce 1.4s infinite ease-in-out;
+}
+
+.chatTypingDot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.chatTypingDot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes typing-bounce {
+  0%, 60%, 100% {
+    transform: translateY(0);
+    opacity: 0.4;
+  }
+  30% {
+    transform: translateY(-4px);
+    opacity: 1;
+  }
+}
+
+/* ---- Error Message ---- */
+.chatError {
+  color: #f87171;
+  font-size: 0.85rem;
+  text-align: center;
+  padding: var(--space-sm);
+  background: rgba(248, 113, 113, 0.1);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(248, 113, 113, 0.2);
+}
+
+/* ---- Input Area (Expanded) ---- */
+.chatInputArea {
+  display: flex;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  padding-bottom: calc(var(--space-sm) + env(safe-area-inset-bottom, var(--space-sm)));
+  background: rgba(0, 0, 0, 0.2);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.chatInput {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 24px;
+  padding: 12px 16px;
+  color: white;
+  font-size: 0.9rem;
+  outline: none;
+  transition: all var(--transition-fast) var(--chat-transition);
+  resize: none;
+  min-height: 44px;
+  max-height: 120px;
+}
+
+.chatInput::placeholder {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.chatInput:focus {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(37, 99, 235, 0.5);
+}
+
+.chatInput:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.chatSendBtn {
+  width: 44px;
+  height: 44px;
+  border: none;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: white;
+  font-size: 1.1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast) var(--chat-transition);
+  box-shadow: 0 2px 8px rgba(37, 99, 235, 0.3);
+  flex-shrink: 0;
+}
+
+.chatSendBtn:hover:not(:disabled) {
+  transform: scale(1.05);
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.4);
+}
+
+.chatSendBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ---- Mobile Styles ---- */
+@media (max-width: 640px) {
+  .chatExpanded {
+    height: 85vh;
+    border-radius: 16px 16px 0 0;
+  }
+
+  .chatCollapsed {
+    padding: var(--space-xs) var(--space-sm);
+    padding-bottom: calc(var(--space-xs) + env(safe-area-inset-bottom, 0px));
+  }
+
+  .chatPreviewText {
+    max-width: 140px;
+  }
+
+  .chatMessage {
+    max-width: 92%;
+  }
+
+  .chatInputArea {
+    padding: var(--space-xs) var(--space-sm);
+    padding-bottom: calc(var(--space-xs) + env(safe-area-inset-bottom, var(--space-xs)));
+    gap: var(--space-xs);
+  }
+
+  .chatSendBtn {
+    width: 40px;
+    height: 40px;
+  }
+}
+
+/* ---- Animation for auto-expand ---- */
+.chatAutoExpand {
+  animation: auto-expand-in 0.4s var(--chat-transition);
+}
+
+@keyframes auto-expand-in {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+/* ---- New message indicator ---- */
+.chatNewMessage {
+  animation: new-message-flash 0.6s var(--chat-transition);
+}
+
+@keyframes new-message-flash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0.4);
+  }
+  50% {
+    box-shadow: 0 0 0 8px rgba(37, 99, 235, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0);
+  }
+}

--- a/app/_components/ChatWidget.tsx
+++ b/app/_components/ChatWidget.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from 'react';
 import type { ChatMessage } from '../_lib/types';
+import styles from './ChatWidget.module.css';
 
 /**
  * Lightweight markdown→HTML for chat messages.
@@ -40,8 +41,33 @@ const TOOL_LABELS: Record<string, string> = {
   'create-context': '📋 Creating context…',
 };
 
+/** Format timestamp for display */
+function formatTime(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+/** Get last message preview text */
+function getLastMessagePreview(messages: ChatMessage[]): string | null {
+  if (messages.length === 0) return null;
+  const lastMsg = messages[messages.length - 1];
+  if (!lastMsg) return null;
+  const preview = lastMsg.content.substring(0, 50);
+  return preview + (lastMsg.content.length > 50 ? '...' : '');
+}
+
+/** Check if there was recent activity (within 5 minutes) */
+function hasRecentActivity(messages: ChatMessage[]): boolean {
+  if (messages.length === 0) return false;
+  const lastMsg = messages[messages.length - 1];
+  if (!lastMsg) return false;
+  const lastMsgTime = new Date(lastMsg.timestamp).getTime();
+  const now = Date.now();
+  return now - lastMsgTime < 5 * 60 * 1000;
+}
+
 export default function ChatWidget() {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -49,28 +75,125 @@ export default function ChatWidget() {
   const [streamContent, setStreamContent] = useState('');
   const [toolStatus, setToolStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const abortRef = useRef<AbortController | null>(null);
+  const [justExpanded, setJustExpanded] = useState(false);
+  const [autoExpanded, setAutoExpanded] = useState(false);
 
-  // Load chat history on first open
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const collapsedInputRef = useRef<HTMLInputElement>(null);
+  const expandedInputRef = useRef<HTMLTextAreaElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const dragStartY = useRef<number>(0);
+  const isDragging = useRef<boolean>(false);
+
+  // Load persisted state from localStorage on mount
   useEffect(() => {
-    if (isOpen && messages.length === 0) {
+    try {
+      const saved = localStorage.getItem('chat-widget-state');
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        if (parsed.isExpanded) {
+          setIsExpanded(true);
+          setJustExpanded(true);
+          setTimeout(() => setJustExpanded(false), 400);
+        }
+      }
+    } catch (e) {
+      // Ignore localStorage errors
+    }
+  }, []);
+
+  // Load chat history on first expand
+  useEffect(() => {
+    if (isExpanded && messages.length === 0) {
       loadChatHistory();
     }
-  }, [isOpen]);
+  }, [isExpanded]);
+
+  // Check for auto-expand on new messages
+  useEffect(() => {
+    if (messages.length > 0 && !isExpanded) {
+      const lastMsg = messages[messages.length - 1];
+      if (lastMsg && lastMsg.role === 'assistant') {
+        // Auto-expand on new incoming message
+        handleExpand(true);
+        setAutoExpanded(true);
+        setTimeout(() => setAutoExpanded(false), 600);
+      }
+    }
+  }, [messages]);
+
+  // Check for recent activity to auto-expand on mount
+  useEffect(() => {
+    if (messages.length > 0 && hasRecentActivity(messages) && !isExpanded) {
+      handleExpand(true);
+      setAutoExpanded(true);
+      setTimeout(() => setAutoExpanded(false), 600);
+    }
+  }, []);
 
   // Auto-scroll to bottom on new messages or stream updates
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages, streamContent, toolStatus]);
+  }, [messages, streamContent, toolStatus, isExpanded]);
 
-  // Focus input when opening
+  // Focus input when expanding
   useEffect(() => {
-    if (isOpen) {
-      inputRef.current?.focus();
+    if (isExpanded) {
+      setTimeout(() => expandedInputRef.current?.focus(), 100);
     }
-  }, [isOpen]);
+  }, [isExpanded]);
+
+  // Save state to localStorage when it changes
+  useEffect(() => {
+    try {
+      localStorage.setItem('chat-widget-state', JSON.stringify({ isExpanded }));
+    } catch (e) {
+      // Ignore localStorage errors
+    }
+  }, [isExpanded]);
+
+  function handleExpand(expanded: boolean) {
+    setIsExpanded(expanded);
+    if (expanded) {
+      setJustExpanded(true);
+      setTimeout(() => setJustExpanded(false), 400);
+    }
+  }
+
+  function handleToggle() {
+    handleExpand(!isExpanded);
+  }
+
+  function handleDragStart(e: React.MouseEvent | React.TouchEvent) {
+    isDragging.current = true;
+    if ('touches' in e && e.touches && e.touches[0]) {
+      dragStartY.current = e.touches[0].clientY;
+    } else if ('clientY' in e) {
+      dragStartY.current = e.clientY;
+    }
+  }
+
+  function handleDragMove(e: React.MouseEvent | React.TouchEvent) {
+    if (!isDragging.current) return;
+    let currentY: number;
+    if ('touches' in e && e.touches && e.touches[0]) {
+      currentY = e.touches[0].clientY;
+    } else if ('clientY' in e) {
+      currentY = e.clientY;
+    } else {
+      return;
+    }
+    const diff = currentY - dragStartY.current;
+    if (diff > 50) {
+      // Dragged down enough to collapse
+      handleExpand(false);
+      isDragging.current = false;
+    }
+  }
+
+  function handleDragEnd() {
+    isDragging.current = false;
+  }
 
   async function loadChatHistory() {
     try {
@@ -148,6 +271,11 @@ export default function ChatWidget() {
     setStreamContent('');
     setToolStatus(null);
 
+    // Expand if collapsed when sending
+    if (!isExpanded) {
+      handleExpand(true);
+    }
+
     // Add user message immediately
     const userMessage: ChatMessage = {
       role: 'user',
@@ -224,111 +352,195 @@ export default function ChatWidget() {
     }
   }
 
-  return (
-    <>
-      <button
-        className="chat-fab"
-        onClick={() => setIsOpen(!isOpen)}
-        aria-label={isOpen ? 'Close chat' : 'Open chat'}
-      >
-        {isOpen ? '✕' : '💬'}
-      </button>
+  const lastPreview = getLastMessagePreview(messages);
 
-      {isOpen && (
-        <div className="chat-panel">
-          <div className="chat-panel-header">
-            <h3>Concierge</h3>
-            <button
-              className="btn-icon btn-ghost"
-              onClick={() => setIsOpen(false)}
-              aria-label="Close chat"
-            >
-              ✕
-            </button>
+  // Render collapsed state
+  if (!isExpanded) {
+    return (
+      <div className={styles.chatRoot}>
+        <div className={styles.chatCollapsed} onClick={handleToggle}>
+          {/* Preview section */}
+          <div className={styles.chatPreview}>
+            <span className={styles.chatPreviewIcon}>💬</span>
+            {lastPreview ? (
+              <span className={styles.chatPreviewText}>{lastPreview}</span>
+            ) : (
+              <span className={styles.chatPreviewPlaceholder}>Ask me anything...</span>
+            )}
           </div>
 
-          <div className="chat-messages">
-            {messages.length === 0 && !loading && !streaming && (
-              <div className="chat-empty">
-                <p>Hey! I&apos;m your Compass Concierge.</p>
-                <p>Ask me about restaurants, places to visit, or help planning your next trip.</p>
-              </div>
-            )}
-
-            {messages.map((msg, i) => (
-              <div
-                key={i}
-                className={`chat-message chat-message-${msg.role}`}
-              >
-                {msg.role === 'assistant' ? (
-                  <div
-                    className="chat-message-content"
-                    dangerouslySetInnerHTML={{ __html: renderMarkdown(msg.content) }}
-                  />
-                ) : (
-                  <div className="chat-message-content">{msg.content}</div>
-                )}
-              </div>
-            ))}
-
-            {/* Streaming response in progress */}
-            {streaming && streamContent && (
-              <div className="chat-message chat-message-assistant">
-                <div
-                  className="chat-message-content"
-                  dangerouslySetInnerHTML={{ __html: renderMarkdown(streamContent) }}
-                />
-                <span className="chat-stream-cursor" />
-              </div>
-            )}
-
-            {/* Tool-use indicator */}
-            {toolStatus && (
-              <div className="chat-message chat-message-assistant">
-                <div className="chat-message-content chat-tool-status">
-                  {toolStatus}
-                </div>
-              </div>
-            )}
-
-            {/* Initial loading dots (before first token) */}
-            {loading && (
-              <div className="chat-message chat-message-assistant">
-                <div className="chat-message-content chat-loading">
-                  <span className="chat-typing-dot">.</span>
-                  <span className="chat-typing-dot">.</span>
-                  <span className="chat-typing-dot">.</span>
-                </div>
-              </div>
-            )}
-
-            {error && (
-              <div className="chat-error">{error}</div>
-            )}
-
-            <div ref={messagesEndRef} />
-          </div>
-
-          <form className="chat-input-form" onSubmit={handleSend}>
+          {/* Input section - handles its own clicks */}
+          <div
+            className={styles.chatCollapsedInput}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleExpand(true);
+            }}
+          >
             <input
-              ref={inputRef}
+              ref={collapsedInputRef}
               type="text"
-              className="chat-input"
-              placeholder="Ask me anything..."
+              className={styles.chatCollapsedField}
+              placeholder="Type a message..."
               value={input}
               onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSend(e as unknown as React.FormEvent);
+                }
+              }}
               disabled={loading || streaming}
             />
             <button
-              type="submit"
-              className="chat-send"
+              type="button"
+              className={styles.chatCollapsedSend}
               disabled={loading || streaming || !input.trim()}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleSend(e as unknown as React.FormEvent);
+              }}
             >
               ➤
             </button>
-          </form>
+          </div>
         </div>
-      )}
-    </>
+      </div>
+    );
+  }
+
+  // Render expanded state
+  return (
+    <div
+      className={`${styles.chatRoot} ${autoExpanded ? styles.chatAutoExpand : ''}`}
+      onMouseMove={handleDragMove}
+      onMouseUp={handleDragEnd}
+      onMouseLeave={handleDragEnd}
+      onTouchMove={handleDragMove}
+      onTouchEnd={handleDragEnd}
+    >
+      <div
+        className={`${styles.chatExpanded} ${justExpanded || autoExpanded ? styles.chatAutoExpand : ''}`}
+      >
+        {/* Drag handle */}
+        <div
+          className={styles.chatDragHandle}
+          onMouseDown={handleDragStart}
+          onTouchStart={handleDragStart}
+        >
+          <div className={styles.chatDragHandleBar} />
+        </div>
+
+        {/* Header */}
+        <div className={styles.chatHeader}>
+          <div className={styles.chatHeaderTitle}>
+            <span className={styles.chatHeaderIcon}>💬</span>
+            <span className={styles.chatHeaderText}>Concierge</span>
+          </div>
+          <button
+            className={styles.chatHeaderClose}
+            onClick={() => handleExpand(false)}
+            aria-label="Collapse chat"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Messages */}
+        <div className={styles.chatMessages}>
+          {messages.length === 0 && !loading && !streaming && (
+            <div className={styles.chatEmpty}>
+              <div className={styles.chatEmptyIcon}>🧭</div>
+              <div className={styles.chatEmptyTitle}>Hey! I&apos;m your Compass Concierge.</div>
+              <div className={styles.chatEmptyText}>
+                Ask me about restaurants, places to visit, or help planning your next trip.
+              </div>
+            </div>
+          )}
+
+          {messages.map((msg, i) => (
+            <div
+              key={i}
+              className={`${styles.chatMessage} ${
+                msg.role === 'user' ? styles.chatMessageUser : styles.chatMessageAssistant
+              }`}
+            >
+              <div
+                className={`${styles.chatBubble} ${
+                  msg.role === 'user' ? styles.chatBubbleUser : styles.chatBubbleAssistant
+                }`}
+              >
+                {msg.role === 'assistant' ? (
+                  <div
+                    className={styles.chatMarkdown}
+                    dangerouslySetInnerHTML={{ __html: renderMarkdown(msg.content) }}
+                  />
+                ) : (
+                  <div className={styles.chatMarkdown}>{msg.content}</div>
+                )}
+              </div>
+              <span className={styles.chatTimestamp}>{formatTime(msg.timestamp)}</span>
+            </div>
+          ))}
+
+          {/* Streaming response in progress */}
+          {streaming && streamContent && (
+            <div className={`${styles.chatMessage} ${styles.chatMessageAssistant}`}>
+              <div className={`${styles.chatBubble} ${styles.chatBubbleAssistant}`}>
+                <div
+                  className={styles.chatMarkdown}
+                  dangerouslySetInnerHTML={{ __html: renderMarkdown(streamContent) }}
+                />
+                <span className={styles.chatStreamCursor} />
+              </div>
+            </div>
+          )}
+
+          {/* Tool-use indicator */}
+          {toolStatus && (
+            <div className={`${styles.chatMessage} ${styles.chatMessageAssistant}`}>
+              <div className={styles.chatToolStatus}>{toolStatus}</div>
+            </div>
+          )}
+
+          {/* Initial loading dots (before first token) */}
+          {loading && (
+            <div className={`${styles.chatMessage} ${styles.chatMessageAssistant}`}>
+              <div className={styles.chatTyping}>
+                <span className={styles.chatTypingDot} />
+                <span className={styles.chatTypingDot} />
+                <span className={styles.chatTypingDot} />
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className={styles.chatError}>{error}</div>
+          )}
+
+          <div ref={messagesEndRef} />
+        </div>
+
+        {/* Input area */}
+        <form className={styles.chatInputArea} onSubmit={handleSend}>
+          <textarea
+            ref={expandedInputRef}
+            className={styles.chatInput}
+            placeholder="Ask me anything..."
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            disabled={loading || streaming}
+            rows={1}
+          />
+          <button
+            type="submit"
+            className={styles.chatSendBtn}
+            disabled={loading || streaming || !input.trim()}
+          >
+            ➤
+          </button>
+        </form>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Transforms modal chat widget into a persistent bottom bar (Telegram/Discord style)
- Collapsed state shows input field + send button + last message preview
- Expanded state slides up to ~65% viewport with full conversation thread
- Auto-expands on recent activity (within 5 minutes) or new incoming messages
- LocalStorage persistence for collapsed/expanded state across page navigation
- Premium frosted glass design with gradient backgrounds and subtle glow effects
- Drag handle for swipe-to-collapse gesture support
- Mobile optimized with 85% viewport fill and safe area insets
- Keeps all existing chat functionality (markdown rendering, message sending, history loading)

## Test plan
- [ ] Test collapsed state renders correctly above nav
- [ ] Test expanded state shows full conversation with scroll
- [ ] Test auto-expand triggers on recent activity or new messages
- [ ] Test localStorage persists state across page navigation
- [ ] Test drag handle allows collapsing chat
- [ ] Test mobile viewport filling and keyboard handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)