### PR TITLE
fix: chat Enter to send + hide scrollbar (Fixes #242)

### DIFF
--- a/app/_components/ChatWidget.module.css
+++ b/app/_components/ChatWidget.module.css
@@ -513,6 +513,13 @@
   resize: none;
   min-height: 44px;
   max-height: 120px;
+  overflow-y: auto;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
+}
+
+.chatInput::-webkit-scrollbar {
+  display: none; /* Chrome/Safari */
 }
 
 .chatInput::placeholder {

--- a/app/_components/ChatWidget.tsx
+++ b/app/_components/ChatWidget.tsx
@@ -519,6 +519,12 @@ export default function ChatWidget() {
             placeholder="Ask me anything..."
             value={input}
             onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                handleSend(e as unknown as React.FormEvent);
+              }
+            }}
             disabled={loading || streaming}
             rows={1}
           />


### PR DESCRIPTION
## Summary
- Add Enter key handler to expanded chat textarea to send messages (Shift+Enter allows newline)
- Hide scrollbar on chat input textarea while keeping scroll functionality

## Test plan
- [x] `npx next build` passes
- [x] `npx playwright test` passes (10/10 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)