### PR TITLE
feat: add /api/health endpoint for server verification (Fixes #224)

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { execSync } from 'child_process';
+
+const GIT_COMMIT = (() => {
+  try {
+    return execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+})();
+
+const GIT_BRANCH = (() => {
+  try {
+    return execSync('git branch --show-current', { encoding: 'utf-8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+})();
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({
+    git: GIT_COMMIT,
+    branch: GIT_BRANCH,
+    uptime: process.uptime() * 1000,
+    nodeEnv: process.env.NODE_ENV,
+    timestamp: new Date().toISOString(),
+  });
+}


### PR DESCRIPTION
## Summary
- Adds new `/api/health` endpoint that returns git commit hash, branch name, uptime, node environment, and timestamp
- Git info is cached at module load time to avoid exec on every request

## Test plan
- [ ] Verify `/api/health` returns expected JSON structure
- [ ] Confirm build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)