### PR TITLE
feat: show trip planning widget on review page (Fixes #247)

### DIFF
--- a/app/_components/ReviewContextClient.tsx
+++ b/app/_components/ReviewContextClient.tsx
@@ -9,13 +9,63 @@ import TypeBadge from './TypeBadge';
 import TriageButtons from './TriageButtons';
 import ReviewMarkersMap from './ReviewMarkersMap';
 import AccommodationReviewLayout from './AccommodationReviewLayout';
+import TripPlanningWidget from './TripPlanningWidget';
 
 type Tab = 'unreviewed' | 'saved' | 'dismissed';
 
+export interface TravelData {
+  outbound?: {
+    date: string;
+    flight: string;
+    operator?: string;
+    aircraft?: string;
+    from: string;
+    to: string;
+    terminal?: string;
+    departs: string;
+    arrives: string;
+    cabin?: string;
+    duration?: string;
+  };
+  return?: {
+    date: string;
+    flight: string;
+    operator?: string;
+    aircraft?: string;
+    from: string;
+    to: string;
+    terminal?: string;
+    departs: string;
+    arrives: string;
+    cabin?: string;
+    duration?: string;
+  };
+}
+
+export interface AccommodationData {
+  name: string;
+  address?: string;
+  status?: string;
+}
+
+export interface PeopleData {
+  name: string;
+  relation?: string;
+  base?: string;
+  note?: string;
+}
+
 interface ReviewContextClientProps {
   userId: string;
+  contextKey: string;
   context: Context;
   discoveries: Discovery[];
+  // Trip-related props (passed when contextKey starts with 'trip:')
+  travel?: TravelData;
+  accommodation?: AccommodationData;
+  bookingStatus?: string;
+  purpose?: string;
+  people?: PeopleData[];
 }
 
 // Cache for place card coordinates (loaded lazily)
@@ -55,8 +105,14 @@ function timeAgo(dateStr: string | undefined | null): string | null {
 
 export default function ReviewContextClient({
   userId,
+  contextKey,
   context,
   discoveries,
+  travel,
+  accommodation,
+  bookingStatus,
+  purpose,
+  people,
 }: ReviewContextClientProps) {
   const [tab, setTab] = useState<Tab>('unreviewed');
   // triageKey changes when triage state changes — forces memo/state recompute
@@ -189,6 +245,22 @@ export default function ReviewContextClient({
           </p>
         )}
       </div>
+
+      {/* Trip Planning Widget — only show for trip contexts */}
+      {contextKey.startsWith('trip:') && (
+        <div style={{ marginBottom: '16px' }}>
+          <TripPlanningWidget
+            userId={userId}
+            contextKey={contextKey}
+            travel={travel}
+            accommodation={accommodation}
+            bookingStatus={bookingStatus}
+            savedCount={counts.saved}
+            purpose={purpose}
+            people={people}
+          />
+        </div>
+      )}
 
       {/* Markers map — show all unreviewed places as pins, no route */}
       {!useAccommodationLayout && filtered.length > 0 && tab === 'unreviewed' && (

--- a/app/review/[contextKey]/page.tsx
+++ b/app/review/[contextKey]/page.tsx
@@ -2,7 +2,7 @@ import { readFileSync, existsSync } from 'fs';
 import path from 'path';
 import { getCurrentUser } from '../../_lib/user';
 import { getUserManifest, getUserDiscoveries } from '../../_lib/user-data';
-import ReviewContextClient from '../../_components/ReviewContextClient';
+import ReviewContextClient, { TravelData, AccommodationData, PeopleData } from '../../_components/ReviewContextClient';
 
 function loadSharedManifest() {
   try {
@@ -59,11 +59,23 @@ export default async function ReviewContextPage({ params }: Props) {
     );
   }
 
+  // Check if this is a trip context - pass through trip-related props
+  const isTripContext = contextKey.startsWith('trip:');
+  const tripProps = isTripContext ? {
+    travel: context.travel as TravelData | undefined,
+    accommodation: context.accommodation as AccommodationData | undefined,
+    bookingStatus: context.bookingStatus as string | undefined,
+    purpose: context.purpose as string | undefined,
+    people: context.people as PeopleData[] | undefined,
+  } : undefined;
+
   return (
     <ReviewContextClient
       userId={user.id}
+      contextKey={contextKey}
       context={context}
       discoveries={discoveries}
+      {...tripProps}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Pass trip-related props (travel, accommodation, bookingStatus, purpose, people) from review page to client component
- Add TripPlanningWidget to ReviewContextClient, rendered only for trip contexts (contextKey starts with 'trip:')
- Export shared types (TravelData, AccommodationData, PeopleData) from ReviewContextClient

## Test plan
- [ ] Build passes: `npx next build`
- [ ] Tests pass: `npx playwright test`
- [ ] Navigate to a trip context review page (e.g., /review/trip:nyc-april-2026) and verify TripPlanningWidget appears above the tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)