### PR TITLE
fix: derive discovery city from place address, not trip context (#187)

### DIFF
--- a/app/_lib/chat/tools/add-to-compass.ts
+++ b/app/_lib/chat/tools/add-to-compass.ts
@@ -6,6 +6,69 @@
 import { setUserData, getUserData } from '../../user-data';
 import type { Discovery, DiscoveryType, UserDiscoveries } from '../../types';
 
+interface PlaceAddressComponent {
+  longText?: string;
+  shortText?: string;
+  types?: string[];
+}
+
+interface GooglePlaceDetails {
+  addressComponents?: PlaceAddressComponent[];
+  formattedAddress?: string;
+}
+
+/**
+ * Extract city from Google Place address components.
+ * Looks for locality (city) or falls back to parsing formatted_address.
+ */
+function extractCityFromPlace(place: GooglePlaceDetails): string | null {
+  // Try to find locality in address components
+  if (place.addressComponents) {
+    for (const component of place.addressComponents) {
+      if (component.types?.includes('locality')) {
+        return component.longText || component.shortText || null;
+      }
+    }
+    // Fallback to sublocality
+    for (const component of place.addressComponents) {
+      if (component.types?.includes('sublocality')) {
+        return component.longText || component.shortText || null;
+      }
+    }
+  }
+  // Fallback: parse from formatted_address
+  if (place.formattedAddress) {
+    const parts = place.formattedAddress.split(',');
+    if (parts.length >= 2) {
+      return parts[0].trim().split(' ').slice(-1)[0] || parts[1]?.trim() || null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Fetch place details from Google Places API to get actual address.
+ */
+async function fetchPlaceDetails(placeId: string): Promise<GooglePlaceDetails | null> {
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+  if (!apiKey) return null;
+
+  try {
+    const url = `https://places.googleapis.com/v1/${placeId}`;
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'X-Goog-Api-Key': apiKey,
+        'X-Goog-FieldMask': 'addressComponents,formattedAddress',
+      },
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
 export interface AddToCompassInput {
   name: string;
   city: string;
@@ -32,12 +95,26 @@ export async function addToCompass(
     // Generate unique ID for the discovery
     const discoveryId = `disco_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
+    // If we have a place_id, fetch actual address to get the real city
+    let city = input.city;
+    let address = input.address;
+    if (input.place_id) {
+      const placeDetails = await fetchPlaceDetails(input.place_id);
+      if (placeDetails) {
+        const extractedCity = extractCityFromPlace(placeDetails);
+        if (extractedCity) {
+          city = extractedCity;
+          address = placeDetails.formattedAddress || input.address;
+        }
+      }
+    }
+
     const discovery: Discovery = {
       id: discoveryId,
       place_id: input.place_id,
       name: input.name,
-      address: input.address,
-      city: input.city,
+      address: address,
+      city: city,
       type: input.category,
       rating: input.rating,
       contextKey: input.contextKey || '',
@@ -65,7 +142,7 @@ export async function addToCompass(
       updatedAt: new Date().toISOString(),
     });
 
-    console.log(`[add_to_compass] ✅ Added "${input.name}" (${input.city}) for user ${userId}`);
+    console.log(`[add_to_compass] ✅ Added "${input.name}" (${city}) for user ${userId}`);
 
     // Build response URLs
     const compassUrl = input.place_id
@@ -74,7 +151,7 @@ export async function addToCompass(
     const mapsUrl = input.place_id
       ? `https://www.google.com/maps/place/?q=place_id:${input.place_id}`
       : (input.address
-        ? `https://www.google.com/maps/search/${encodeURIComponent(input.name + ' ' + input.city)}`
+        ? `https://www.google.com/maps/search/${encodeURIComponent(input.name + ' ' + city)}`
         : null);
 
     return `✅ Added "${input.name}" to Compass! Links: compass=${compassUrl || 'pending'} maps=${mapsUrl || 'pending'}`;

--- a/app/_lib/chat/tools/save-discovery.ts
+++ b/app/_lib/chat/tools/save-discovery.ts
@@ -8,6 +8,69 @@ import { put, list } from '@vercel/blob';
 import { getUserData, setUserData } from '../../user-data';
 import type { Discovery, DiscoveryType, UserDiscoveries } from '../../types';
 
+interface PlaceAddressComponent {
+  longText?: string;
+  shortText?: string;
+  types?: string[];
+}
+
+interface GooglePlaceDetails {
+  addressComponents?: PlaceAddressComponent[];
+  formattedAddress?: string;
+}
+
+/**
+ * Extract city from Google Place address components.
+ * Looks for locality (city) or falls back to parsing formatted_address.
+ */
+function extractCityFromPlace(place: GooglePlaceDetails): string | null {
+  // Try to find locality in address components
+  if (place.addressComponents) {
+    for (const component of place.addressComponents) {
+      if (component.types?.includes('locality')) {
+        return component.longText || component.shortText || null;
+      }
+    }
+    // Fallback to sublocality
+    for (const component of place.addressComponents) {
+      if (component.types?.includes('sublocality')) {
+        return component.longText || component.shortText || null;
+      }
+    }
+  }
+  // Fallback: parse from formatted_address
+  if (place.formattedAddress) {
+    const parts = place.formattedAddress.split(',');
+    if (parts.length >= 2) {
+      return parts[0].trim().split(' ').slice(-1)[0] || parts[1]?.trim() || null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Fetch place details from Google Places API to get actual address.
+ */
+async function fetchPlaceDetails(placeId: string): Promise<GooglePlaceDetails | null> {
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+  if (!apiKey) return null;
+
+  try {
+    const url = `https://places.googleapis.com/v1/${placeId}`;
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'X-Goog-Api-Key': apiKey,
+        'X-Goog-FieldMask': 'addressComponents,formattedAddress',
+      },
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
 export interface SaveDiscoveryInput {
   name: string;
   contextKey: string;       // which context to save to
@@ -57,12 +120,26 @@ export async function saveDiscovery(userId: string, input: SaveDiscoveryInput): 
   try {
     const discoveryId = `disco_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
+    // If we have a place_id, fetch actual address to get the real city
+    let city = input.city;
+    let address = input.address;
+    if (input.place_id) {
+      const placeDetails = await fetchPlaceDetails(input.place_id);
+      if (placeDetails) {
+        const extractedCity = extractCityFromPlace(placeDetails);
+        if (extractedCity) {
+          city = extractedCity;
+          address = placeDetails.formattedAddress || input.address;
+        }
+      }
+    }
+
     const discovery: Discovery = {
       id: discoveryId,
       place_id: input.place_id,
       name: input.name,
-      address: input.address,
-      city: input.city,
+      address: address,
+      city: city,
       type: input.type || 'restaurant',
       rating: input.rating,
       contextKey: input.contextKey,
@@ -99,7 +176,7 @@ export async function saveDiscovery(userId: string, input: SaveDiscoveryInput): 
     store[input.contextKey]!.seen![discoveryId] = {
       firstSeen: new Date().toISOString(),
       name: input.name,
-      city: input.city,
+      city: city,
       type: input.type || 'restaurant',
     };
 


### PR DESCRIPTION
## Problem
Disco was setting `city` from the active trip context (e.g. Haliburton cottage trip), so all Toronto discoveries got tagged as Haliburton.

## Fix
Both `add-to-compass.ts` and `save-discovery.ts` now:
1. Fetch actual place details from Google Places API using the place_id
2. Extract city from `addressComponents.locality` (with sublocality fallback)
3. Fall back to parsing `formattedAddress` if no address components
4. Only use the chat-provided city as a last resort if API call fails

## Changes
- `app/_lib/chat/tools/add-to-compass.ts` — city derivation from place address
- `app/_lib/chat/tools/save-discovery.ts` — same fix

Closes #187