### PR TITLE
feat: add Playwright smoke tests for dev verification (#217)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-dom": "19.2.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1243,6 +1244,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -3431,6 +3448,21 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4902,6 +4934,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "npx playwright test",
+    "test:headed": "npx playwright test --headed"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
@@ -18,6 +20,7 @@
     "react-dom": "19.2.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:3002',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        browserName: 'chromium',
+      },
+    },
+  ],
+  timeout: 30000,
+});

--- a/tests/chat.spec.ts
+++ b/tests/chat.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test('chat widget has correct light background', async ({ page }) => {
+  // Authenticate first by visiting /u/john
+  await page.goto('/u/john', { waitUntil: 'networkidle' });
+
+  // Navigate to home page
+  await page.goto('/', { waitUntil: 'networkidle' });
+
+  // Look for the chat input (input with placeholder containing 'message' or 'anything')
+  const chatInput = page.locator('input[placeholder*="message"], input[placeholder*="Message"], input[placeholder*="anything"], input[placeholder*="Anything"]');
+
+  // Assert it exists and is visible
+  await expect(chatInput).toBeVisible();
+
+  // Check its computed background-color is a warm/light color (not dark)
+  // rgb values where all channels > 200 means light color
+  const bgColor = await chatInput.evaluate((el) => {
+    const style = window.getComputedStyle(el);
+    const match = style.backgroundColor.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+    if (match) {
+      return {
+        r: parseInt(match[1], 10),
+        g: parseInt(match[2], 10),
+        b: parseInt(match[3], 10),
+      };
+    }
+    return null;
+  });
+
+  expect(bgColor).not.toBeNull();
+
+  // All channels should be > 200 for a light background
+  const isLightBackground = bgColor!.r > 200 && bgColor!.g > 200 && bgColor!.b > 200;
+
+  console.log('Chat input background color:', bgColor);
+
+  expect(isLightBackground).toBe(true);
+});

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+test('all visible images load correctly', async ({ page }) => {
+  // Authenticate first by visiting /u/john
+  await page.goto('/u/john', { waitUntil: 'networkidle' });
+
+  // Navigate to home page
+  await page.goto('/', { waitUntil: 'networkidle' });
+
+  // Find all img elements with src attributes
+  const images = page.locator('img[src]');
+  const count = await images.count();
+
+  expect(count).toBeGreaterThan(0);
+
+  const brokenImages: string[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const img = images.nth(i);
+    const src = await img.getAttribute('src');
+
+    // Check if image is visible
+    const isVisible = await img.isVisible();
+    if (!isVisible) continue;
+
+    // Wait for the image to potentially load
+    await img.waitFor({ state: 'attached', timeout: 5000 }).catch(() => {});
+
+    // Get naturalWidth to check if image loaded
+    const naturalWidth = await img.evaluate((el) => (el as HTMLImageElement).naturalWidth);
+
+    if (naturalWidth === 0) {
+      brokenImages.push(src || 'unknown');
+    }
+  }
+
+  if (brokenImages.length > 0) {
+    console.log('Broken images found:', brokenImages);
+  }
+
+  expect(brokenImages).toHaveLength(0);
+});

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+const PAGES = ['/', '/placecards', '/hot', '/review', '/admin'];
+
+test.describe('Page load and console error tests', () => {
+  test.beforeEach(async ({ page }) => {
+    // Authenticate first by visiting /u/john
+    await page.goto('/u/john', { waitUntil: 'networkidle' });
+  });
+
+  for (const path of PAGES) {
+    test(`page ${path} loads without hydration errors`, async ({ page }) => {
+      const consoleErrors: string[] = [];
+
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      const response = await page.goto(path, { waitUntil: 'networkidle' });
+
+      // Assert HTTP 200
+      expect(response?.status()).toBe(200);
+
+      // Log all console errors for debugging
+      if (consoleErrors.length > 0) {
+        console.log(`Page ${path} console errors:`, consoleErrors);
+      }
+
+      // FAIL if any console.error contains 'Hydration' or 'hydration'
+      const hydrationErrors = consoleErrors.filter(
+        (err) => err.toLowerCase().includes('hydration')
+      );
+      expect(hydrationErrors).toHaveLength(0);
+
+      // FAIL if any console.error contains 'Unhandled' or 'unhandled'
+      const unhandledErrors = consoleErrors.filter(
+        (err) => err.toLowerCase().includes('unhandled')
+      );
+      expect(unhandledErrors).toHaveLength(0);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Add Playwright as a dev dependency with chromium browser
- Create playwright.config.ts with baseURL localhost:3002, no retries, 30s timeout
- Add test and test:headed scripts to package.json
- Create smoke tests for page loads and console error detection
- Create image verification tests to check for broken images
- Create chat widget tests to verify light background color

## Test plan
- [ ] Run `npm test` to verify all smoke tests pass
- [ ] Run `npm test:headed` to see browser in action

🤖 Generated with [Claude Code](https://claude.com/claude-code)