### PR TITLE
Hide empty homepage contexts

### DIFF
--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -14,6 +14,7 @@ interface HomeClientProps {
   contexts: Context[];
   discoveryMap: Record<string, Discovery[]>;
   contextMeta?: Record<string, { travel?: unknown; accommodation?: unknown; bookingStatus?: string }>;
+  hasHiddenEmptyContexts?: boolean;
 }
 
 const TYPE_EMOJI: Record<string, string> = {
@@ -115,6 +116,7 @@ export default function HomeClient({
   contexts,
   discoveryMap,
   contextMeta = {},
+  hasHiddenEmptyContexts = false,
 }: HomeClientProps) {
   // Mounted state to avoid hydration mismatch from localStorage reads
   const [mounted, setMounted] = useState(false);
@@ -148,7 +150,11 @@ export default function HomeClient({
       <main className="page">
         <div className="page-header">
           <h1>🧭 Compass</h1>
-          <p>No active contexts yet. Chat with the concierge to set up your first trip, outing, or radar.</p>
+          <p>
+            {hasHiddenEmptyContexts
+              ? 'No discovery-ready contexts yet. Active contexts stay hidden until Compass has places to show.'
+              : 'No active contexts yet. Chat with the concierge to set up your first trip, outing, or radar.'}
+          </p>
         </div>
       </main>
     );

--- a/app/_components/PlaceCard.tsx
+++ b/app/_components/PlaceCard.tsx
@@ -105,6 +105,9 @@ export default function PlaceCard({ discovery, contextKey, userId }: PlaceCardPr
               <span className="rating-placeholder">&nbsp;</span>
             )}
           </div>
+          {discovery.rankingExplanation && (
+            <div className="place-card-explanation">Why now: {discovery.rankingExplanation}</div>
+          )}
         </div>
       </Link>
       {mapsUrl && (

--- a/app/_components/PlaceCard.tsx
+++ b/app/_components/PlaceCard.tsx
@@ -6,6 +6,7 @@ import type { Discovery } from '../_lib/types';
 import TypeBadge from './TypeBadge';
 import TriageButtons from './TriageButtons';
 import { resolveImageUrlClient } from '../_lib/image-url';
+import { getMonitoringExplanation, getMonitorStatusLabel } from '../_lib/discovery-monitoring';
 
 interface PlaceCardProps {
   discovery: Discovery;
@@ -70,6 +71,7 @@ export default function PlaceCard({ discovery, contextKey, userId }: PlaceCardPr
   const mapsUrl = place_id
     ? `https://www.google.com/maps/place/?q=place_id:${place_id}`
     : null;
+  const monitorExplanation = getMonitoringExplanation(discovery);
 
   return (
     <div style={{ position: 'relative' }}>
@@ -107,6 +109,11 @@ export default function PlaceCard({ discovery, contextKey, userId }: PlaceCardPr
           </div>
           {discovery.rankingExplanation && (
             <div className="place-card-explanation">Why now: {discovery.rankingExplanation}</div>
+          )}
+          {discovery.monitorStatus && discovery.monitorStatus !== 'none' && monitorExplanation && (
+            <div className="place-card-monitoring">
+              Monitoring: {getMonitorStatusLabel(discovery.monitorStatus)} · {monitorExplanation}
+            </div>
           )}
         </div>
       </Link>

--- a/app/_components/PlaceCardDetail.tsx
+++ b/app/_components/PlaceCardDetail.tsx
@@ -1,18 +1,18 @@
 'use client';
 
 import { useState } from 'react';
-import type { PlaceCard, DiscoveryType, Discovery } from '../_lib/types';
+import type { PlaceCard, Discovery } from '../_lib/types';
 import { getTypeMeta } from '../_lib/discovery-types';
 import { resolveImageUrlClient } from '../_lib/image-url';
 import TriageWidget from './TriageWidget';
 import ProvenanceSection from './ProvenanceSection';
-import RatingWidget from './widgets/RatingWidget';
 import HoursWidget from './widgets/HoursWidget';
 import MapWidget from './widgets/MapWidget';
 import PhotoGallery from './widgets/PhotoGallery';
 import TravelIntelWidget from './widgets/TravelIntelWidget';
 import { scoreDiscovery } from '../_lib/discovery-score';
 import type { ScoreBreakdown } from '../_lib/discovery-score';
+import { getMonitoringExplanation, getMonitorStatusLabel } from '../_lib/discovery-monitoring';
 
 /* ---- Share button ---- */
 function ShareButton({ name }: { name: string }) {
@@ -258,6 +258,7 @@ export default function PlaceCardDetail({ card, userId, contextKey, discovery }:
   const googleMapsUrl = card.place_id
     ? `https://www.google.com/maps/place/?q=place_id:${card.place_id}`
     : null;
+  const monitoringExplanation = discovery ? getMonitoringExplanation(discovery) : null;
 
   // Google Earth 3D link — useful for spatial context on outdoor/area types
   const EARTH_TYPES = new Set(['accommodation', 'neighbourhood', 'park', 'architecture', 'experience', 'development']);
@@ -406,6 +407,27 @@ export default function PlaceCardDetail({ card, userId, contextKey, discovery }:
         {narrativeBlocks.filter(b => /vibe|review/i.test(normalizeBlockTitle(b.title))).map((block, i) => (
           <NarrativeBlock key={`vibe-${i}`} title={block.title} body={block.body} truncate={2} />
         ))}
+
+        {discovery?.monitorStatus && discovery.monitorStatus !== 'none' && monitoringExplanation && (
+          <section className="monitoring-note">
+            <div className="monitoring-note-header">
+              <span className="monitoring-note-kicker">Monitoring</span>
+              <span className={`monitoring-note-status monitoring-note-status-${discovery.monitorStatus}`}>
+                {getMonitorStatusLabel(discovery.monitorStatus)}
+              </span>
+            </div>
+            <p className="monitoring-note-body">{monitoringExplanation}</p>
+            {discovery.monitorDimensions && discovery.monitorDimensions.length > 0 && (
+              <ul className="monitoring-note-list">
+                {discovery.monitorDimensions.slice(0, 4).map((dimension) => (
+                  <li key={dimension.key}>
+                    <strong>{dimension.label}:</strong> {dimension.description}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        )}
 
         {/* Provenance section — why this place was recommended */}
         {discovery && discovery.source && (

--- a/app/_lib/discovery-history.ts
+++ b/app/_lib/discovery-history.ts
@@ -51,6 +51,13 @@ export function getDiscoveryHistoryKey(discovery: Partial<Discovery>): string {
   return `name:${normalizeName(discovery.name)}:${discovery.contextKey || ''}`;
 }
 
+export function getDiscoveryInventoryKey(discovery: Partial<Discovery>): string {
+  if (discovery.place_id && discovery.contextKey) return `place:${discovery.place_id}:${discovery.contextKey}`;
+  if (discovery.name && discovery.contextKey) return `name:${normalizeName(discovery.name)}:${discovery.contextKey}`;
+  if (discovery.id) return `id:${discovery.id}`;
+  return getDiscoveryHistoryKey(discovery);
+}
+
 function toRemovedItem(discovery: Discovery): DiscoveryHistoryRemovedItem {
   return {
     key: getDiscoveryHistoryKey(discovery),
@@ -187,17 +194,58 @@ export async function getRecentDiscoveryObservations(
   return observations;
 }
 
-export async function deriveDiscoveryQueueFromHistory(userId: string, historyLimit = 50): Promise<Discovery[]> {
-  const events = await listRecentDiscoveryHistory(userId, historyLimit);
+function discoveryRecency(discovery: Partial<Discovery>, fallbackTimestamp?: string): number {
+  const timestamp = discovery.discoveredAt || fallbackTimestamp;
+  const time = timestamp ? new Date(timestamp).getTime() : 0;
+  return Number.isFinite(time) ? time : 0;
+}
+
+function mergeLatestDiscovery(
+  latestByKey: Map<string, Discovery>,
+  discovery: Discovery,
+  options: { preserveExisting?: boolean } = {},
+): void {
+  const key = getDiscoveryInventoryKey(discovery);
+  const existing = latestByKey.get(key);
+
+  if (!existing) {
+    latestByKey.set(key, discovery);
+    return;
+  }
+
+  if (options.preserveExisting) {
+    return;
+  }
+
+  if (discoveryRecency(discovery) >= discoveryRecency(existing)) {
+    latestByKey.set(key, discovery);
+  }
+}
+
+export async function deriveDiscoveryInventory(params: {
+  userId: string;
+  currentDiscoveries?: Discovery[];
+  historyLimit?: number;
+}): Promise<Discovery[]> {
+  const { userId, currentDiscoveries = [], historyLimit = 50 } = params;
   const latestByKey = new Map<string, Discovery>();
 
-  for (const event of [...events].reverse()) {
-    for (const discovery of [...event.added, ...event.updated]) {
-      latestByKey.set(getDiscoveryHistoryKey(discovery), discovery);
+  for (const discovery of currentDiscoveries) {
+    mergeLatestDiscovery(latestByKey, discovery);
+  }
+
+  const events = await listRecentDiscoveryHistory(userId, historyLimit);
+  for (const event of events) {
+    for (const discovery of [...event.updated, ...event.added]) {
+      mergeLatestDiscovery(latestByKey, discovery, { preserveExisting: true });
     }
   }
 
   return Array.from(latestByKey.values()).sort((a, b) =>
-    new Date(b.discoveredAt).getTime() - new Date(a.discoveredAt).getTime(),
+    discoveryRecency(b) - discoveryRecency(a),
   );
+}
+
+export async function deriveDiscoveryQueueFromHistory(userId: string, historyLimit = 50): Promise<Discovery[]> {
+  return deriveDiscoveryInventory({ userId, historyLimit });
 }

--- a/app/_lib/discovery-history.ts
+++ b/app/_lib/discovery-history.ts
@@ -1,0 +1,203 @@
+import { list, put } from '@vercel/blob';
+import type { Discovery } from './types';
+
+const BLOB_PREFIX = 'users';
+const DISCOVERY_HISTORY_VERSION = 1;
+
+export interface DiscoveryHistoryRemovedItem {
+  key: string;
+  id?: string;
+  place_id?: string;
+  name: string;
+  contextKey: string;
+}
+
+export interface DiscoveryHistoryEvent {
+  version: number;
+  eventId: string;
+  userId: string;
+  recordedAt: string;
+  source: string;
+  previousCount: number;
+  nextCount: number;
+  added: Discovery[];
+  updated: Discovery[];
+  removed: DiscoveryHistoryRemovedItem[];
+  contextKeys: string[];
+}
+
+export interface DiscoveryObservation {
+  recordedAt: string;
+  source: string;
+  change: 'added' | 'updated';
+  discovery: Discovery;
+}
+
+function historyPrefix(userId: string): string {
+  return `${BLOB_PREFIX}/${userId}/discovery-history/`;
+}
+
+function safeSourceSegment(source: string): string {
+  return source.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 48) || 'write';
+}
+
+function normalizeName(name: string | undefined): string {
+  return (name || '').toLowerCase().replace(/[^a-z0-9 ]/g, '').replace(/\s+/g, ' ').trim();
+}
+
+export function getDiscoveryHistoryKey(discovery: Partial<Discovery>): string {
+  if (discovery.id) return `id:${discovery.id}`;
+  if (discovery.place_id && discovery.contextKey) return `place:${discovery.place_id}:${discovery.contextKey}`;
+  return `name:${normalizeName(discovery.name)}:${discovery.contextKey || ''}`;
+}
+
+function toRemovedItem(discovery: Discovery): DiscoveryHistoryRemovedItem {
+  return {
+    key: getDiscoveryHistoryKey(discovery),
+    id: discovery.id,
+    place_id: discovery.place_id,
+    name: discovery.name,
+    contextKey: discovery.contextKey,
+  };
+}
+
+function isSameDiscovery(a: Discovery, b: Discovery): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function diffDiscoveries(previous: Discovery[], next: Discovery[]) {
+  const previousByKey = new Map(previous.map((d) => [getDiscoveryHistoryKey(d), d]));
+  const nextByKey = new Map(next.map((d) => [getDiscoveryHistoryKey(d), d]));
+
+  const added: Discovery[] = [];
+  const updated: Discovery[] = [];
+  const removed: DiscoveryHistoryRemovedItem[] = [];
+
+  for (const [key, discovery] of nextByKey) {
+    const existing = previousByKey.get(key);
+    if (!existing) {
+      added.push(discovery);
+      continue;
+    }
+    if (!isSameDiscovery(existing, discovery)) {
+      updated.push(discovery);
+    }
+  }
+
+  for (const [key, discovery] of previousByKey) {
+    if (!nextByKey.has(key)) {
+      removed.push(toRemovedItem(discovery));
+    }
+  }
+
+  return { added, updated, removed };
+}
+
+export async function recordDiscoveryHistoryEvent(params: {
+  userId: string;
+  source: string;
+  previous: Discovery[];
+  next: Discovery[];
+}): Promise<DiscoveryHistoryEvent | null> {
+  const { userId, source, previous, next } = params;
+  const { added, updated, removed } = diffDiscoveries(previous, next);
+
+  if (added.length === 0 && updated.length === 0 && removed.length === 0) {
+    return null;
+  }
+
+  const recordedAt = new Date().toISOString();
+  const stamp = Date.now();
+  const eventId = `dhe_${stamp}_${Math.random().toString(36).slice(2, 8)}`;
+  const event: DiscoveryHistoryEvent = {
+    version: DISCOVERY_HISTORY_VERSION,
+    eventId,
+    userId,
+    recordedAt,
+    source,
+    previousCount: previous.length,
+    nextCount: next.length,
+    added,
+    updated,
+    removed,
+    contextKeys: Array.from(new Set([...added, ...updated].map((d) => d.contextKey).filter(Boolean))).sort(),
+  };
+
+  const blobPath = `${historyPrefix(userId)}${stamp}-${safeSourceSegment(source)}.json`;
+  await put(blobPath, JSON.stringify(event, null, 2), {
+    access: 'public',
+    contentType: 'application/json',
+    addRandomSuffix: false,
+  });
+
+  return event;
+}
+
+export async function listRecentDiscoveryHistory(userId: string, limit = 20): Promise<DiscoveryHistoryEvent[]> {
+  const { blobs } = await list({ prefix: historyPrefix(userId), limit: Math.max(limit, 20) });
+  const sorted = [...blobs].sort((a, b) => b.pathname.localeCompare(a.pathname)).slice(0, limit);
+
+  const events = await Promise.all(sorted.map(async (blob) => {
+    try {
+      const res = await fetch(blob.url, { cache: 'no-store' });
+      if (!res.ok) return null;
+      return (await res.json()) as DiscoveryHistoryEvent;
+    } catch {
+      return null;
+    }
+  }));
+
+  return events.filter((event): event is DiscoveryHistoryEvent => Boolean(event));
+}
+
+export async function getRecentDiscoveryObservations(
+  userId: string,
+  options: {
+    placeId?: string;
+    name?: string;
+    contextKey?: string;
+    limit?: number;
+    historyLimit?: number;
+  } = {},
+): Promise<DiscoveryObservation[]> {
+  const { placeId, name, contextKey, limit = 10, historyLimit = 20 } = options;
+  const normalizedName = normalizeName(name);
+  const events = await listRecentDiscoveryHistory(userId, historyLimit);
+  const observations: DiscoveryObservation[] = [];
+
+  for (const event of events) {
+    for (const change of ['added', 'updated'] as const) {
+      for (const discovery of event[change]) {
+        if (placeId && discovery.place_id !== placeId) continue;
+        if (contextKey && discovery.contextKey !== contextKey) continue;
+        if (normalizedName && normalizeName(discovery.name) !== normalizedName) continue;
+        observations.push({
+          recordedAt: event.recordedAt,
+          source: event.source,
+          change,
+          discovery,
+        });
+        if (observations.length >= limit) {
+          return observations;
+        }
+      }
+    }
+  }
+
+  return observations;
+}
+
+export async function deriveDiscoveryQueueFromHistory(userId: string, historyLimit = 50): Promise<Discovery[]> {
+  const events = await listRecentDiscoveryHistory(userId, historyLimit);
+  const latestByKey = new Map<string, Discovery>();
+
+  for (const event of [...events].reverse()) {
+    for (const discovery of [...event.added, ...event.updated]) {
+      latestByKey.set(getDiscoveryHistoryKey(discovery), discovery);
+    }
+  }
+
+  return Array.from(latestByKey.values()).sort((a, b) =>
+    new Date(b.discoveredAt).getTime() - new Date(a.discoveredAt).getTime(),
+  );
+}

--- a/app/_lib/discovery-monitoring.ts
+++ b/app/_lib/discovery-monitoring.ts
@@ -1,0 +1,331 @@
+import { list } from '@vercel/blob';
+import type {
+  Context,
+  ContextTriage,
+  Discovery,
+  MonitorDimension,
+  MonitorReason,
+  MonitorStatus,
+  TriageStore,
+} from './types';
+import { getDiscoveryHistoryKey, listRecentDiscoveryHistory } from './discovery-history';
+
+const BLOB_PREFIX = 'users';
+const MONITOR_HISTORY_LIMIT = 60;
+const RECENT_WINDOW_DAYS = 45;
+
+type MonitorType = NonNullable<Discovery['monitorType']>;
+
+interface ObservationSummary {
+  count: number;
+  recentCount: number;
+  distinctSources: number;
+}
+
+interface TriageSummary {
+  savedCount: number;
+  dismissedCount: number;
+  resurfacedCount: number;
+}
+
+const MONITOR_REASON_LABELS: Record<MonitorReason, string> = {
+  saved: 'saved',
+  contentious: 'contentious',
+  'repeated-signal': 'repeated signal',
+  'live-trip': 'live trip',
+  volatile: 'volatile',
+  shortlist: 'shortlist',
+};
+
+const TYPE_DIMENSIONS: Record<MonitorType, MonitorDimension[]> = {
+  hospitality: [
+    { key: 'reservations', label: 'Reservations', description: 'Watch bookability, release windows, and sell-out pressure.' },
+    { key: 'hours', label: 'Hours', description: 'Track service days, seasonal closures, and late changes.' },
+    { key: 'menu', label: 'Menu / drinks', description: 'Notice chef, menu, or bar-program shifts that change the reason to go.' },
+    { key: 'buzz', label: 'Buzz', description: 'Monitor awards, critical heat, and repeat mention momentum.' },
+  ],
+  stay: [
+    { key: 'availability', label: 'Availability', description: 'Track open nights, sold-out weekends, and release timing.' },
+    { key: 'pricing', label: 'Pricing', description: 'Watch rate drift, packages, and shoulder-season opportunities.' },
+    { key: 'policies', label: 'Policies', description: 'Notice cancellation, minimum-stay, and pet/guest rule changes.' },
+    { key: 'condition', label: 'Condition', description: 'Track renovation, amenity, and seasonal suitability updates.' },
+  ],
+  development: [
+    { key: 'timeline', label: 'Timeline', description: 'Watch approvals, launch timing, occupancy, and completion slips.' },
+    { key: 'pricing', label: 'Pricing / sales', description: 'Track price sheets, incentives, and absorption signals.' },
+    { key: 'design', label: 'Design / amenities', description: 'Notice material, amenity, or architect-story changes.' },
+    { key: 'construction', label: 'Construction', description: 'Monitor visible progress and major permitting milestones.' },
+  ],
+  culture: [
+    { key: 'program', label: 'Program', description: 'Track exhibitions, lineups, residencies, and event calendars.' },
+    { key: 'tickets', label: 'Tickets', description: 'Watch release dates, timed-entry pressure, and sellouts.' },
+    { key: 'hours', label: 'Hours', description: 'Notice closure days, special openings, and seasonal schedule changes.' },
+    { key: 'news', label: 'News', description: 'Watch curator, artist, and venue announcements that change relevance.' },
+  ],
+  general: [
+    { key: 'status', label: 'Status', description: 'Monitor whether the place is becoming more actionable or more uncertain.' },
+    { key: 'signal', label: 'Signal strength', description: 'Watch whether it keeps resurfacing from independent inputs.' },
+  ],
+};
+
+function triageBlobPath(userId: string) {
+  return `${BLOB_PREFIX}/${userId}/triage.json`;
+}
+
+async function loadServerTriageStore(userId: string): Promise<TriageStore> {
+  try {
+    const { blobs } = await list({ prefix: triageBlobPath(userId), limit: 1 });
+    const blob = blobs[0];
+    if (!blob) return {};
+    const res = await fetch(blob.url, { cache: 'no-store' });
+    if (!res.ok) return {};
+    return (await res.json()) as TriageStore;
+  } catch {
+    return {};
+  }
+}
+
+function normalizeToken(value: string | undefined): string {
+  return (value || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+function daysAgo(iso: string | undefined): number {
+  if (!iso) return Number.POSITIVE_INFINITY;
+  const time = new Date(iso).getTime();
+  if (!Number.isFinite(time)) return Number.POSITIVE_INFINITY;
+  return (Date.now() - time) / (1000 * 60 * 60 * 24);
+}
+
+function placeLookupKeys(discovery: Discovery): string[] {
+  const keys = new Set<string>();
+  if (discovery.place_id) keys.add(`place:${discovery.place_id}`);
+  keys.add(`history:${getDiscoveryHistoryKey(discovery)}`);
+  if (discovery.name) keys.add(`name:${normalizeToken(discovery.name)}`);
+  return Array.from(keys);
+}
+
+function getMonitorType(discovery: Discovery): MonitorType {
+  if (['restaurant', 'bar', 'cafe'].includes(discovery.type)) return 'hospitality';
+  if (['hotel', 'accommodation'].includes(discovery.type)) return 'stay';
+  if (discovery.type === 'development') return 'development';
+  if (['museum', 'gallery', 'theatre', 'music-venue', 'experience'].includes(discovery.type)) return 'culture';
+  return 'general';
+}
+
+function getMonitorDimensions(discovery: Discovery): MonitorDimension[] {
+  return TYPE_DIMENSIONS[getMonitorType(discovery)] ?? TYPE_DIMENSIONS.general;
+}
+
+function summarizeObservations(discoveries: Discovery[], historyEvents: Awaited<ReturnType<typeof listRecentDiscoveryHistory>>) {
+  const summary = new Map<string, ObservationSummary>();
+  const seenSources = new Map<string, Set<string>>();
+
+  const ensure = (key: string) => {
+    const current = summary.get(key);
+    if (current) return current;
+    const created: ObservationSummary = { count: 0, recentCount: 0, distinctSources: 0 };
+    summary.set(key, created);
+    return created;
+  };
+
+  for (const discovery of discoveries) {
+    const key = getDiscoveryHistoryKey(discovery);
+    ensure(key);
+    seenSources.set(key, new Set<string>());
+  }
+
+  for (const event of historyEvents) {
+    const isRecent = daysAgo(event.recordedAt) <= RECENT_WINDOW_DAYS;
+    for (const discovery of [...event.added, ...event.updated]) {
+      const key = getDiscoveryHistoryKey(discovery);
+      const item = ensure(key);
+      item.count += 1;
+      if (isRecent) item.recentCount += 1;
+      const sources = seenSources.get(key) ?? new Set<string>();
+      sources.add(event.source);
+      seenSources.set(key, sources);
+    }
+  }
+
+  for (const [key, sources] of seenSources) {
+    const item = ensure(key);
+    item.distinctSources = sources.size;
+  }
+
+  return summary;
+}
+
+function summarizeTriageForDiscovery(discovery: Discovery, triageStore: TriageStore): TriageSummary {
+  const keys = placeLookupKeys(discovery);
+  let savedCount = 0;
+  let dismissedCount = 0;
+  let resurfacedCount = 0;
+
+  for (const [contextKey, context] of Object.entries(triageStore)) {
+    const ctx = context as ContextTriage;
+    const triageEntries = Object.entries(ctx.triage ?? {});
+    const matching = triageEntries.filter(([placeId]) => {
+      if (discovery.place_id && placeId === discovery.place_id) return true;
+      const seen = ctx.seen?.[placeId];
+      if (!seen) return false;
+      return keys.includes(`name:${normalizeToken(seen.name)}`)
+        || keys.includes(`history:${getDiscoveryHistoryKey({
+          id: placeId,
+          place_id: placeId,
+          name: seen.name,
+          city: seen.city,
+          type: seen.type,
+          contextKey,
+          source: 'triage:seen',
+          discoveredAt: seen.firstSeen,
+          placeIdStatus: 'verified',
+        })}`);
+    });
+
+    for (const [, entry] of matching) {
+      if (entry.state === 'saved') savedCount += 1;
+      if (entry.state === 'dismissed') dismissedCount += 1;
+      if (entry.state === 'resurfaced') resurfacedCount += 1;
+    }
+  }
+
+  return { savedCount, dismissedCount, resurfacedCount };
+}
+
+function inferVolatileReason(discovery: Discovery, activeTripRelevant: boolean): boolean {
+  if (['hotel', 'accommodation', 'development'].includes(discovery.type)) return true;
+  if (activeTripRelevant && ['restaurant', 'bar', 'cafe', 'museum', 'gallery', 'theatre', 'music-venue'].includes(discovery.type)) {
+    return true;
+  }
+  return false;
+}
+
+function pushReason(reasons: MonitorReason[], reason: MonitorReason) {
+  if (!reasons.includes(reason)) reasons.push(reason);
+}
+
+function scoreMonitoringCandidate(args: {
+  reasons: MonitorReason[];
+  triage: TriageSummary;
+  observation: ObservationSummary;
+  activeTripRelevant: boolean;
+  rankingScore?: number;
+}) {
+  const { reasons, triage, observation, activeTripRelevant, rankingScore } = args;
+  let score = 0;
+  if (reasons.includes('saved')) score += 4;
+  if (reasons.includes('live-trip')) score += 4;
+  if (reasons.includes('repeated-signal')) score += observation.recentCount >= 3 || observation.distinctSources >= 2 ? 3 : 2;
+  if (reasons.includes('contentious')) score += triage.resurfacedCount > 0 ? 3 : 2;
+  if (reasons.includes('shortlist')) score += (rankingScore ?? 0) >= 92 ? 3 : 2;
+  if (reasons.includes('volatile')) score += activeTripRelevant ? 2 : 1;
+  return score;
+}
+
+function toMonitorStatus(score: number): MonitorStatus {
+  if (score >= 9) return 'priority';
+  if (score >= 6) return 'active';
+  if (score >= 3) return 'candidate';
+  return 'none';
+}
+
+function summarizeReasons(reasons: MonitorReason[]): string {
+  return reasons.map((reason) => MONITOR_REASON_LABELS[reason]).slice(0, 3).join(' · ');
+}
+
+export function getMonitorStatusLabel(status: MonitorStatus | undefined): string {
+  switch (status) {
+    case 'candidate': return 'Candidate';
+    case 'active': return 'Active';
+    case 'priority': return 'Priority';
+    default: return 'None';
+  }
+}
+
+export function getMonitoringExplanation(discovery: Partial<Discovery>): string | null {
+  if (discovery.monitorExplanation) return discovery.monitorExplanation;
+  if (!discovery.monitorReasons?.length) return null;
+  return summarizeReasons(discovery.monitorReasons);
+}
+
+export async function annotateDiscoveriesForMonitoring(params: {
+  userId: string;
+  discoveries: Discovery[];
+  contexts: Context[];
+}): Promise<Discovery[]> {
+  const { userId, discoveries, contexts } = params;
+  const [triageStore, historyEvents] = await Promise.all([
+    loadServerTriageStore(userId),
+    listRecentDiscoveryHistory(userId, MONITOR_HISTORY_LIMIT),
+  ]);
+
+  const observations = summarizeObservations(discoveries, historyEvents);
+  const activeTripContextKeys = new Set(
+    contexts
+      .filter((context) => context.type === 'trip' && context.active !== false && context.status !== 'archived' && context.status !== 'completed')
+      .map((context) => context.key),
+  );
+
+  return discoveries.map((discovery) => {
+    const triage = summarizeTriageForDiscovery(discovery, triageStore);
+    const observation = observations.get(getDiscoveryHistoryKey(discovery)) ?? {
+      count: 0,
+      recentCount: 0,
+      distinctSources: 0,
+    };
+
+    const activeTripRelevant = activeTripContextKeys.has(discovery.contextKey);
+    const repeatedSignalStrong = observation.count >= 3 || observation.recentCount >= 2 || observation.distinctSources >= 2;
+    const contentious = triage.resurfacedCount > 0 || (triage.savedCount > 0 && triage.dismissedCount > 0);
+    const shortlist = (discovery.rankingScore ?? 0) >= 88 || ((discovery.rankingBaseScore ?? 0) >= 78 && repeatedSignalStrong);
+    const volatile = inferVolatileReason(discovery, activeTripRelevant);
+
+    const monitorReasons: MonitorReason[] = [];
+    if (triage.savedCount > 0) pushReason(monitorReasons, 'saved');
+    if (contentious) pushReason(monitorReasons, 'contentious');
+    if (repeatedSignalStrong) pushReason(monitorReasons, 'repeated-signal');
+    if (activeTripRelevant) pushReason(monitorReasons, 'live-trip');
+    if (shortlist) pushReason(monitorReasons, 'shortlist');
+    if (volatile && monitorReasons.length > 0) pushReason(monitorReasons, 'volatile');
+
+    const monitorScore = scoreMonitoringCandidate({
+      reasons: monitorReasons,
+      triage,
+      observation,
+      activeTripRelevant,
+      rankingScore: discovery.rankingScore,
+    });
+    const monitorStatus = toMonitorStatus(monitorScore);
+    const monitorType = getMonitorType(discovery);
+    const monitorDimensions = monitorStatus === 'none' ? undefined : getMonitorDimensions(discovery);
+
+    const explanationParts: string[] = [];
+    if (triage.savedCount > 0) explanationParts.push(triage.savedCount > 1 ? 'saved in multiple reviews' : 'saved already');
+    if (contentious) explanationParts.push(triage.resurfacedCount > 0 ? 'resurfaced / mixed signals' : 'split save-dismiss signal');
+    if (repeatedSignalStrong) explanationParts.push(
+      observation.distinctSources >= 2 ? 'keeps resurfacing across sources' : 'keeps resurfacing in discovery history',
+    );
+    if (activeTripRelevant) explanationParts.push('belongs to an active trip');
+    if (shortlist) explanationParts.push('scores like a shortlist contender');
+    if (volatile) explanationParts.push('has time-sensitive details worth watching');
+
+    return {
+      ...discovery,
+      monitorStatus,
+      monitorReasons,
+      monitorType,
+      monitorDimensions,
+      monitorSignals: {
+        savedCount: triage.savedCount,
+        dismissedCount: triage.dismissedCount,
+        resurfacedCount: triage.resurfacedCount,
+        observationCount: observation.count,
+        recentObservationCount: observation.recentCount,
+        distinctSourceCount: observation.distinctSources,
+        activeTripRelevant,
+        monitorScore,
+      },
+      monitorExplanation: monitorStatus === 'none' ? undefined : explanationParts.slice(0, 3).join(' · '),
+    };
+  });
+}

--- a/app/_lib/discovery-preferences.ts
+++ b/app/_lib/discovery-preferences.ts
@@ -1,0 +1,375 @@
+import { list } from '@vercel/blob';
+import type { Context, ContextTriage, Discovery, DiscoveryType, TriageEntry, TriageStore } from './types';
+import { getDiscoveryHistoryKey, listRecentDiscoveryHistory } from './discovery-history';
+
+const BLOB_PREFIX = 'users';
+const RECENT_WINDOW_DAYS = 45;
+const FRESH_DISCOVERY_DAYS = 21;
+
+interface WeightedDecision {
+  contextKey: string;
+  focusTokens: string[];
+  type: DiscoveryType;
+  state: TriageEntry['state'];
+  updatedAt: string;
+  weight: number;
+}
+
+interface PreferenceCounter {
+  saved: number;
+  dismissed: number;
+  recentSaved: number;
+  recentDismissed: number;
+}
+
+interface ObservationSummary {
+  count: number;
+  recentCount: number;
+  distinctSources: number;
+}
+
+export interface PreferenceSignalBreakdown {
+  samePlaceSignal: number;
+  typeAffinity: number;
+  contextAffinity: number;
+  repeatObservation: number;
+  emergingPreference: number;
+  total: number;
+  reasons: string[];
+}
+
+export interface RankedDiscovery extends Discovery {
+  rankingScore: number;
+  rankingBaseScore: number;
+  preferenceSignals: PreferenceSignalBreakdown;
+  rankingExplanation: string;
+}
+
+function triageBlobPath(userId: string) {
+  return `${BLOB_PREFIX}/${userId}/triage.json`;
+}
+
+async function loadServerTriageStore(userId: string): Promise<TriageStore> {
+  try {
+    const { blobs } = await list({ prefix: triageBlobPath(userId), limit: 1 });
+    const blob = blobs[0];
+    if (!blob) return {};
+    const res = await fetch(blob.url, { cache: 'no-store' });
+    if (!res.ok) return {};
+    return (await res.json()) as TriageStore;
+  } catch {
+    return {};
+  }
+}
+
+function normalizeToken(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+function getContextFocusTokens(context: Context | undefined): string[] {
+  if (!context) return [];
+  return Array.from(
+    new Set(
+      (context.focus ?? [])
+        .map(normalizeToken)
+        .filter(Boolean),
+    ),
+  );
+}
+
+function daysAgo(iso: string | undefined): number {
+  if (!iso) return Number.POSITIVE_INFINITY;
+  const time = new Date(iso).getTime();
+  if (!Number.isFinite(time)) return Number.POSITIVE_INFINITY;
+  return (Date.now() - time) / (1000 * 60 * 60 * 24);
+}
+
+function recencyWeight(updatedAt: string): number {
+  const ageDays = daysAgo(updatedAt);
+  if (ageDays <= 7) return 1.35;
+  if (ageDays <= 21) return 1.15;
+  if (ageDays <= 45) return 1;
+  if (ageDays <= 90) return 0.85;
+  return 0.7;
+}
+
+function addToCounter(counter: PreferenceCounter, state: TriageEntry['state'], weight: number, isRecent: boolean) {
+  if (state === 'saved') {
+    counter.saved += weight;
+    if (isRecent) counter.recentSaved += weight;
+    return;
+  }
+
+  if (state === 'dismissed') {
+    counter.dismissed += weight;
+    if (isRecent) counter.recentDismissed += weight;
+  }
+}
+
+function createCounter(): PreferenceCounter {
+  return {
+    saved: 0,
+    dismissed: 0,
+    recentSaved: 0,
+    recentDismissed: 0,
+  };
+}
+
+function signedPreference(counter: PreferenceCounter | undefined): number {
+  if (!counter) return 0;
+  const total = counter.saved + counter.dismissed;
+  if (total === 0) return 0;
+  return (counter.saved - counter.dismissed * 1.15) / (total + 0.75);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function placeLookupKeys(discovery: Discovery): string[] {
+  const keys = new Set<string>();
+  if (discovery.place_id) keys.add(`place:${discovery.place_id}`);
+  keys.add(`history:${getDiscoveryHistoryKey(discovery)}`);
+  if (discovery.name) keys.add(`name:${normalizeToken(discovery.name)}`);
+  return Array.from(keys);
+}
+
+function addPlaceDecisionIndex(index: Map<string, TriageEntry['state'][]>, discovery: Discovery, state: TriageEntry['state']) {
+  for (const key of placeLookupKeys(discovery)) {
+    const existing = index.get(key) ?? [];
+    existing.push(state);
+    index.set(key, existing);
+  }
+}
+
+function summarizePlaceStates(states: TriageEntry['state'][] | undefined): { saved: number; dismissed: number } {
+  let saved = 0;
+  let dismissed = 0;
+  for (const state of states ?? []) {
+    if (state === 'saved') saved += 1;
+    if (state === 'dismissed') dismissed += 1;
+  }
+  return { saved, dismissed };
+}
+
+function summarizeObservations(discoveries: Discovery[], historyEvents: Awaited<ReturnType<typeof listRecentDiscoveryHistory>>) {
+  const summary = new Map<string, ObservationSummary>();
+
+  const ensure = (key: string) => {
+    const current = summary.get(key);
+    if (current) return current;
+    const created: ObservationSummary = { count: 0, recentCount: 0, distinctSources: 0 };
+    summary.set(key, created);
+    return created;
+  };
+
+  const seenSources = new Map<string, Set<string>>();
+
+  for (const discovery of discoveries) {
+    const key = getDiscoveryHistoryKey(discovery);
+    ensure(key);
+    seenSources.set(key, new Set<string>());
+  }
+
+  for (const event of historyEvents) {
+    const isRecent = daysAgo(event.recordedAt) <= RECENT_WINDOW_DAYS;
+    for (const discovery of [...event.added, ...event.updated]) {
+      const key = getDiscoveryHistoryKey(discovery);
+      const item = ensure(key);
+      item.count += 1;
+      if (isRecent) item.recentCount += 1;
+      const sources = seenSources.get(key) ?? new Set<string>();
+      sources.add(event.source);
+      seenSources.set(key, sources);
+    }
+  }
+
+  for (const [key, sources] of seenSources) {
+    const item = ensure(key);
+    item.distinctSources = sources.size;
+  }
+
+  return summary;
+}
+
+function compactReason(parts: string[]): string {
+  return parts.filter(Boolean).slice(0, 3).join(' · ');
+}
+
+export async function rankDiscoveriesForHomepage(params: {
+  userId: string;
+  discoveries: Discovery[];
+  contexts: Context[];
+  baseScore: (discovery: Discovery) => number;
+}): Promise<RankedDiscovery[]> {
+  const { userId, discoveries, contexts, baseScore } = params;
+  const [triageStore, historyEvents] = await Promise.all([
+    loadServerTriageStore(userId),
+    listRecentDiscoveryHistory(userId, 60),
+  ]);
+
+  const contextByKey = new Map(contexts.map((context) => [context.key, context]));
+  const discoveryByPlaceId = new Map<string, Discovery>();
+  const discoveryByHistoryKey = new Map<string, Discovery>();
+  const discoveryByName = new Map<string, Discovery>();
+
+  for (const discovery of discoveries) {
+    if (discovery.place_id) discoveryByPlaceId.set(discovery.place_id, discovery);
+    discoveryByHistoryKey.set(getDiscoveryHistoryKey(discovery), discovery);
+    discoveryByName.set(normalizeToken(discovery.name), discovery);
+  }
+
+  for (const event of historyEvents) {
+    for (const discovery of [...event.added, ...event.updated]) {
+      if (discovery.place_id && !discoveryByPlaceId.has(discovery.place_id)) {
+        discoveryByPlaceId.set(discovery.place_id, discovery);
+      }
+      if (!discoveryByHistoryKey.has(getDiscoveryHistoryKey(discovery))) {
+        discoveryByHistoryKey.set(getDiscoveryHistoryKey(discovery), discovery);
+      }
+      const normalizedName = normalizeToken(discovery.name);
+      if (normalizedName && !discoveryByName.has(normalizedName)) {
+        discoveryByName.set(normalizedName, discovery);
+      }
+    }
+  }
+
+  const decisions: WeightedDecision[] = [];
+  const typeCounters = new Map<DiscoveryType, PreferenceCounter>();
+  const focusCounters = new Map<string, PreferenceCounter>();
+  const placeDecisionIndex = new Map<string, TriageEntry['state'][]>();
+
+  for (const [contextKey, ctx] of Object.entries(triageStore)) {
+    const context = contextByKey.get(contextKey);
+    const focusTokens = getContextFocusTokens(context);
+
+    for (const [placeId, entry] of Object.entries((ctx as ContextTriage).triage ?? {})) {
+      if (entry.state !== 'saved' && entry.state !== 'dismissed') continue;
+
+      const seenEntry = (ctx as ContextTriage).seen?.[placeId];
+      const discovery = discoveryByPlaceId.get(placeId)
+        ?? discoveryByHistoryKey.get(`place:${placeId}:${contextKey}`)
+        ?? (seenEntry ? {
+          id: placeId,
+          place_id: placeId,
+          name: seenEntry.name,
+          city: seenEntry.city,
+          type: seenEntry.type,
+          contextKey,
+          source: 'triage:seen',
+          discoveredAt: seenEntry.firstSeen,
+          placeIdStatus: 'verified' as const,
+        } : undefined)
+        ?? discoveryByName.get(normalizeToken(seenEntry?.name ?? ''));
+      if (!discovery) continue;
+
+      const decision: WeightedDecision = {
+        contextKey,
+        focusTokens,
+        type: discovery.type,
+        state: entry.state,
+        updatedAt: entry.updatedAt,
+        weight: recencyWeight(entry.updatedAt),
+      };
+      decisions.push(decision);
+
+      const isRecent = daysAgo(entry.updatedAt) <= RECENT_WINDOW_DAYS;
+      const typeCounter = typeCounters.get(discovery.type) ?? createCounter();
+      addToCounter(typeCounter, entry.state, decision.weight, isRecent);
+      typeCounters.set(discovery.type, typeCounter);
+
+      for (const token of focusTokens) {
+        const focusCounter = focusCounters.get(token) ?? createCounter();
+        addToCounter(focusCounter, entry.state, decision.weight, isRecent);
+        focusCounters.set(token, focusCounter);
+      }
+
+      addPlaceDecisionIndex(placeDecisionIndex, discovery, entry.state);
+    }
+  }
+
+  const observations = summarizeObservations(discoveries, historyEvents);
+
+  return discoveries
+    .map((discovery) => {
+      const rankingBaseScore = baseScore(discovery);
+      const reasons: string[] = [];
+
+      let samePlaceSignal = 0;
+      const placeStates = placeLookupKeys(discovery)
+        .flatMap((key) => placeDecisionIndex.get(key) ?? []);
+      const placeSummary = summarizePlaceStates(placeStates);
+      if (placeSummary.saved > 0) {
+        samePlaceSignal = Math.min(10, 6 + (placeSummary.saved - 1) * 2);
+        reasons.push(placeSummary.saved > 1 ? 'saved in multiple reviews' : 'saved before');
+      } else if (placeSummary.dismissed > 0) {
+        samePlaceSignal = -Math.min(10, 5 + (placeSummary.dismissed - 1) * 2);
+      }
+
+      const typeScoreRaw = signedPreference(typeCounters.get(discovery.type));
+      const typeAffinity = round1(clamp(typeScoreRaw * 12, -8, 12));
+      if (typeAffinity >= 3) reasons.push(`${discovery.type.replace(/-/g, ' ')} is a saved type`);
+
+      const currentFocusTokens = getContextFocusTokens(contextByKey.get(discovery.contextKey));
+      const focusScores = currentFocusTokens
+        .map((token) => signedPreference(focusCounters.get(token)))
+        .filter((value) => Math.abs(value) > 0.01);
+      const focusAverage = focusScores.length > 0
+        ? focusScores.reduce((sum, value) => sum + value, 0) / focusScores.length
+        : 0;
+      const contextAffinity = round1(clamp(focusAverage * 10, -6, 10));
+      if (contextAffinity >= 2.5 && currentFocusTokens.length > 0) {
+        reasons.push(`fits ${currentFocusTokens.slice(0, 2).join(' + ')} contexts`);
+      }
+
+      const observation = observations.get(getDiscoveryHistoryKey(discovery));
+      const repeatObservation = observation
+        ? round1(clamp(
+            Math.max(0, (observation.count - 1) * 1.8) + Math.max(0, (observation.distinctSources - 1) * 1.2),
+            0,
+            9,
+          ))
+        : 0;
+      if (repeatObservation >= 3) {
+        reasons.push(observation?.distinctSources && observation.distinctSources > 1
+          ? 'seen repeatedly across sources'
+          : 'seen repeatedly in discovery history');
+      }
+
+      const typeCounter = typeCounters.get(discovery.type);
+      const recentNet = (typeCounter?.recentSaved ?? 0) - (typeCounter?.recentDismissed ?? 0);
+      const lifetimeNet = (typeCounter?.saved ?? 0) - (typeCounter?.dismissed ?? 0);
+      const freshnessMultiplier = daysAgo(discovery.discoveredAt) <= FRESH_DISCOVERY_DAYS ? 1 : 0.45;
+      const emergingPreference = round1(clamp(
+        recentNet > 0
+          ? Math.min(8, (recentNet / Math.max(1, (Math.abs(lifetimeNet) + 1))) * 6 * freshnessMultiplier)
+          : 0,
+        0,
+        8,
+      ));
+      if (emergingPreference >= 2.5) reasons.push('matches a recent saving streak');
+
+      const preferenceSignals: PreferenceSignalBreakdown = {
+        samePlaceSignal,
+        typeAffinity,
+        contextAffinity,
+        repeatObservation,
+        emergingPreference,
+        total: round1(samePlaceSignal + typeAffinity + contextAffinity + repeatObservation + emergingPreference),
+        reasons,
+      };
+
+      return {
+        ...discovery,
+        rankingBaseScore,
+        rankingScore: round1(rankingBaseScore + preferenceSignals.total),
+        preferenceSignals,
+        rankingExplanation: compactReason(reasons),
+      } satisfies RankedDiscovery;
+    })
+    .sort((a, b) => b.rankingScore - a.rankingScore);
+}

--- a/app/_lib/homepage-contexts.ts
+++ b/app/_lib/homepage-contexts.ts
@@ -1,0 +1,39 @@
+import type { Context, Discovery } from './types';
+
+interface HomepageContextVisibilityParams {
+  contexts: Context[];
+  discoveryBuckets: ReadonlyMap<string, Discovery[]> | Record<string, Discovery[]>;
+}
+
+export interface HomepageContextVisibility {
+  visibleContexts: Context[];
+  hiddenEmptyContextCount: number;
+}
+
+function getBucket(
+  discoveryBuckets: HomepageContextVisibilityParams['discoveryBuckets'],
+  contextKey: string,
+): Discovery[] {
+  if (discoveryBuckets instanceof Map) {
+    return discoveryBuckets.get(contextKey) ?? [];
+  }
+
+  const recordBuckets = discoveryBuckets as Record<string, Discovery[]>;
+  return recordBuckets[contextKey] ?? [];
+}
+
+/**
+ * Homepage sections should stay decision-ready: only render contexts that have
+ * at least one discovery after all matching, deduping, and ranking has run.
+ */
+export function getHomepageContextVisibility({
+  contexts,
+  discoveryBuckets,
+}: HomepageContextVisibilityParams): HomepageContextVisibility {
+  const visibleContexts = contexts.filter((context) => getBucket(discoveryBuckets, context.key).length > 0);
+
+  return {
+    visibleContexts,
+    hiddenEmptyContextCount: contexts.length - visibleContexts.length,
+  };
+}

--- a/app/_lib/types.ts
+++ b/app/_lib/types.ts
@@ -118,6 +118,18 @@ export interface Discovery {
   verified?: boolean;    // verified via Google Places
   ratingCount?: number; // review count from Google Places
   description?: string; // Disco description
+  rankingScore?: number;
+  rankingBaseScore?: number;
+  rankingExplanation?: string;
+  preferenceSignals?: {
+    samePlaceSignal: number;
+    typeAffinity: number;
+    contextAffinity: number;
+    repeatObservation: number;
+    emergingPreference: number;
+    total: number;
+    reasons: string[];
+  };
 }
 
 export interface UserDiscoveries {

--- a/app/_lib/types.ts
+++ b/app/_lib/types.ts
@@ -93,6 +93,14 @@ export type DiscoveryType =
 // ---- Discoveries ----
 
 export type PlaceIdStatus = 'verified' | 'missing' | 'changed' | 'pending';
+export type MonitorStatus = 'none' | 'candidate' | 'active' | 'priority';
+export type MonitorReason = 'saved' | 'contentious' | 'repeated-signal' | 'live-trip' | 'volatile' | 'shortlist';
+
+export interface MonitorDimension {
+  key: string;
+  label: string;
+  description: string;
+}
 
 export interface Discovery {
   id: string;
@@ -130,6 +138,21 @@ export interface Discovery {
     total: number;
     reasons: string[];
   };
+  monitorStatus?: MonitorStatus;
+  monitorReasons?: MonitorReason[];
+  monitorType?: 'hospitality' | 'stay' | 'development' | 'culture' | 'general';
+  monitorDimensions?: MonitorDimension[];
+  monitorSignals?: {
+    savedCount: number;
+    dismissedCount: number;
+    resurfacedCount: number;
+    observationCount: number;
+    recentObservationCount: number;
+    distinctSourceCount: number;
+    activeTripRelevant: boolean;
+    monitorScore: number;
+  };
+  monitorExplanation?: string;
 }
 
 export interface UserDiscoveries {

--- a/app/_lib/user-data.ts
+++ b/app/_lib/user-data.ts
@@ -6,7 +6,8 @@
 import { put, list, del } from '@vercel/blob';
 import { readFileSync, existsSync } from 'fs';
 import path from 'path';
-import type { UserDocType, UserDocMap, UserProfile, UserPreferences, UserManifest, UserDiscoveries, UserChat } from './types';
+import type { Discovery, UserDocType, UserDocMap, UserProfile, UserPreferences, UserManifest, UserDiscoveries, UserChat } from './types';
+import { recordDiscoveryHistoryEvent } from './discovery-history';
 
 // Place card index cache (server-side only)
 let _placeCardIndex: Record<string, { name: string; type: string }> | null = null;
@@ -60,6 +61,7 @@ export async function setUserData<T extends UserDocType>(
   data: UserDocMap[T],
 ): Promise<void> {
   const blobPath = `${BLOB_PREFIX}/${userId}/${docType}.json`;
+  let previousDiscoveries: UserDiscoveries | null = null;
 
   // Snapshot current document before overwrite for recovery/audit.
   try {
@@ -69,6 +71,16 @@ export async function setUserData<T extends UserDocType>(
       const res = await fetch(existing.url);
       if (res.ok) {
         const existingText = await res.text();
+        if (docType === 'discoveries') {
+          try {
+            const parsed = JSON.parse(existingText) as UserDiscoveries | Discovery[];
+            previousDiscoveries = Array.isArray(parsed)
+              ? { discoveries: parsed, updatedAt: new Date().toISOString() }
+              : parsed;
+          } catch {
+            previousDiscoveries = null;
+          }
+        }
         const snapshotPath = `${BLOB_PREFIX}/${userId}/history/${docType}-${Date.now()}.json`;
         await put(snapshotPath, existingText, {
           access: 'public',
@@ -87,6 +99,20 @@ export async function setUserData<T extends UserDocType>(
     contentType: 'application/json',
     addRandomSuffix: false,
   });
+
+  if (docType === 'discoveries') {
+    try {
+      const nextDiscoveries = (data as UserDiscoveries).discoveries ?? [];
+      await recordDiscoveryHistoryEvent({
+        userId,
+        source: 'user-data:set',
+        previous: previousDiscoveries?.discoveries ?? [],
+        next: nextDiscoveries,
+      });
+    } catch {
+      // best-effort history only
+    }
+  }
 }
 
 // ---- Convenience methods ----

--- a/app/_lib/user-data.ts
+++ b/app/_lib/user-data.ts
@@ -7,7 +7,7 @@ import { put, list, del } from '@vercel/blob';
 import { readFileSync, existsSync } from 'fs';
 import path from 'path';
 import type { Discovery, UserDocType, UserDocMap, UserProfile, UserPreferences, UserManifest, UserDiscoveries, UserChat } from './types';
-import { recordDiscoveryHistoryEvent } from './discovery-history';
+import { deriveDiscoveryInventory, recordDiscoveryHistoryEvent } from './discovery-history';
 
 // Place card index cache (server-side only)
 let _placeCardIndex: Record<string, { name: string; type: string }> | null = null;
@@ -237,10 +237,7 @@ function normalizeContextKey(key: string | undefined | null): string {
   return k;
 }
 
-export async function getUserDiscoveries(userId: string): Promise<UserDiscoveries | null> {
-  const raw = await getUserData(userId, 'discoveries');
-  if (!raw) return null;
-
+function normalizeDiscoveries(raw: UserDiscoveries | Discovery[]): UserDiscoveries {
   // V1→V2 compatibility: V1 stores as raw array, V2 expects { discoveries: [...] }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const rawAny = raw as any;
@@ -272,7 +269,34 @@ export async function getUserDiscoveries(userId: string): Promise<UserDiscoverie
     source: (d.source as string) || 'v1:migrated',
   }));
 
-  return { discoveries: normalized, updatedAt: new Date().toISOString() } as unknown as UserDiscoveries;
+  return {
+    discoveries: normalized,
+    updatedAt: !Array.isArray(rawAny) && typeof rawAny?.updatedAt === 'string'
+      ? rawAny.updatedAt
+      : new Date().toISOString(),
+  } as UserDiscoveries;
+}
+
+export async function getUserDiscoveries(userId: string): Promise<UserDiscoveries | null> {
+  const raw = await getUserData(userId, 'discoveries');
+  if (!raw) return null;
+  return normalizeDiscoveries(raw as UserDiscoveries | Discovery[]);
+}
+
+export async function getDerivedUserDiscoveries(userId: string, historyLimit = 50): Promise<UserDiscoveries | null> {
+  const current = await getUserDiscoveries(userId);
+  const discoveries = await deriveDiscoveryInventory({
+    userId,
+    currentDiscoveries: current?.discoveries ?? [],
+    historyLimit,
+  });
+
+  if (!current && discoveries.length === 0) return null;
+
+  return {
+    discoveries,
+    updatedAt: current?.updatedAt ?? new Date().toISOString(),
+  };
 }
 
 export async function getUserChat(userId: string): Promise<UserChat | null> {

--- a/app/api/internal/discoveries/route.ts
+++ b/app/api/internal/discoveries/route.ts
@@ -8,6 +8,8 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { list, put, del } from '@vercel/blob';
+import { recordDiscoveryHistoryEvent } from '../../../_lib/discovery-history';
+import type { Discovery } from '../../../_lib/types';
 
 export const dynamic = 'force-dynamic';
 
@@ -101,6 +103,17 @@ export async function POST(request: NextRequest) {
     access: 'public',
     addRandomSuffix: false,
   });
+
+  try {
+    await recordDiscoveryHistoryEvent({
+      userId,
+      source: 'api/internal/discoveries',
+      previous: existing as Discovery[],
+      next: merged as Discovery[],
+    });
+  } catch {
+    // best-effort history only
+  }
 
   console.log(`[internal/discoveries] Added ${newItems.length} discoveries for ${userId}`);
 

--- a/app/api/internal/enrich-photos/route.ts
+++ b/app/api/internal/enrich-photos/route.ts
@@ -6,6 +6,8 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { list, put } from '@vercel/blob';
+import type { Discovery } from '../../../_lib/types';
+import { recordDiscoveryHistoryEvent } from '../../../_lib/discovery-history';
 
 const PLACES_SERVER_KEY = process.env.GOOGLE_PLACES_SERVER_KEY;
 const BASE_URL = process.env.NEXT_PUBLIC_BLOB_BASE_URL || '';
@@ -32,6 +34,7 @@ export async function POST(req: NextRequest) {
   const res = await fetch(blobUrl);
   const raw = await res.json();
   const discoveries: Record<string, unknown>[] = Array.isArray(raw) ? raw : raw.discoveries || [];
+  const previousDiscoveries = discoveries.map((d) => ({ ...d })) as Discovery[];
 
   // Find candidates
   const candidates = discoveries.filter(d => {
@@ -94,6 +97,17 @@ export async function POST(req: NextRequest) {
     access: 'public',
     addRandomSuffix: false,
   });
+
+  try {
+    await recordDiscoveryHistoryEvent({
+      userId,
+      source: 'api/internal/enrich-photos',
+      previous: previousDiscoveries,
+      next: discoveries as Discovery[],
+    });
+  } catch {
+    // best-effort history only
+  }
 
   return NextResponse.json({
     ...results,

--- a/app/api/internal/retry-missing-photos/route.ts
+++ b/app/api/internal/retry-missing-photos/route.ts
@@ -8,6 +8,8 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { list } from '@vercel/blob';
+import type { Discovery } from '../../../_lib/types';
+import { recordDiscoveryHistoryEvent } from '../../../_lib/discovery-history';
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
@@ -25,6 +27,7 @@ export async function GET(req: NextRequest) {
   const res = await fetch(blobUrl);
   const raw = await res.json();
   const discoveries: Record<string, unknown>[] = Array.isArray(raw) ? raw : raw.discoveries || [];
+  const previousDiscoveries = discoveries.map((d) => ({ ...d })) as Discovery[];
 
   // Find candidates missing heroImage but have place_id
   const candidates = discoveries.filter(d => d.place_id && !d.heroImage);
@@ -87,6 +90,17 @@ export async function GET(req: NextRequest) {
       access: 'public',
       addRandomSuffix: false,
     });
+
+    try {
+      await recordDiscoveryHistoryEvent({
+        userId,
+        source: 'api/internal/retry-missing-photos',
+        previous: previousDiscoveries,
+        next: discoveries as Discovery[],
+      });
+    } catch {
+      // best-effort history only
+    }
   }
 
   return NextResponse.json({

--- a/app/api/internal/validate-discoveries/route.ts
+++ b/app/api/internal/validate-discoveries/route.ts
@@ -12,6 +12,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { list, put, del } from '@vercel/blob';
 import { existsSync, writeFileSync, mkdirSync, readFileSync } from 'fs';
 import path from 'path';
+import type { Discovery } from '../../../_lib/types';
+import { recordDiscoveryHistoryEvent } from '../../../_lib/discovery-history';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 30; // 30s limit — fast validation only
@@ -154,6 +156,18 @@ export async function POST(request: NextRequest) {
         contentType: 'application/json',
         addRandomSuffix: false,
       });
+
+      try {
+        const previousDiscoveries = (Array.isArray(raw) ? raw : raw.discoveries || []) as Discovery[];
+        await recordDiscoveryHistoryEvent({
+          userId,
+          source: 'api/internal/validate-discoveries',
+          previous: previousDiscoveries,
+          next: discoveries as Discovery[],
+        });
+      } catch {
+        // best-effort history only
+      }
     }
 
     console.log(`[validate-discoveries] ${userId}: cityFixed=${cityFixed} stubCreated=${stubCreated}`);

--- a/app/api/user/discoveries/route.ts
+++ b/app/api/user/discoveries/route.ts
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers';
 import { put, list, del } from '@vercel/blob';
 import { COOKIE_NAME, getUserById } from '../../../_lib/user';
 import type { Discovery, DiscoveryType, PlaceIdStatus } from '../../../_lib/types';
+import { recordDiscoveryHistoryEvent } from '../../../_lib/discovery-history';
 
 export const dynamic = 'force-dynamic';
 
@@ -157,7 +158,7 @@ async function readRawDiscoveries(userId: string): Promise<unknown[]> {
 /**
  * Write discoveries to Blob. Includes safety checks.
  */
-async function writeDiscoveries(userId: string, discoveries: unknown[]): Promise<void> {
+async function writeDiscoveries(userId: string, previous: Discovery[], discoveries: Discovery[]): Promise<void> {
   const blobPath = `${BLOB_PREFIX}/${userId}/discoveries.json`;
   // Delete existing
   try {
@@ -172,6 +173,17 @@ async function writeDiscoveries(userId: string, discoveries: unknown[]): Promise
     contentType: 'application/json',
     addRandomSuffix: false,
   });
+
+  try {
+    await recordDiscoveryHistoryEvent({
+      userId,
+      source: 'api/user/discoveries',
+      previous,
+      next: discoveries,
+    });
+  } catch {
+    // best-effort history only
+  }
 }
 
 // GET: retrieve user discoveries
@@ -349,7 +361,7 @@ export async function POST(request: NextRequest) {
   }
 
   if (newItems.length > 0 || upgraded > 0) {
-    await writeDiscoveries(targetUserId, merged);
+    await writeDiscoveries(targetUserId, existingRaw as Discovery[], merged as Discovery[]);
     console.log(`[discoveries] ${newItems.length} added, ${upgraded} upgraded for ${targetUserId}. ${existingCount} → ${merged.length}`);
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1038,6 +1038,16 @@ a:hover {
   min-height: 1.2em;
 }
 
+.place-card-explanation {
+  font-size: 0.76rem;
+  line-height: 1.35;
+  color: var(--text-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 .star-filled {
   color: var(--warm-amber);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1048,6 +1048,17 @@ a:hover {
   overflow: hidden;
 }
 
+.place-card-monitoring {
+  margin-top: 4px;
+  font-size: 0.72rem;
+  line-height: 1.35;
+  color: color-mix(in srgb, var(--accent) 62%, var(--text-secondary));
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 .star-filled {
   color: var(--warm-amber);
 }
@@ -6114,6 +6125,71 @@ body {
   font-weight: 500;
   color: var(--text-muted, #8a857c);
   font-variant-numeric: tabular-nums;
+}
+
+.monitoring-note {
+  margin: 18px 0;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid var(--border, rgba(0,0,0,0.08));
+  background: color-mix(in srgb, var(--accent) 8%, white);
+}
+
+.monitoring-note-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.monitoring-note-kicker {
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted, #8a857c);
+}
+
+.monitoring-note-status {
+  font-size: 0.73rem;
+  font-weight: 600;
+  padding: 4px 9px;
+  border-radius: 999px;
+  background: rgba(0,0,0,0.06);
+  color: var(--text-secondary, #6f6a62);
+}
+
+.monitoring-note-status-candidate {
+  background: rgba(168, 85, 247, 0.12);
+  color: #7c3aed;
+}
+
+.monitoring-note-status-active {
+  background: rgba(14, 165, 233, 0.14);
+  color: #0369a1;
+}
+
+.monitoring-note-status-priority {
+  background: rgba(234, 88, 12, 0.14);
+  color: #c2410c;
+}
+
+.monitoring-note-body {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: var(--text-primary, #2b2723);
+}
+
+.monitoring-note-list {
+  margin: 10px 0 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+  color: var(--text-secondary, #6f6a62);
+  font-size: 0.84rem;
+  line-height: 1.45;
 }
 
 /* Hide Next.js dev error overlay indicator */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { resolveImageUrl } from './_lib/image-url';
 import { getManifestHeroImage } from './_lib/image-url.server';
 import { isTypeCompatible } from './_lib/context-compat';
 import { scoreDiscovery } from './_lib/discovery-score';
+import { rankDiscoveriesForHomepage } from './_lib/discovery-preferences';
 import HomeClient from './_components/HomeClient';
 
 export const dynamic = 'force-dynamic';
@@ -167,12 +168,28 @@ export default async function HomePage() {
       globalSeenPlaceIds.add(d.place_id);
       return true;
     });
+    byContext.set(ctxKey, globalDeduped);
+  }
 
-    // Score and sort — best places first
-    const scored = globalDeduped
-      .map(d => ({ ...d, _score: scoreDiscovery(d).total }))
-      .sort((a, b) => (b._score || 0) - (a._score || 0));
-    byContext.set(ctxKey, scored);
+  const rankedDiscoveries = await rankDiscoveriesForHomepage({
+    userId: user.id,
+    discoveries: Array.from(byContext.values()).flat(),
+    contexts,
+    baseScore: (discovery) => scoreDiscovery(discovery).total,
+  });
+
+  const rankedByKey = new Map(
+    rankedDiscoveries.map((discovery) => [
+      discovery.place_id ? `${discovery.contextKey}::${discovery.place_id}` : `${discovery.contextKey}::${discovery.id}`,
+      discovery,
+    ]),
+  );
+
+  for (const [ctxKey, items] of byContext) {
+    const ranked = items
+      .map((discovery) => rankedByKey.get(discovery.place_id ? `${ctxKey}::${discovery.place_id}` : `${ctxKey}::${discovery.id}`) ?? discovery)
+      .sort((a, b) => (b.rankingScore ?? scoreDiscovery(b).total) - (a.rankingScore ?? scoreDiscovery(a).total));
+    byContext.set(ctxKey, ranked);
   }
 
   // Build contextMeta — structured trip data for widgets

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import { isTypeCompatible } from './_lib/context-compat';
 import { scoreDiscovery } from './_lib/discovery-score';
 import { rankDiscoveriesForHomepage } from './_lib/discovery-preferences';
 import { annotateDiscoveriesForMonitoring } from './_lib/discovery-monitoring';
+import { getHomepageContextVisibility } from './_lib/homepage-contexts';
 import HomeClient from './_components/HomeClient';
 
 export const dynamic = 'force-dynamic';
@@ -200,9 +201,14 @@ export default async function HomePage() {
     byContext.set(ctxKey, ranked);
   }
 
+  const { visibleContexts, hiddenEmptyContextCount } = getHomepageContextVisibility({
+    contexts,
+    discoveryBuckets: byContext,
+  });
+
   // Build contextMeta — structured trip data for widgets
   const contextMeta = Object.fromEntries(
-    contexts
+    visibleContexts
       .filter(c => c.type === 'trip')
       .map(c => {
         const raw = c as unknown as Record<string, unknown>;
@@ -217,9 +223,10 @@ export default async function HomePage() {
   return (
     <HomeClient
       userId={user.id}
-      contexts={contexts}
+      contexts={visibleContexts}
       discoveryMap={Object.fromEntries(byContext)}
       contextMeta={contextMeta}
+      hasHiddenEmptyContexts={hiddenEmptyContextCount > 0}
     />
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync } from 'fs';
 import path from 'path';
+import Link from 'next/link';
 import { getCurrentUser } from './_lib/user';
 import { getUserManifest, getUserDiscoveries } from './_lib/user-data';
 import type { Context, Discovery, UserManifest } from './_lib/types';
@@ -9,6 +10,7 @@ import { getManifestHeroImage } from './_lib/image-url.server';
 import { isTypeCompatible } from './_lib/context-compat';
 import { scoreDiscovery } from './_lib/discovery-score';
 import { rankDiscoveriesForHomepage } from './_lib/discovery-preferences';
+import { annotateDiscoveriesForMonitoring } from './_lib/discovery-monitoring';
 import HomeClient from './_components/HomeClient';
 
 export const dynamic = 'force-dynamic';
@@ -53,7 +55,7 @@ export default async function HomePage() {
       <main className="page">
         <div className="page-header">
           <h1>🧭 Compass</h1>
-          <p>Personal travel intelligence. <a href="/u/join" style={{textDecoration: 'underline', color: 'inherit'}}>Sign in</a> to get started.</p>
+          <p>Personal travel intelligence. <Link href="/u/join" style={{textDecoration: 'underline', color: 'inherit'}}>Sign in</Link> to get started.</p>
         </div>
       </main>
     );
@@ -178,8 +180,14 @@ export default async function HomePage() {
     baseScore: (discovery) => scoreDiscovery(discovery).total,
   });
 
+  const monitoredDiscoveries = await annotateDiscoveriesForMonitoring({
+    userId: user.id,
+    discoveries: rankedDiscoveries,
+    contexts,
+  });
+
   const rankedByKey = new Map(
-    rankedDiscoveries.map((discovery) => [
+    monitoredDiscoveries.map((discovery) => [
       discovery.place_id ? `${discovery.contextKey}::${discovery.place_id}` : `${discovery.contextKey}::${discovery.id}`,
       discovery,
     ]),

--- a/app/review/[contextKey]/page.tsx
+++ b/app/review/[contextKey]/page.tsx
@@ -1,7 +1,7 @@
 import { readFileSync, existsSync } from 'fs';
 import path from 'path';
 import { getCurrentUser } from '../../_lib/user';
-import { getUserManifest, getUserDiscoveries } from '../../_lib/user-data';
+import { getUserManifest, getDerivedUserDiscoveries } from '../../_lib/user-data';
 import ReviewContextClient from '../../_components/ReviewContextClient';
 
 function loadSharedManifest() {
@@ -33,7 +33,7 @@ export default async function ReviewContextPage({ params }: Props) {
 
   const [manifest, discoveriesData] = await Promise.all([
     getUserManifest(user.id),
-    getUserDiscoveries(user.id),
+    getDerivedUserDiscoveries(user.id),
   ]);
 
   // Fall back to shared compass-manifest.json ONLY for the owner user

--- a/app/review/page.tsx
+++ b/app/review/page.tsx
@@ -1,5 +1,5 @@
 import { getCurrentUser } from '../_lib/user';
-import { getUserManifest, getUserDiscoveries } from '../_lib/user-data';
+import { getUserManifest, getDerivedUserDiscoveries } from '../_lib/user-data';
 import { getContextStatus } from '../_lib/context-lifecycle';
 import ReviewHubClient from '../_components/ReviewHubClient';
 
@@ -21,7 +21,7 @@ export default async function ReviewPage() {
 
   const [manifest, discoveriesData] = await Promise.all([
     getUserManifest(user.id),
-    getUserDiscoveries(user.id),
+    getDerivedUserDiscoveries(user.id),
   ]);
 
   const allContexts = manifest?.contexts ?? [];

--- a/tests/homepage-contexts.test.ts
+++ b/tests/homepage-contexts.test.ts
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { Context, Discovery } from '../app/_lib/types';
+import { getHomepageContextVisibility } from '../app/_lib/homepage-contexts';
+
+function makeContext(key: string, label: string): Context {
+  return {
+    key,
+    label,
+    emoji: '🧭',
+    type: 'radar',
+    focus: [],
+    active: true,
+  };
+}
+
+function makeDiscovery(id: string, contextKey: string): Discovery {
+  return {
+    id,
+    name: id,
+    city: 'Toronto',
+    type: 'restaurant',
+    contextKey,
+    source: 'test',
+    discoveredAt: '2026-04-05T00:00:00.000Z',
+    placeIdStatus: 'verified',
+  };
+}
+
+test('keeps homepage order while hiding contexts with zero discoveries', () => {
+  const contexts = [
+    makeContext('trip:cottage-july-2026', 'Ontario Cottage'),
+    makeContext('radar:developments', 'Developments'),
+    makeContext('radar:toronto-experiences', 'Toronto Experiences'),
+  ];
+
+  const discoveryBuckets = new Map<string, Discovery[]>([
+    ['trip:cottage-july-2026', []],
+    ['radar:developments', []],
+    ['radar:toronto-experiences', [makeDiscovery('toronto-experiences-1', 'radar:toronto-experiences')]],
+  ]);
+
+  const result = getHomepageContextVisibility({ contexts, discoveryBuckets });
+
+  assert.deepEqual(
+    result.visibleContexts.map((context) => context.key),
+    ['radar:toronto-experiences'],
+  );
+  assert.equal(result.hiddenEmptyContextCount, 2);
+});
+
+test('reports when every active homepage context is hidden', () => {
+  const contexts = [
+    makeContext('trip:cottage-july-2026', 'Ontario Cottage'),
+    makeContext('radar:developments', 'Developments'),
+  ];
+
+  const result = getHomepageContextVisibility({
+    contexts,
+    discoveryBuckets: {
+      'trip:cottage-july-2026': [],
+      'radar:developments': [],
+    },
+  });
+
+  assert.deepEqual(result.visibleContexts, []);
+  assert.equal(result.hiddenEmptyContextCount, 2);
+});


### PR DESCRIPTION
## Summary
- hide homepage contexts once their final discovery bucket is empty after matching/deduping/ranking
- keep empty contexts available elsewhere by limiting the suppression to homepage rendering only
- add a focused regression test for homepage context visibility

## Testing
- `node --import tsx --test tests/homepage-contexts.test.ts`
- `npm run build` *(currently blocked by a pre-existing unrelated type error in `app/api/internal/enrich-photos/route.ts`)*

Closes #254.
