### PR TITLE
fix: guarantee every place has a photo before display (Fixes #211)

### DIFF
--- a/app/_components/PlaceCard.tsx
+++ b/app/_components/PlaceCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import type { Discovery } from '../_lib/types';
 import TypeBadge from './TypeBadge';
@@ -22,13 +23,41 @@ export default function PlaceCard({ discovery, contextKey, userId }: PlaceCardPr
   const rawImage = discovery.heroImage;
   const imageUrl = resolveImageUrlClient(rawImage);
 
+  // Fix #211: onError recovery - if image fails to load, trigger fetch from API
+  const [fetchedImageUrl, setFetchedImageUrl] = useState<string | null>(null);
+  const [hasTriedFetch, setHasTriedFetch] = useState(false);
+
+  // Final URL: prioritize fetched image (from onError recovery), then original
+  const finalImageUrl = fetchedImageUrl || imageUrl;
+
+  const handleImageError = async () => {
+    if (!place_id || hasTriedFetch) return;
+    setHasTriedFetch(true);
+
+    try {
+      const res = await fetch('/api/internal/fetch-photo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ placeId: place_id }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.photoUrl) {
+          setFetchedImageUrl(data.photoUrl);
+        }
+      }
+    } catch (e) {
+      console.error('[PlaceCard] Failed to fetch photo:', e);
+    }
+  };
+
   // Generate fallback gradient based on type
   // NOTE: Use separate properties instead of `background` shorthand.
   // The shorthand `url(...) center/cover` is parsed differently by
   // server (Node CSS) vs browser, causing hydration mismatches.
-  const gradientStyle = imageUrl
+  const gradientStyle = finalImageUrl
     ? {
-        backgroundImage: `url(${imageUrl})`,
+        backgroundImage: `url(${finalImageUrl})`,
         backgroundPosition: 'center',
         backgroundSize: 'cover',
       }
@@ -46,7 +75,16 @@ export default function PlaceCard({ discovery, contextKey, userId }: PlaceCardPr
     <div style={{ position: 'relative' }}>
       <Link href={`/placecards/${place_id || id}?context=${encodeURIComponent(contextKey)}`} className="place-card">
         <div className="place-card-image" style={gradientStyle as React.CSSProperties}>
-          {!imageUrl && <span className="place-card-image-fallback" />}
+          {!finalImageUrl && <span className="place-card-image-fallback" />}
+          {/* Hidden img for onError detection - triggers on load failure */}
+          {place_id && imageUrl && (
+            <img
+              src={imageUrl}
+              alt=""
+              style={{ display: 'none' }}
+              onError={handleImageError}
+            />
+          )}
         </div>
         <div className="place-card-body">
           <div className="place-card-header">

--- a/app/_lib/chat/tools/add-to-compass.ts
+++ b/app/_lib/chat/tools/add-to-compass.ts
@@ -6,6 +6,7 @@
 import { setUserData, getUserData } from '../../user-data';
 import type { Discovery, DiscoveryType, UserDiscoveries } from '../../types';
 import { resolveCity } from './resolve-city';
+import { put, head } from '@vercel/blob';
 
 export interface AddToCompassInput {
   name: string;
@@ -17,6 +18,103 @@ export interface AddToCompassInput {
   rating?: number;
   address?: string;
   contextKey?: string;
+}
+
+/**
+ * Fetch photo for a place using Google Places API with fallback chain.
+ * Returns the blob URL if successful, null otherwise.
+ * Uses a 5 second timeout.
+ */
+async function fetchPhotoForPlace(placeId: string): Promise<string | null> {
+  const PLACES_API_KEY = process.env.GOOGLE_PLACES_API_KEY;
+  if (!PLACES_API_KEY) return null;
+
+  const blobPath = `place-photos/${placeId}/1.jpg`;
+
+  // Check if already exists
+  try {
+    const existing = await head(blobPath);
+    if (existing) return existing.url;
+  } catch {
+    // Doesn't exist, need to fetch
+  }
+
+  let photoBuffer: ArrayBuffer | null = null;
+
+  // ---- Try 1: Google Places Photo API (v1) ----
+  try {
+    const detailsRes = await fetch(
+      `https://places.googleapis.com/v1/places/${placeId}?fields=photos,location&key=${PLACES_API_KEY}`,
+      {
+        headers: { 'X-Goog-Api-Key': PLACES_API_KEY, 'Content-Type': 'application/json' },
+      }
+    );
+
+    if (detailsRes.ok) {
+      const details = await detailsRes.json();
+      const photos = details.photos;
+      const location = details.location;
+
+      if (photos && Array.isArray(photos) && photos.length > 0 && location) {
+        const photoName = photos[0].name;
+        const photoRes = await fetch(
+          `https://places.googleapis.com/v1/${photoName}/media?maxWidthPx=800&key=${PLACES_API_KEY}`
+        );
+
+        if (photoRes.ok) {
+          photoBuffer = await photoRes.arrayBuffer();
+        }
+      }
+
+      // If Places photos failed but we have location, try Street View
+      if (!photoBuffer && location) {
+        const lat = location.latitude;
+        const lng = location.longitude;
+
+        // ---- Try 2: Google Street View ----
+        const streetViewUrl = `https://maps.googleapis.com/maps/api/streetview?size=800x600&location=${lat},${lng}&key=${PLACES_API_KEY}`;
+        const streetViewRes = await fetch(streetViewUrl);
+
+        if (streetViewRes.ok) {
+          const contentType = streetViewRes.headers.get('content-type') || '';
+          if (contentType.includes('image')) {
+            photoBuffer = await streetViewRes.arrayBuffer();
+          }
+        }
+
+        // ---- Try 3: Google Static Map ----
+        if (!photoBuffer) {
+          const staticMapUrl = `https://maps.googleapis.com/maps/api/staticmap?center=${lat},${lng}&zoom=16&size=800x600&maptype=roadmap&markers=color:red|${lat},${lng}&key=${PLACES_API_KEY}`;
+          const staticMapRes = await fetch(staticMapUrl);
+
+          if (staticMapRes.ok) {
+            const contentType = staticMapRes.headers.get('content-type') || '';
+            if (contentType.includes('image')) {
+              photoBuffer = await staticMapRes.arrayBuffer();
+            }
+          }
+        }
+      }
+    }
+  } catch (e) {
+    console.error('[add_to_compass] fetchPhoto: Places API error:', e);
+  }
+
+  // If no photo found, return null
+  if (!photoBuffer) return null;
+
+  // Upload to Vercel Blob
+  try {
+    const uploaded = await put(blobPath, new Blob([photoBuffer], { type: 'image/jpeg' }), {
+      access: 'public',
+      addRandomSuffix: false,
+      contentType: 'image/jpeg',
+    });
+    return uploaded.url;
+  } catch (e) {
+    console.error('[add_to_compass] fetchPhoto: Blob upload error:', e);
+    return null;
+  }
 }
 
 /**
@@ -36,6 +134,23 @@ export async function addToCompass(
     // Derive city from actual place data, not from LLM context (fixes #187)
     const resolvedCity = await resolveCity(input.place_id, input.address, input.city);
 
+    let heroImage: string | undefined = undefined;
+
+    // Fix #211: If the discovery has a place_id, fetch photo SYNCHRONOUSLY
+    // with a 5 second timeout. If fetch fails, save without heroImage.
+    if (input.place_id) {
+      try {
+        const photoPromise = fetchPhotoForPlace(input.place_id);
+        const timeoutPromise = new Promise<string | null>((_, reject) =>
+          setTimeout(() => reject(new Error('Timeout')), 5000)
+        );
+        heroImage = await Promise.race([photoPromise, timeoutPromise]) || undefined;
+      } catch (e) {
+        console.error('[add_to_compass] Failed to fetch photo:', e);
+        // Save without heroImage - it will be filtered from display until photo is available
+      }
+    }
+
     const discovery: Discovery = {
       id: discoveryId,
       place_id: input.place_id,
@@ -44,6 +159,7 @@ export async function addToCompass(
       city: resolvedCity,
       type: input.category,
       rating: input.rating,
+      heroImage,
       contextKey: input.contextKey || '',
       source: 'chat:recommendation',
       discoveredAt: new Date().toISOString(),

--- a/app/api/internal/fetch-photo/route.ts
+++ b/app/api/internal/fetch-photo/route.ts
@@ -1,0 +1,133 @@
+/**
+ * POST /api/internal/fetch-photo
+ * Fetches a photo for a place using Google Places API with fallback chain.
+ * Uploads the result to Vercel Blob at place-photos/{placeId}/1.jpg
+ *
+ * Body: { placeId: string }
+ * Returns: { ok: true, photoUrl: blobUrl }
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { put, head } from '@vercel/blob';
+
+const PLACES_API_KEY = process.env.GOOGLE_PLACES_API_KEY;
+const BLOB_BASE_URL = process.env.NEXT_PUBLIC_BLOB_BASE_URL || '';
+
+export async function POST(req: NextRequest) {
+  if (!PLACES_API_KEY) {
+    return NextResponse.json(
+      { error: 'GOOGLE_PLACES_API_KEY not configured' },
+      { status: 501 }
+    );
+  }
+
+  let body: { placeId?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { placeId } = body;
+  if (!placeId) {
+    return NextResponse.json({ error: 'placeId is required' }, { status: 400 });
+  }
+
+  const blobPath = `place-photos/${placeId}/1.jpg`;
+
+  // Check if already exists
+  try {
+    const existing = await head(blobPath);
+    if (existing) {
+      return NextResponse.json({
+        ok: true,
+        photoUrl: existing.url,
+        cached: true,
+      });
+    }
+  } catch {
+    // Doesn't exist, need to fetch
+  }
+
+  let photoBuffer: ArrayBuffer | null = null;
+
+  // ---- Try 1: Google Places Photo API (v1) ----
+  try {
+    const detailsRes = await fetch(
+      `https://places.googleapis.com/v1/places/${placeId}?fields=photos,location&key=${PLACES_API_KEY}`,
+      {
+        headers: { 'X-Goog-Api-Key': PLACES_API_KEY, 'Content-Type': 'application/json' },
+      }
+    );
+
+    if (detailsRes.ok) {
+      const details = await detailsRes.json();
+      const photos = details.photos;
+      const location = details.location;
+
+      if (photos && Array.isArray(photos) && photos.length > 0 && location) {
+        const photoName = photos[0].name;
+        const photoRes = await fetch(
+          `https://places.googleapis.com/v1/${photoName}/media?maxWidthPx=800&key=${PLACES_API_KEY}`
+        );
+
+        if (photoRes.ok) {
+          photoBuffer = await photoRes.arrayBuffer();
+        }
+      }
+
+      // If Places photos failed but we have location, try Street View
+      if (!photoBuffer && location) {
+        const lat = location.latitude;
+        const lng = location.longitude;
+
+        // ---- Try 2: Google Street View ----
+        const streetViewUrl = `https://maps.googleapis.com/maps/api/streetview?size=800x600&location=${lat},${lng}&key=${PLACES_API_KEY}`;
+        const streetViewRes = await fetch(streetViewUrl);
+
+        if (streetViewRes.ok) {
+          const contentType = streetViewRes.headers.get('content-type') || '';
+          if (contentType.includes('image')) {
+            photoBuffer = await streetViewRes.arrayBuffer();
+          }
+        }
+
+        // ---- Try 3: Google Static Map ----
+        if (!photoBuffer) {
+          const staticMapUrl = `https://maps.googleapis.com/maps/api/staticmap?center=${lat},${lng}&zoom=16&size=800x600&maptype=roadmap&markers=color:red|${lat},${lng}&key=${PLACES_API_KEY}`;
+          const staticMapRes = await fetch(staticMapUrl);
+
+          if (staticMapRes.ok) {
+            const contentType = staticMapRes.headers.get('content-type') || '';
+            if (contentType.includes('image')) {
+              photoBuffer = await staticMapRes.arrayBuffer();
+            }
+          }
+        }
+      }
+    }
+  } catch (e) {
+    console.error('[fetch-photo] Places API error:', e);
+  }
+
+  // If no photo found, return 404
+  if (!photoBuffer) {
+    return NextResponse.json({ error: 'No photo found for this place' }, { status: 404 });
+  }
+
+  // Upload to Vercel Blob
+  try {
+    const uploaded = await put(blobPath, new Blob([photoBuffer], { type: 'image/jpeg' }), {
+      access: 'public',
+      addRandomSuffix: false,
+      contentType: 'image/jpeg',
+    });
+
+    return NextResponse.json({
+      ok: true,
+      photoUrl: uploaded.url,
+    });
+  } catch (e) {
+    console.error('[fetch-photo] Blob upload error:', e);
+    return NextResponse.json({ error: 'Failed to upload photo' }, { status: 500 });
+  }
+}

--- a/app/api/internal/retry-missing-photos/route.ts
+++ b/app/api/internal/retry-missing-photos/route.ts
@@ -1,0 +1,97 @@
+/**
+ * GET /api/internal/retry-missing-photos
+ * Scans all user discoveries for missing heroImage where place_id exists.
+ * Calls fetch-photo for each (with 200ms delay between to avoid rate limits).
+ * Returns summary of what was fixed.
+ *
+ * Query params: ?userId=xxx&dryRun=true
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { list } from '@vercel/blob';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get('userId') || 'john';
+  const dryRun = searchParams.get('dryRun') === 'true';
+
+  // Load all user discoveries
+  const { blobs } = await list({ prefix: `users/${userId}/discoveries` });
+  if (blobs.length === 0) {
+    return NextResponse.json({ error: 'No discoveries found' }, { status: 404 });
+  }
+
+  const matchedBlob = blobs.find(b => b.pathname === `users/${userId}/discoveries.json`) ?? blobs[0];
+  const blobUrl = matchedBlob!.url;
+  const res = await fetch(blobUrl);
+  const raw = await res.json();
+  const discoveries: Record<string, unknown>[] = Array.isArray(raw) ? raw : raw.discoveries || [];
+
+  // Find candidates missing heroImage but have place_id
+  const candidates = discoveries.filter(d => d.place_id && !d.heroImage);
+
+  const results = {
+    total: discoveries.length,
+    missing: candidates.length,
+    fixed: 0,
+    failed: 0,
+    errors: [] as string[],
+  };
+
+  for (const d of candidates) {
+    const placeId = d.place_id as string;
+
+    try {
+      if (dryRun) {
+        results.fixed++;
+      } else {
+        const fetchRes = await fetch(new URL(req.url).origin + '/api/internal/fetch-photo', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ placeId }),
+        });
+
+        if (fetchRes.ok) {
+          const data = await fetchRes.json();
+          if (data.photoUrl) {
+            d.heroImage = data.photoUrl;
+            results.fixed++;
+          } else {
+            results.failed++;
+            results.errors.push(`${d.name}: no photo URL returned`);
+          }
+        } else {
+          results.failed++;
+          results.errors.push(`${d.name}: fetch-photo failed ${fetchRes.status}`);
+        }
+      }
+    } catch (e: unknown) {
+      results.failed++;
+      results.errors.push(`${d.name}: ${(e as Error).message}`);
+    }
+
+    // 200ms delay between requests to avoid rate limits
+    if (!dryRun) {
+      await new Promise(r => setTimeout(r, 200));
+    }
+  }
+
+  // Save back to blob if not dry run and we fixed something
+  if (!dryRun && results.fixed > 0) {
+    const { blobs: toDelete } = await list({ prefix: `users/${userId}/discoveries` });
+    for (const b of toDelete) {
+      await fetch(b.url, { method: 'DELETE' }).catch(() => {});
+    }
+
+    const { put } = await import('@vercel/blob');
+    await put(`users/${userId}/discoveries.json`, JSON.stringify(discoveries), {
+      access: 'public',
+      addRandomSuffix: false,
+    });
+  }
+
+  return NextResponse.json({
+    ...results,
+    dryRun,
+    coverage: `${discoveries.filter((d: Record<string, unknown>) => d.heroImage).length}/${discoveries.length}`,
+  });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -151,10 +151,10 @@ export default async function HomePage() {
       return true;
     });
 
-    // Fix #107: sort cards with real photos first so the carousel looks complete
+    // Fix #211: only show discoveries that have a photo
+    // Filter out any discovery where heroImage is falsy (no user-uploaded image AND no manifest fallback)
     const withPhoto = deduped.filter(d => d.heroImage);
-    const withoutPhoto = deduped.filter(d => !d.heroImage);
-    byContext.set(ctx.key, [...withPhoto, ...withoutPhoto]);
+    byContext.set(ctx.key, withPhoto);
   }
 
   // Fix #108 (global): deduplicate place_ids across ALL context carousels


### PR DESCRIPTION
## Summary
- Add `/api/internal/fetch-photo` API endpoint with fallback chain (Google Places Photo API → Street View → Static Map)
- Filter out imageless discoveries from homepage feed in `app/page.tsx`
- Add client-side `onError` recovery in `PlaceCard.tsx` to fetch missing photos dynamically
- Add `/api/internal/retry-missing-photos` endpoint for bulk backfill of missing photos
- Ensure chat tool fetches `heroImage` synchronously when creating discoveries via `add-to-compass.ts`

## Test plan
- [ ] Run `npx next build` — passes ✓
- [ ] Verify homepage only shows places with images
- [ ] Test `/api/internal/fetch-photo` with a valid place ID
- [ ] Test `/api/internal/retry-missing-photos` endpoint
- [ ] Test PlaceCard onError recovery by loading a page with an image that fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)