### PR TITLE
fix: split image-url.ts to prevent fs require in client bundle

### DIFF
--- a/app/_lib/image-url.server.ts
+++ b/app/_lib/image-url.server.ts
@@ -1,0 +1,77 @@
+import 'server-only';
+/* ============================================================
+   Compass v2 — Server-only Image URL helpers (fs-dependent)
+   
+   These functions use Node.js `fs` to read manifest files and
+   the image index. They must ONLY be imported from Server
+   Components or Route Handlers — never from 'use client' files.
+   ============================================================ */
+
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+import { resolveImageUrl } from './image-url';
+
+// Re-export client-safe helpers so server code can import everything from one place
+export { resolveImageUrl, resolveImageUrlClient } from './image-url';
+
+// Pre-built image index — populated at build time from manifest.json files
+let _imageIndex: Record<string, string> | null = null;
+
+function loadImageIndex(): Record<string, string> {
+  if (_imageIndex) return _imageIndex;
+  try {
+    const indexPath = path.join(process.cwd(), 'data', 'image-index.json');
+    if (existsSync(indexPath)) {
+      _imageIndex = JSON.parse(readFileSync(indexPath, 'utf8'));
+      return _imageIndex!;
+    }
+  } catch { /* ignore */ }
+  return {};
+}
+
+/**
+ * Get the first image URL from a place card manifest.
+ * Uses pre-built index (data/image-index.json) for reliability on Vercel.
+ * Falls back to direct manifest read.
+ */
+export function getManifestHeroImage(placeId: string): string | null {
+  // Try pre-built index first (fast, reliable on Vercel)
+  const index = loadImageIndex();
+  if (index[placeId]) return resolveImageUrl(index[placeId]);
+
+  // Fallback: direct manifest read
+  try {
+    const manifestPath = path.join(process.cwd(), 'data', 'placecards', placeId, 'manifest.json');
+    if (!existsSync(manifestPath)) return null;
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    const images = manifest?.images;
+    if (!Array.isArray(images) || images.length === 0) return null;
+    const hero = images.find((i: { category?: string }) => i.category !== 'map') || images[0];
+    return resolveImageUrl(hero?.path) || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get hero image URL for a place card, trying multiple sources.
+ * Server-side only (uses fs).
+ * 
+ * Priority:
+ * 1. Provided heroImage (already resolved)
+ * 2. Manifest.json first image
+ * 3. null (caller should show placeholder)
+ */
+export function getHeroImage(
+  placeId: string | undefined | null,
+  heroImage?: string | null,
+): string | null {
+  // 1. Use provided heroImage if available
+  const resolved = resolveImageUrl(heroImage);
+  if (resolved) return resolved;
+
+  // 2. Try manifest
+  if (placeId) return getManifestHeroImage(placeId);
+
+  return null;
+}

--- a/app/_lib/image-url.ts
+++ b/app/_lib/image-url.ts
@@ -1,13 +1,15 @@
 /* ============================================================
-   Compass v2 — Unified Image URL Resolution
+   Compass v2 — Client-safe Image URL Resolution
    SINGLE source of truth for ALL image paths.
+   
+   This file is safe to import from 'use client' components.
+   For server-only helpers (getHeroImage, getManifestHeroImage),
+   import from './image-url.server' instead.
    
    Handles:
    - Blob URLs (https://...blob.vercel-storage.com/...)
    - Relative place-photos (/place-photos/ChIJ.../photos/1.jpg)
    - Relative cottage images (/cottages/the-lookout/photo_1.jpg)
-   - Manifest.json fallback (data/placecards/{id}/manifest.json)
-   - Cottage data heroImage field
    ============================================================ */
 
 const BLOB_BASE = process.env.NEXT_PUBLIC_BLOB_BASE_URL || '';
@@ -27,75 +29,6 @@ export function resolveImageUrl(path: string | undefined | null): string | null 
   if (path.startsWith('/') && BLOB_BASE) return `${BLOB_BASE}${path}`;
   if (BLOB_BASE && !path.startsWith('.')) return `${BLOB_BASE}/${path}`;
   return path;
-}
-
-/**
- * Get hero image URL for a place card, trying multiple sources.
- * Server-side only (uses fs).
- * 
- * Priority:
- * 1. Provided heroImage (already resolved)
- * 2. Manifest.json first image
- * 3. null (caller should show placeholder)
- */
-export function getHeroImage(
-  placeId: string | undefined | null,
-  heroImage?: string | null,
-): string | null {
-  // 1. Use provided heroImage if available
-  const resolved = resolveImageUrl(heroImage);
-  if (resolved) return resolved;
-
-  // 2. Try manifest
-  if (placeId) return getManifestHeroImage(placeId);
-
-  return null;
-}
-
-// Pre-built image index — populated at build time from manifest.json files
-// Avoids dynamic fs reads which may fail on Vercel serverless
-let _imageIndex: Record<string, string> | null = null;
-
-function loadImageIndex(): Record<string, string> {
-  if (_imageIndex) return _imageIndex;
-  try {
-    const fs = require('fs');
-    const pathMod = require('path');
-    const indexPath = pathMod.join(process.cwd(), 'data', 'image-index.json');
-    if (fs.existsSync(indexPath)) {
-      _imageIndex = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
-      return _imageIndex!;
-    }
-  } catch { /* ignore */ }
-  return {};
-}
-
-/**
- * Get the first image URL from a place card manifest.
- * Uses pre-built index (data/image-index.json) for reliability on Vercel.
- * Falls back to direct manifest read.
- */
-export function getManifestHeroImage(placeId: string): string | null {
-  if (typeof window !== 'undefined') return null;
-
-  // Try pre-built index first (fast, reliable on Vercel)
-  const index = loadImageIndex();
-  if (index[placeId]) return resolveImageUrl(index[placeId]);
-
-  // Fallback: direct manifest read
-  try {
-    const fs = require('fs');
-    const pathMod = require('path');
-    const manifestPath = pathMod.join(process.cwd(), 'data', 'placecards', placeId, 'manifest.json');
-    if (!fs.existsSync(manifestPath)) return null;
-    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-    const images = manifest?.images;
-    if (!Array.isArray(images) || images.length === 0) return null;
-    const hero = images.find((i: { category?: string }) => i.category !== 'map') || images[0];
-    return resolveImageUrl(hero?.path) || null;
-  } catch {
-    return null;
-  }
 }
 
 /**

--- a/app/hot/page.tsx
+++ b/app/hot/page.tsx
@@ -3,7 +3,7 @@ import path from 'path';
 import type { DiscoveryType } from '../_lib/types';
 import { ALL_TYPES } from '../_lib/discovery-types';
 import { getCurrentUser } from '../_lib/user';
-import { getManifestHeroImage } from '../_lib/image-url';
+import { getManifestHeroImage } from '../_lib/image-url.server';
 import HotClient from './HotClient';
 
 export const dynamic = 'force-dynamic';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { getCurrentUser } from './_lib/user';
 import { getUserManifest, getUserDiscoveries } from './_lib/user-data';
 import type { Context, Discovery, UserManifest } from './_lib/types';
 import { isContextActive } from './_lib/context-lifecycle';
-import { resolveImageUrl, getManifestHeroImage } from './_lib/image-url';
+import { resolveImageUrl, getManifestHeroImage } from './_lib/image-url.server';
 import { isTypeCompatible } from './_lib/context-compat';
 import HomeClient from './_components/HomeClient';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "jose": "^6.2.2",
         "next": "16.2.1",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "server-only": "^0.0.1"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -5222,6 +5223,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "jose": "^6.2.2",
     "next": "16.2.1",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "server-only": "^0.0.1"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
Addresses issue #212

## Problem
`app/_lib/image-url.ts` used `require('fs')` in `loadImageIndex()` and `getManifestHeroImage()`. These were transitively imported by client components (PlaceCard → PlaceGrid → HomeClient → page.tsx), causing Turbopack to fail with `Module not found: Can't resolve 'fs'` — resulting in 500 on all pages.

## Fix
- **Created `image-url.server.ts`** with `import 'server-only'` guard containing all fs-dependent functions (`loadImageIndex`, `getManifestHeroImage`, `getHeroImage`). Uses proper ESM `import { readFileSync, existsSync } from 'fs'` instead of `require('fs')`.
- **Stripped fs code from `image-url.ts`** — now contains only client-safe helpers (`resolveImageUrl`, `resolveImageUrlClient`).
- **Updated server component imports** in `app/page.tsx` and `app/hot/page.tsx` to import from `image-url.server`.
- **Added `server-only`** package to enforce the boundary at build time.

## Verification
- `next build` compiles successfully (no fs resolution errors)
- Smoke test: 8/8 endpoints pass (all 200s, no 500s)