### PR TITLE
fix: repair broken hero image references in smoke test (#252)

### DIFF
--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -156,8 +156,10 @@ async function run() {
     const urls = [...new Set((detailHtml.match(blobUrlRe) || []).filter(u => u.match(/\.(jpg|jpeg|png|webp)/i)).slice(0, 3))];
     if (urls.length === 0) return; // no images to check on this card — pass
     for (const url of urls) {
-      const res = await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(5000) });
-      assert(res.ok, `Image returned ${res.status}: ${url.slice(-40)}`);
+      // Clean up trailing ) or \ from inline styles (e.g., "url(...)" or "url(\)")
+      const cleanUrl = url.replace(/[)\\s]+$/, '');
+      const res = await fetch(cleanUrl, { method: 'HEAD', signal: AbortSignal.timeout(5000) });
+      assert(res.ok, `Image returned ${res.status}: ${cleanUrl.slice(-40)}`);
     }
   });
 


### PR DESCRIPTION
## Problem
Smoke test reported hero image 404s, but the root cause was the smoke test regex capturing trailing characters from inline styles when extracting blob image URLs.

## Fix
Tightened the URL extraction in 
🧭 Compass V2 Smoke Tests (Layer 1)
   Target: http://localhost:3002

  — Page Routes —
  ✅ Homepage loads
  ✅ Homepage has ≥5 context sections
  ✅ Homepage has ≥10 place cards
  ✅ Homepage has ≥5 Blob image URLs
  ✅ Homepage no React errors
  ✅ Places Browse loads
  ✅ Review Hub loads
  ✅ What's Hot loads
  ✅ Admin loads
  ✅ Join Page loads

  — Place Card Detail —
  ✅ Place card detail loads
  ✅ Place card has hero image
  ✅ Place card has name heading
  ✅ Place card no wrong city (Brooklyn ≠ Toronto)
  ✅ Map embed present on place card

  — Hero Image URLs —
  ✅ Hero image URLs return 200
  ✅ Homepage Blob images return 200 (sample 3)

  — City Label Consistency —
  ✅ NYC discoveries not labeled Toronto
  ✅ Discoveries have city field (≥90%)

  — API Routes —
  ✅ Auth API returns user
  ✅ Discoveries API returns array
  ❌ Discoveries count ≥50 — Only 48 discoveries
  ❌ Manifest API returns contexts — HTTP 404
  ✅ Admin Agents: non-zero agents
  ✅ Admin Crons: has jobs
  ✅ Admin Tokens: has 24h data

  — Triage API —
  ✅ GET /api/user/triage returns store
  ✅ POST /api/user/triage accepts save action
  ✅ POST /api/user/triage handles null triage field gracefully
  ✅ POST /api/user/triage rejects without auth

  — Security —
  ✅ Discovery POST rejects without auth
  ✅ Briefing POST rejects without token

  — Data Quality —
  ✅ Discoveries: no duplicate place_ids
  ✅ Discoveries: all have contextKey
  ❌ Discoveries: all have valid type — 6 discoveries with invalid type: Cervo's=seafood_restaurant, DROM=live_music_venue
  ❌ Manifest: all contexts have emoji — HTTP 404

──────────────────────────────────────────────────
  Results: 32 passed, 4 failed, 36 total

  ⚠️  4 test(s) failed:
     • Discoveries count ≥50: Only 48 discoveries
     • Manifest API returns contexts: HTTP 404
     • Discoveries: all have valid type: 6 discoveries with invalid type: Cervo's=seafood_restaurant, DROM=live_music_venue
     • Manifest: all contexts have emoji: HTTP 404 so valid hero image URLs are parsed correctly.

## Changes
- 
🧭 Compass V2 Smoke Tests (Layer 1)
   Target: http://localhost:3002

  — Page Routes —
  ✅ Homepage loads
  ✅ Homepage has ≥5 context sections
  ✅ Homepage has ≥10 place cards
  ✅ Homepage has ≥5 Blob image URLs
  ✅ Homepage no React errors
  ✅ Places Browse loads
  ✅ Review Hub loads
  ✅ What's Hot loads
  ✅ Admin loads
  ✅ Join Page loads

  — Place Card Detail —
  ✅ Place card detail loads
  ✅ Place card has hero image
  ✅ Place card has name heading
  ✅ Place card no wrong city (Brooklyn ≠ Toronto)
  ✅ Map embed present on place card

  — Hero Image URLs —
  ✅ Hero image URLs return 200
  ✅ Homepage Blob images return 200 (sample 3)

  — City Label Consistency —
  ✅ NYC discoveries not labeled Toronto
  ✅ Discoveries have city field (≥90%)

  — API Routes —
  ✅ Auth API returns user
  ✅ Discoveries API returns array
  ❌ Discoveries count ≥50 — Only 48 discoveries
  ❌ Manifest API returns contexts — HTTP 404
  ✅ Admin Agents: non-zero agents
  ✅ Admin Crons: has jobs
  ✅ Admin Tokens: has 24h data

  — Triage API —
  ✅ GET /api/user/triage returns store
  ✅ POST /api/user/triage accepts save action
  ✅ POST /api/user/triage handles null triage field gracefully
  ✅ POST /api/user/triage rejects without auth

  — Security —
  ✅ Discovery POST rejects without auth
  ✅ Briefing POST rejects without token

  — Data Quality —
  ✅ Discoveries: no duplicate place_ids
  ✅ Discoveries: all have contextKey
  ❌ Discoveries: all have valid type — 6 discoveries with invalid type: Cervo's=seafood_restaurant, DROM=live_music_venue
  ❌ Manifest: all contexts have emoji — HTTP 404

──────────────────────────────────────────────────
  Results: 32 passed, 4 failed, 36 total

  ⚠️  4 test(s) failed:
     • Discoveries count ≥50: Only 48 discoveries
     • Manifest API returns contexts: HTTP 404
     • Discoveries: all have valid type: 6 discoveries with invalid type: Cervo's=seafood_restaurant, DROM=live_music_venue
     • Manifest: all contexts have emoji: HTTP 404
- Fix blob image URL extraction regex/parsing

Closes #252