### PR TITLE
fix: Split image-url.ts to fix 500 errors (#212)

### DIFF
--- a/app/_lib/image-url.server.ts
+++ b/app/_lib/image-url.server.ts
@@ -1,0 +1,61 @@
+/* ============================================================
+   Server-only image utilities — uses fs, must NOT be imported
+   by client components.
+   ============================================================ */
+import 'server-only';
+import { resolveImageUrl } from './image-url';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Pre-built image index — populated at build time from manifest.json files
+let _imageIndex: Record<string, string> | null = null;
+
+function loadImageIndex(): Record<string, string> {
+  if (_imageIndex) return _imageIndex;
+  try {
+    const indexPath = path.join(process.cwd(), 'data', 'image-index.json');
+    if (fs.existsSync(indexPath)) {
+      _imageIndex = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+      return _imageIndex!;
+    }
+  } catch { /* ignore */ }
+  return {};
+}
+
+/**
+ * Get the first image URL from a place card manifest.
+ * Uses pre-built index (data/image-index.json) for reliability on Vercel.
+ * Falls back to direct manifest read.
+ */
+export function getManifestHeroImage(placeId: string): string | null {
+  // Try pre-built index first (fast, reliable on Vercel)
+  const index = loadImageIndex();
+  if (index[placeId]) return resolveImageUrl(index[placeId]);
+
+  // Fallback: direct manifest read
+  try {
+    const manifestPath = path.join(process.cwd(), 'data', 'placecards', placeId, 'manifest.json');
+    if (!fs.existsSync(manifestPath)) return null;
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    const images = manifest?.images;
+    if (!Array.isArray(images) || images.length === 0) return null;
+    const hero = images.find((i: { category?: string }) => i.category !== 'map') || images[0];
+    return resolveImageUrl(hero?.path) || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get hero image URL for a place card, trying multiple sources.
+ * Server-side only (uses fs).
+ */
+export function getHeroImage(
+  placeId: string | undefined | null,
+  heroImage?: string | null,
+): string | null {
+  const resolved = resolveImageUrl(heroImage);
+  if (resolved) return resolved;
+  if (placeId) return getManifestHeroImage(placeId);
+  return null;
+}

--- a/app/_lib/image-url.ts
+++ b/app/_lib/image-url.ts
@@ -2,12 +2,8 @@
    Compass v2 — Unified Image URL Resolution
    SINGLE source of truth for ALL image paths.
    
-   Handles:
-   - Blob URLs (https://...blob.vercel-storage.com/...)
-   - Relative place-photos (/place-photos/ChIJ.../photos/1.jpg)
-   - Relative cottage images (/cottages/the-lookout/photo_1.jpg)
-   - Manifest.json fallback (data/placecards/{id}/manifest.json)
-   - Cottage data heroImage field
+   ⚠️ This file is safe for client AND server components.
+   Server-only functions (fs-dependent) are in image-url.server.ts
    ============================================================ */
 
 const BLOB_BASE = process.env.NEXT_PUBLIC_BLOB_BASE_URL || '';
@@ -27,75 +23,6 @@ export function resolveImageUrl(path: string | undefined | null): string | null 
   if (path.startsWith('/') && BLOB_BASE) return `${BLOB_BASE}${path}`;
   if (BLOB_BASE && !path.startsWith('.')) return `${BLOB_BASE}/${path}`;
   return path;
-}
-
-/**
- * Get hero image URL for a place card, trying multiple sources.
- * Server-side only (uses fs).
- * 
- * Priority:
- * 1. Provided heroImage (already resolved)
- * 2. Manifest.json first image
- * 3. null (caller should show placeholder)
- */
-export function getHeroImage(
-  placeId: string | undefined | null,
-  heroImage?: string | null,
-): string | null {
-  // 1. Use provided heroImage if available
-  const resolved = resolveImageUrl(heroImage);
-  if (resolved) return resolved;
-
-  // 2. Try manifest
-  if (placeId) return getManifestHeroImage(placeId);
-
-  return null;
-}
-
-// Pre-built image index — populated at build time from manifest.json files
-// Avoids dynamic fs reads which may fail on Vercel serverless
-let _imageIndex: Record<string, string> | null = null;
-
-function loadImageIndex(): Record<string, string> {
-  if (_imageIndex) return _imageIndex;
-  try {
-    const fs = require('fs');
-    const pathMod = require('path');
-    const indexPath = pathMod.join(process.cwd(), 'data', 'image-index.json');
-    if (fs.existsSync(indexPath)) {
-      _imageIndex = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
-      return _imageIndex!;
-    }
-  } catch { /* ignore */ }
-  return {};
-}
-
-/**
- * Get the first image URL from a place card manifest.
- * Uses pre-built index (data/image-index.json) for reliability on Vercel.
- * Falls back to direct manifest read.
- */
-export function getManifestHeroImage(placeId: string): string | null {
-  if (typeof window !== 'undefined') return null;
-
-  // Try pre-built index first (fast, reliable on Vercel)
-  const index = loadImageIndex();
-  if (index[placeId]) return resolveImageUrl(index[placeId]);
-
-  // Fallback: direct manifest read
-  try {
-    const fs = require('fs');
-    const pathMod = require('path');
-    const manifestPath = pathMod.join(process.cwd(), 'data', 'placecards', placeId, 'manifest.json');
-    if (!fs.existsSync(manifestPath)) return null;
-    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-    const images = manifest?.images;
-    if (!Array.isArray(images) || images.length === 0) return null;
-    const hero = images.find((i: { category?: string }) => i.category !== 'map') || images[0];
-    return resolveImageUrl(hero?.path) || null;
-  } catch {
-    return null;
-  }
 }
 
 /**

--- a/app/hot/page.tsx
+++ b/app/hot/page.tsx
@@ -3,7 +3,7 @@ import path from 'path';
 import type { DiscoveryType } from '../_lib/types';
 import { ALL_TYPES } from '../_lib/discovery-types';
 import { getCurrentUser } from '../_lib/user';
-import { getManifestHeroImage } from '../_lib/image-url';
+import { getManifestHeroImage } from '../_lib/image-url.server';
 import HotClient from './HotClient';
 
 export const dynamic = 'force-dynamic';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,8 @@ import { getCurrentUser } from './_lib/user';
 import { getUserManifest, getUserDiscoveries } from './_lib/user-data';
 import type { Context, Discovery, UserManifest } from './_lib/types';
 import { isContextActive } from './_lib/context-lifecycle';
-import { resolveImageUrl, getManifestHeroImage } from './_lib/image-url';
+import { resolveImageUrl } from './_lib/image-url';
+import { getManifestHeroImage } from './_lib/image-url.server';
 import { isTypeCompatible } from './_lib/context-compat';
 import HomeClient from './_components/HomeClient';
 


### PR DESCRIPTION
## Critical Fix — Site Down

All pages returning 500 because `image-url.ts` uses `require('fs')` which Turbopack bundles into client components.

### Changes
- **`image-url.ts`** — removed `getHeroImage`, `getManifestHeroImage`, `loadImageIndex` (all fs-dependent)
- **`image-url.server.ts`** (new) — moved those functions here with `import 'server-only'` guard
- Updated imports in `page.tsx` and `hot/page.tsx`

### Build
✅ `next build` passes clean

Fixes #212