### PR TITLE
fix: hide empty great streets context on homepage (#251)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -169,9 +169,15 @@ export default async function HomePage() {
     byContext.set(ctxKey, globalDeduped);
   }
 
+  // Fix #251: filter out active contexts with no discoveries to avoid showing empty sections
+  const contextsWithDiscoveries = contexts.filter(ctx => {
+    const discoveries = byContext.get(ctx.key);
+    return discoveries && discoveries.length > 0;
+  });
+
   // Build contextMeta — structured trip data for widgets
   const contextMeta = Object.fromEntries(
-    contexts
+    contextsWithDiscoveries
       .filter(c => c.type === 'trip')
       .map(c => {
         const raw = c as unknown as Record<string, unknown>;
@@ -186,7 +192,7 @@ export default async function HomePage() {
   return (
     <HomeClient
       userId={user.id}
-      contexts={contexts}
+      contexts={contextsWithDiscoveries}
       discoveryMap={Object.fromEntries(byContext)}
       contextMeta={contextMeta}
     />


### PR DESCRIPTION
## Problem
Homepage showed an active Great Streets context with an empty-state message instead of useful content.

## Fix
Filter homepage contexts so empty active contexts are not rendered as broken-looking sections.

## Changes
- 
- Skip contexts with no discoveries when building homepage sections

Closes #251