### PR TITLE
fix: switch chat web search from Brave to Google Custom Search (#188)

### DIFF
--- a/app/_lib/chat/tools/web-search.ts
+++ b/app/_lib/chat/tools/web-search.ts
@@ -15,24 +15,23 @@ export interface WebSearchResult {
  * @returns Formatted search results or error message
  */
 export async function braveSearch(query: string): Promise<string> {
-  const apiKey = process.env.BRAVE_SEARCH_API_KEY;
-  if (!apiKey) {
+  const apiKey = process.env.GOOGLE_API_KEY || process.env.GOOGLE_PLACES_API_KEY || process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY;
+  const cseId = process.env.GOOGLE_CSE_ID;
+  if (!apiKey || !cseId) {
     // Stub - return placeholder when no API key
-    return `🔍 Web search not configured. (Query: "${query}")\n\nTo enable web search, add BRAVE_SEARCH_API_KEY to your environment.`;
+    return `🔍 Web search not configured. (Query: "${query}")\n\nTo enable web search, add GOOGLE_API_KEY and GOOGLE_CSE_ID to your environment.`;
   }
 
   try {
-    const url = `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}&count=5`;
-    const res = await fetch(url, {
-      headers: { 'X-Subscription-Token': apiKey, Accept: 'application/json' },
-    });
+    const url = `https://www.googleapis.com/customsearch/v1?key=${apiKey}&cx=${cseId}&q=${encodeURIComponent(query)}&num=5`;
+    const res = await fetch(url);
     if (!res.ok) return `Search error: ${res.status}`;
     const data = await res.json();
-    const results = (data.web?.results || []).slice(0, 5);
+    const results = (data.items || []).slice(0, 5);
     if (results.length === 0) return 'No results found.';
     return results
-      .map((r: WebSearchResult, i: number) =>
-        `${i + 1}. ${r.title}\n   ${r.url}\n   ${r.description}`
+      .map((r: { title: string; link: string; snippet: string }, i: number) =>
+        `${i + 1}. ${r.title}\n   ${r.link}\n   ${r.snippet}`
       )
       .join('\n\n');
   } catch (e) {


### PR DESCRIPTION
## Problem
Chat web search was using Brave Search API but no API key was ever configured, so search always returned 'not configured'.

## Fix
Swapped to Google Custom Search API which uses the same Google API key we already have:
- Endpoint: `googleapis.com/customsearch/v1`
- Key: `GOOGLE_API_KEY` (falls back to `GOOGLE_PLACES_API_KEY` / `NEXT_PUBLIC_GOOGLE_MAPS_KEY`)
- CSE ID: new `GOOGLE_CSE_ID` env var needed

## Action needed
Add `GOOGLE_CSE_ID` to Vercel env vars. Create a Custom Search Engine at https://cse.google.com (set to search the whole web) and use the `cx` ID.

## Changes
- `app/_lib/chat/tools/web-search.ts` — 1 file, 9 insertions, 10 deletions

Closes #188