### PR TITLE
feat: show Google Places photos on placecards browse page (Fixes #230)

### DIFF
--- a/app/api/internal/place-photo/route.ts
+++ b/app/api/internal/place-photo/route.ts
@@ -1,0 +1,126 @@
+/**
+ * GET /api/internal/place-photo
+ * Photo proxy with caching: checks Blob first, fetches from Google Places if needed.
+ *
+ * Query params: ?placeId=ChIJ...
+ * Returns: 302 redirect to Blob URL or transparent pixel
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { head, put } from '@vercel/blob';
+
+const PLACES_API_KEY = process.env.GOOGLE_PLACES_API_KEY;
+
+// Transparent 1x1 GIF (base64)
+const TRANSPARENT_PIXEL = Buffer.from(
+  'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+  'base64'
+);
+
+// Cache for 24 hours
+const CACHE_CONTROL = 'public, max-age=86400';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const placeId = searchParams.get('placeId');
+
+  if (!placeId) {
+    return new NextResponse(TRANSPARENT_PIXEL, {
+      status: 404,
+      headers: { 'Content-Type': 'image/gif', 'Cache-Control': CACHE_CONTROL },
+    });
+  }
+
+  const blobPath = `place-photos/${placeId}/1.jpg`;
+
+  // 1. Check Vercel Blob cache
+  try {
+    const existing = await head(blobPath);
+    if (existing) {
+      return NextResponse.redirect(existing.url, {
+        status: 302,
+        headers: { 'Cache-Control': CACHE_CONTROL },
+      });
+    }
+  } catch {
+    // Doesn't exist, need to fetch from Google Places
+  }
+
+  // 2. Fetch from Google Places API if no API key
+  if (!PLACES_API_KEY) {
+    return new NextResponse(TRANSPARENT_PIXEL, {
+      status: 404,
+      headers: { 'Content-Type': 'image/gif', 'Cache-Control': CACHE_CONTROL },
+    });
+  }
+
+  // 3. Get photo reference from Google Places
+  let photoBuffer: ArrayBuffer | null = null;
+
+  try {
+    const detailsRes = await fetch(
+      `https://places.googleapis.com/v1/places/${placeId}?fields=photos&key=${PLACES_API_KEY}`,
+      {
+        headers: { 'X-Goog-Api-Key': PLACES_API_KEY, 'Content-Type': 'application/json' },
+      }
+    );
+
+    if (!detailsRes.ok) {
+      return new NextResponse(TRANSPARENT_PIXEL, {
+        status: 404,
+        headers: { 'Content-Type': 'image/gif', 'Cache-Control': CACHE_CONTROL },
+      });
+    }
+
+    const details = await detailsRes.json();
+    const photos = details.photos;
+
+    if (!photos || !Array.isArray(photos) || photos.length === 0) {
+      return new NextResponse(TRANSPARENT_PIXEL, {
+        status: 404,
+        headers: { 'Content-Type': 'image/gif', 'Cache-Control': CACHE_CONTROL },
+      });
+    }
+
+    const photoName = photos[0].name;
+
+    // 4. Fetch the photo at 400px width
+    const photoRes = await fetch(
+      `https://places.googleapis.com/v1/${photoName}/media?maxWidthPx=400&key=${PLACES_API_KEY}`
+    );
+
+    if (!photoRes.ok) {
+      return new NextResponse(TRANSPARENT_PIXEL, {
+        status: 404,
+        headers: { 'Content-Type': 'image/gif', 'Cache-Control': CACHE_CONTROL },
+      });
+    }
+
+    photoBuffer = await photoRes.arrayBuffer();
+  } catch (e) {
+    console.error('[place-photo] Google Places API error:', e);
+    return new NextResponse(TRANSPARENT_PIXEL, {
+      status: 404,
+      headers: { 'Content-Type': 'image/gif', 'Cache-Control': CACHE_CONTROL },
+    });
+  }
+
+  // 5. Upload to Vercel Blob
+  try {
+    const uploaded = await put(blobPath, new Blob([photoBuffer], { type: 'image/jpeg' }), {
+      access: 'public',
+      addRandomSuffix: false,
+      contentType: 'image/jpeg',
+    });
+
+    return NextResponse.redirect(uploaded.url, {
+      status: 302,
+      headers: { 'Cache-Control': CACHE_CONTROL },
+    });
+  } catch (e) {
+    console.error('[place-photo] Blob upload error:', e);
+    return new NextResponse(TRANSPARENT_PIXEL, {
+      status: 500,
+      headers: { 'Content-Type': 'image/gif', 'Cache-Control': CACHE_CONTROL },
+    });
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1881,6 +1881,12 @@ a:hover {
   color: inherit;
 }
 
+.place-card-image {
+  width: 100%;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  display: block;
+}
+
 .place-browse-name {
   font-size: 0.95rem;
   margin-bottom: var(--space-xs);

--- a/app/placecards/PlacecardsBrowseClient.tsx
+++ b/app/placecards/PlacecardsBrowseClient.tsx
@@ -1,11 +1,53 @@
 'use client';
 
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import Link from 'next/link';
 import type { DiscoveryType } from '../_lib/types';
 import { ALL_TYPES, getTypeMeta } from '../_lib/discovery-types';
 import TypeBadge from '../_components/TypeBadge';
 import TriageButtons from '../_components/TriageButtons';
+
+function PlaceCardImage({ src }: { src: string | null }) {
+  const [imgError, setImgError] = useState(false);
+  const [imgLoaded, setImgLoaded] = useState(false);
+
+  useEffect(() => {
+    setImgError(false);
+    setImgLoaded(false);
+  }, [src]);
+
+  if (!src) return null;
+
+  return (
+    <div
+      className="place-card-image"
+      style={{
+        aspectRatio: '3/2',
+        background: imgLoaded
+          ? 'transparent'
+          : 'linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)',
+        overflow: 'hidden',
+      }}
+    >
+      {!imgError && (
+        <img
+          src={src}
+          alt=""
+          loading="lazy"
+          onLoad={() => setImgLoaded(true)}
+          onError={() => setImgError(true)}
+          style={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            opacity: imgLoaded ? 1 : 0,
+            transition: 'opacity 0.2s ease',
+          }}
+        />
+      )}
+    </div>
+  );
+}
 
 export interface PlaceCardData {
   placeId: string;
@@ -13,6 +55,7 @@ export interface PlaceCardData {
   type: DiscoveryType;
   city: string;
   rating: number | null;
+  heroImage: string | null;
 }
 
 export interface PlacecardsBrowseClientProps {
@@ -178,6 +221,7 @@ export default function PlacecardsBrowseClient({
         {filteredCards.map((card) => (
           <div key={card.placeId} className="card place-browse-card" style={{ position: 'relative' }}>
             <Link href={`/placecards/${card.placeId}`} className="place-browse-card-link">
+              <PlaceCardImage src={card.heroImage} />
               <div className="card-body">
                 <h3 className="place-browse-name">{card.name}</h3>
                 <TypeBadge type={card.type} />

--- a/app/placecards/page.tsx
+++ b/app/placecards/page.tsx
@@ -37,6 +37,7 @@ interface PlaceCardData {
   type: DiscoveryType;
   city: string;
   rating: number | null;
+  heroImage: string | null;
 }
 
 export default async function PlacecardsPage() {
@@ -68,6 +69,7 @@ export default async function PlacecardsPage() {
         type: entry.type,
         city,
         rating,
+        heroImage: `/api/internal/place-photo?placeId=${placeId}`,
       };
     })
   );


### PR DESCRIPTION
## Summary
- Creates GET /api/internal/place-photo endpoint that proxies Google Places photos with Vercel Blob caching
- Adds heroImage field to PlaceCardData and populates it with the photo proxy URL
- Updates PlacecardsBrowseClient to render photos with gradient placeholder, lazy loading, and error handling
- Adds CSS styling for the card image area

## Test plan
- [ ] Run `npx next build` — passes
- [ ] Navigate to /placecards and verify photos load for cards with Google Places data
- [ ] Verify gradient placeholder shows while loading
- [ ] Verify cards without photos show gracefully (placeholder hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)