### PR TITLE
feat: admin user reset for testing (Fixes #240)

### DIFF
--- a/app/admin/AdminClient.tsx
+++ b/app/admin/AdminClient.tsx
@@ -189,6 +189,7 @@ export default function AdminClient() {
   const [loading, setLoading] = useState(true);
   const [expandedUsers, setExpandedUsers] = useState<Set<string>>(new Set());
   const [activeTab, setActiveTab] = useState<AdminTab>('overview');
+  const [resettingUser, setResettingUser] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -213,6 +214,30 @@ export default function AdminClient() {
       // silent
     } finally {
       setLoading(false);
+    }
+  }, []);
+
+  const resetUser = useCallback(async (userId: string, userName: string) => {
+    const confirmed = window.confirm(`Reset all data for ${userName}? This cannot be undone.`);
+    if (!confirmed) return;
+
+    setResettingUser(userId);
+    try {
+      const res = await fetch('/api/admin/reset-user', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId }),
+      });
+      if (res.ok) {
+        alert(`Reset complete: user data cleared`);
+      } else {
+        const err = await res.json();
+        alert(`Reset failed: ${err.error}`);
+      }
+    } catch (e) {
+      alert(`Reset failed: ${e}`);
+    } finally {
+      setResettingUser(null);
     }
   }, []);
 
@@ -629,6 +654,19 @@ export default function AdminClient() {
                   <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
                     <span className="badge badge-accent">{user.city}</span>
                     {user.isOwner && <span className="badge badge-success">Owner</span>}
+                    {!user.isOwner && (
+                      <button
+                        className="btn btn-sm"
+                        style={{ padding: '4px 8px', fontSize: '0.75rem' }}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          resetUser(user.id, user.name);
+                        }}
+                        disabled={resettingUser === user.id}
+                      >
+                        {resettingUser === user.id ? 'Resetting...' : 'Reset'}
+                      </button>
+                    )}
                     <span style={{ color: 'var(--text-muted)' }}>{expanded ? '▼' : '▶'}</span>
                   </div>
                 </div>

--- a/app/api/admin/reset-user/route.ts
+++ b/app/api/admin/reset-user/route.ts
@@ -1,0 +1,49 @@
+/* ============================================================
+   Admin API — Reset User
+   Deletes all Blob data for a specific user
+   ============================================================ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { list, del } from '@vercel/blob';
+import { getCurrentUser, getUserById } from '../../../_lib/user';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const currentUser = await getCurrentUser();
+
+  if (!currentUser || !currentUser.isOwner) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const { userId } = body;
+
+  if (!userId) {
+    return NextResponse.json({ error: 'userId required' }, { status: 400 });
+  }
+
+  const targetUser = getUserById(userId);
+  if (!targetUser) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+
+  if (targetUser.isOwner) {
+    return NextResponse.json({ error: 'Cannot reset owner user' }, { status: 403 });
+  }
+
+  // List all blobs with prefix 'users/{userId}/'
+  const prefix = `users/${userId}/`;
+  const { blobs } = await list({ prefix });
+
+  // Delete each blob
+  const deleted: string[] = [];
+  for (const blob of blobs) {
+    await del(blob.url);
+    // Extract filename from URL for reporting
+    const pathParts = blob.url.split('/');
+    deleted.push(pathParts[pathParts.length - 1] || blob.url);
+  }
+
+  return NextResponse.json({ ok: true, deleted });
+}

--- a/app/reset-local/page.tsx
+++ b/app/reset-local/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function ResetLocalPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState('Resetting...');
+
+  useEffect(() => {
+    // Clear localStorage
+    localStorage.clear();
+
+    // Get redirect target
+    const redirectTo = searchParams.get('redirect') || '/';
+
+    // Brief delay to show "Resetting..." message
+    setStatus('Done. Redirecting...');
+    router.push(redirectTo);
+  }, [router, searchParams]);
+
+  return (
+    <main className="page">
+      <div style={{ textAlign: 'center', padding: 'var(--space-xl)' }}>
+        <p>{status}</p>
+      </div>
+    </main>
+  );
+}

--- a/app/u/[code]/route.ts
+++ b/app/u/[code]/route.ts
@@ -4,11 +4,13 @@ import { NextRequest } from 'next/server';
 import { getUserByCode, COOKIE_NAME } from '../../_lib/user';
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ code: string }> },
 ) {
   const { code } = await params;
   const user = getUserByCode(code);
+  const searchParams = request.nextUrl.searchParams;
+  const reset = searchParams.get('reset') === 'true';
 
   if (!user) {
     return new Response('Invalid invite code', { status: 404 });
@@ -23,7 +25,9 @@ export async function GET(
     maxAge: 60 * 60 * 24 * 365,
   });
 
-  if (user.isOwner) {
+  if (reset) {
+    redirect(`/reset-local?redirect=/onboarding`);
+  } else if (user.isOwner) {
     redirect('/');
   } else {
     redirect('/onboarding');


### PR DESCRIPTION
## Summary
- Add POST /api/admin/reset-user endpoint that deletes all Blob data for a user
- Add Reset button to admin page for non-owner users with confirmation dialog
- Support ?reset=true on /u/[code] login route to clear localStorage
- Add /reset-local client page that clears localStorage then redirects

## Test plan
- [ ] Build passes (`npx next build`)
- [ ] Tests pass (`npx playwright test`)
- [ ] Test admin page shows reset button for non-owner users
- [ ] Test ?reset=true redirects to /reset-local then /onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)