### PR TITLE
fix: Eliminate all hydration mismatches (#218)

### DIFF
--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -116,6 +116,11 @@ export default function HomeClient({
   discoveryMap,
   contextMeta = {},
 }: HomeClientProps) {
+  // Mounted state to avoid hydration mismatch from localStorage reads
+  const [mounted, setMounted] = useState(false);
+  // Store context counts - initialize with zeros to match server render
+  const [contextCounts, setContextCounts] = useState<Record<string, { saved: number; dismissed: number; resurfaced: number }>>({});
+
   // Re-render when triage state changes (for saved count badges)
   // Must be BEFORE any conditional returns (Rules of Hooks)
   const [, setTriageVersion] = useState(0);
@@ -124,6 +129,17 @@ export default function HomeClient({
     window.addEventListener('triage-changed', handler);
     return () => window.removeEventListener('triage-changed', handler);
   }, []);
+
+  // Initialize from localStorage after mount
+  useEffect(() => {
+    setMounted(true);
+    // Load all context counts
+    const counts: Record<string, { saved: number; dismissed: number; resurfaced: number }> = {};
+    for (const ctx of contexts) {
+      counts[ctx.key] = getContextCounts(userId, ctx.key);
+    }
+    setContextCounts(counts);
+  }, [userId, contexts]);
 
   // Triage hydration now handled by <TriageHydrator> in root layout
 
@@ -149,7 +165,8 @@ export default function HomeClient({
 
       {contexts.map(ctx => {
         const discoveries = discoveryMap[ctx.key] ?? [];
-        const counts = getContextCounts(userId, ctx.key);
+        // Use stored counts after mount, or zeros before mount (matches server)
+        const counts = mounted ? (contextCounts[ctx.key] ?? { saved: 0, dismissed: 0, resurfaced: 0 }) : { saved: 0, dismissed: 0, resurfaced: 0 };
         const naturalDate = formatDateNatural(ctx.dates);
         const description = buildDescription(ctx);
 

--- a/app/hot/HotClient.tsx
+++ b/app/hot/HotClient.tsx
@@ -133,13 +133,17 @@ export default function HotClient({ cards, availableTypes, userId }: HotClientPr
   function renderCard(card: HotPlaceCard) {
     const gradient = TYPE_GRADIENTS[card.type] || 'linear-gradient(135deg, #1e3a5f 0%, #3b82f6 100%)';
     const bgStyle = card.heroImage
-      ? `linear-gradient(to bottom, rgba(0,0,0,0) 30%, rgba(0,0,0,0.65) 100%), url(${card.heroImage}) center/cover`
+      ? {
+          backgroundImage: `linear-gradient(to bottom, rgba(0,0,0,0) 30%, rgba(0,0,0,0.65) 100%), url(${card.heroImage})`,
+          backgroundPosition: 'center',
+          backgroundSize: 'cover',
+        }
       : gradient;
 
     return (
       <div key={card.placeId} className="hot-place-card" style={{ position: 'relative' }}>
         <Link href={`/placecards/${card.placeId}`} className="hot-place-card-link">
-          <div className="hot-place-card-image" style={{ background: bgStyle }}>
+          <div className="hot-place-card-image" style={bgStyle as React.CSSProperties}>
             <div className="hot-place-card-overlay">
               <TypeBadge type={card.type} size="sm" />
               <h3 className="hot-place-card-name">{card.name}</h3>


### PR DESCRIPTION
## Summary
- Fix HotClient.tsx CSS background shorthand to use separate backgroundImage/backgroundPosition/backgroundSize properties
- Fix HomeClient.tsx getContextCounts hydration mismatch by initializing with zeros and loading from localStorage after mount

## Test plan
- [x] `npx next build` passes
- [x] No localStorage reads during initial SSR render
- [x] All client-only data initialized with server-safe defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)