### PR TITLE
feat: Build Compass concierge tool endpoints (create-context, update-trip, add-discovery)

### DIFF
--- a/app/_lib/types.ts
+++ b/app/_lib/types.ts
@@ -60,6 +60,7 @@ export interface Context {
   dates?: string;
   parentTrip?: string;  // for outings nested in a trip
   focus: string[];      // "food", "jazz", "architecture"
+  accommodation?: string; // "Airbnb in Alfama", "Hotel Negresco"
   active: boolean;
   status?: ContextStatus;  // defaults to 'active' if missing; overrides `active` when present
   anchor?: ContextAnchor;  // geographic anchor for proximity sorting

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -88,6 +88,54 @@ const CONCIERGE_TOOLS = [
       },
     },
   },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'add-discovery',
+      description: 'Add a discovered place (restaurant, bar, cafe, etc.) to the user\'s Compass radar or trip.',
+      parameters: {
+        type: 'object',
+        properties: {
+          contextKey: {
+            type: 'string',
+            description: 'The key of the context to add the discovery to (e.g., "radar:toronto" or "trip:nyc-solo")',
+          },
+          discovery: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+                description: 'Name of the place',
+              },
+              type: {
+                type: 'string',
+                enum: ['restaurant', 'bar', 'cafe', 'grocery', 'gallery', 'museum', 'theatre', 'music-venue', 'hotel', 'experience', 'shop', 'park', 'architecture', 'development', 'accommodation', 'neighbourhood'],
+                description: 'Type of place',
+              },
+              city: {
+                type: 'string',
+                description: 'City where the place is located',
+              },
+              address: {
+                type: 'string',
+                description: 'Address (optional)',
+              },
+              place_id: {
+                type: 'string',
+                description: 'Google Places ID (optional)',
+              },
+              rating: {
+                type: 'number',
+                description: 'Rating (optional, 1-5)',
+              },
+            },
+            required: ['name', 'type', 'city'],
+          },
+        },
+        required: ['contextKey', 'discovery'],
+      },
+    },
+  },
 ];
 
 /** Execute a tool call locally by calling the appropriate API endpoint */
@@ -120,6 +168,12 @@ async function executeToolCall(
       dates: args.dates,
       city: args.city,
       focus: args.focus,
+    };
+  } else if (toolName === 'add-discovery') {
+    endpoint = `${baseUrl}/api/compass/add-discovery`;
+    body = {
+      contextKey: args.contextKey,
+      discovery: args.discovery,
     };
   } else {
     throw new Error(`Unknown tool: ${toolName}`);

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -13,8 +13,16 @@ const MAX_MESSAGE_LENGTH = 4000;
 const OPENCLAW_TIMEOUT_MS = 90_000; // longer timeout for streaming — tool calls can take time
 
 interface OpenClawMessage {
-  role: 'system' | 'user' | 'assistant';
+  role: 'system' | 'user' | 'assistant' | 'tool';
   content: string;
+  tool_calls?: ToolCallMessage[];
+  tool_call_id?: string;
+}
+
+interface ToolCallMessage {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
 }
 
 /** OpenAI function-calling tools for the Concierge agent */
@@ -82,6 +90,10 @@ const CONCIERGE_TOOLS = [
             type: 'array',
             items: { type: 'string' },
             description: 'Updated focus areas (optional)',
+          },
+          accommodation: {
+            type: 'string',
+            description: 'Accommodation details (optional, e.g., "Airbnb in Alfama")',
           },
         },
         required: ['contextKey'],
@@ -168,6 +180,7 @@ async function executeToolCall(
       dates: args.dates,
       city: args.city,
       focus: args.focus,
+      accommodation: args.accommodation,
     };
   } else if (toolName === 'add-discovery') {
     endpoint = `${baseUrl}/api/compass/add-discovery`;
@@ -294,6 +307,107 @@ async function callOpenClawSync(
   }
 }
 
+/** Parsed tool call from the stream */
+interface ParsedToolCall {
+  id: string;
+  name: string;
+  arguments: string;
+}
+
+/**
+ * Consume an SSE stream from the OpenClaw Gateway.
+ * Forwards content deltas and tool-name events to the browser controller.
+ * Accumulates tool_calls arguments across chunked deltas.
+ * Returns the full content, any tool calls, and the finish_reason.
+ */
+async function consumeStream(
+  body: ReadableStream<Uint8Array>,
+  controller: ReadableStreamDefaultController,
+  encoder: TextEncoder,
+  messageId: string,
+  onContent: (text: string) => void,
+): Promise<{ content: string; toolCalls: ParsedToolCall[]; finishReason: string | null }> {
+  const decoder = new TextDecoder();
+  const reader = body.getReader();
+  let content = '';
+  let finishReason: string | null = null;
+
+  // Accumulate tool calls by index (they arrive in chunks)
+  const toolCallMap = new Map<number, { id: string; name: string; args: string }>();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunk = decoder.decode(value, { stream: true });
+      const lines = chunk.split('\n');
+
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        const data = line.slice(6).trim();
+        if (data === '[DONE]') continue;
+
+        try {
+          const parsed = JSON.parse(data);
+          const choice = parsed?.choices?.[0];
+          const delta = choice?.delta;
+
+          if (choice?.finish_reason) {
+            finishReason = choice.finish_reason;
+          }
+
+          if (delta?.content) {
+            content += delta.content;
+            onContent(delta.content);
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify({ content: delta.content, messageId })}\n\n`),
+            );
+          }
+
+          // Accumulate tool call chunks
+          if (delta?.tool_calls) {
+            for (const tc of delta.tool_calls) {
+              const idx = tc.index ?? 0;
+              const existing = toolCallMap.get(idx);
+              if (!existing) {
+                toolCallMap.set(idx, {
+                  id: tc.id || '',
+                  name: tc.function?.name || '',
+                  args: tc.function?.arguments || '',
+                });
+                // Emit tool event to frontend on first chunk (has the name)
+                if (tc.function?.name) {
+                  controller.enqueue(
+                    encoder.encode(`data: ${JSON.stringify({ tool: tc.function.name, messageId })}\n\n`),
+                  );
+                }
+              } else {
+                if (tc.id) existing.id = tc.id;
+                if (tc.function?.name) existing.name = tc.function.name;
+                if (tc.function?.arguments) existing.args += tc.function.arguments;
+              }
+            }
+          }
+        } catch {
+          // Not valid JSON — skip
+        }
+      }
+    }
+  } catch (err) {
+    console.error('[chat/consumeStream] Read error:', err);
+  }
+
+  const toolCalls: ParsedToolCall[] = [];
+  for (const [, tc] of toolCallMap) {
+    if (tc.name) {
+      toolCalls.push({ id: tc.id, name: tc.name, arguments: tc.args });
+    }
+  }
+
+  return { content, toolCalls, finishReason };
+}
+
 export async function POST(request: NextRequest) {
   try {
     const user = await getCurrentUser();
@@ -366,60 +480,72 @@ export async function POST(request: NextRequest) {
     const streamRes = await streamOpenClaw(openclawMessages, user.id);
 
     if (streamRes?.body) {
-      // Proxy SSE stream to the browser, collecting full text for persistence
       const encoder = new TextEncoder();
-      const decoder = new TextDecoder();
-      let fullReply = '';
       const messageId = `${Date.now()}-concierge`;
+      let fullReply = '';
+
+      // Messages accumulator for tool-call loops (starts with our initial messages)
+      const loopMessages = [...openclawMessages];
 
       const readable = new ReadableStream({
         async start(controller) {
-          const reader = streamRes.body!.getReader();
+          const MAX_TOOL_ROUNDS = 5;
+          let currentStream: Response | null = streamRes;
 
           try {
-            while (true) {
-              const { done, value } = await reader.read();
-              if (done) break;
+            for (let round = 0; round <= MAX_TOOL_ROUNDS; round++) {
+              if (!currentStream?.body) break;
 
-              const chunk = decoder.decode(value, { stream: true });
+              const { content, toolCalls, finishReason } = await consumeStream(
+                currentStream.body,
+                controller,
+                encoder,
+                messageId,
+                (text) => { fullReply += text; },
+              );
 
-              // Parse SSE lines to extract content deltas
-              const lines = chunk.split('\n');
-              for (const line of lines) {
-                if (line.startsWith('data: ')) {
-                  const data = line.slice(6).trim();
-                  if (data === '[DONE]') {
-                    // Send our own [DONE] marker
-                    controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
-                    continue;
-                  }
+              // If the model finished with tool_calls, execute them and loop
+              if (finishReason === 'tool_calls' && toolCalls.length > 0 && round < MAX_TOOL_ROUNDS) {
+                // Append the assistant's tool-call message
+                loopMessages.push({
+                  role: 'assistant',
+                  content: content || '',
+                  tool_calls: toolCalls.map(tc => ({
+                    id: tc.id,
+                    type: 'function' as const,
+                    function: { name: tc.name, arguments: tc.arguments },
+                  })),
+                });
 
+                // Execute each tool call and append results
+                for (const tc of toolCalls) {
+                  let result: unknown;
                   try {
-                    const parsed = JSON.parse(data);
-                    const delta = parsed?.choices?.[0]?.delta;
-                    if (delta?.content) {
-                      fullReply += delta.content;
-                      // Forward the SSE event to the browser
-                      controller.enqueue(encoder.encode(`data: ${JSON.stringify({ content: delta.content, messageId })}\n\n`));
-                    }
-                    // Surface tool-use status so UI can show "searching..." etc.
-                    if (delta?.tool_calls) {
-                      const toolName = delta.tool_calls[0]?.function?.name;
-                      if (toolName) {
-                        controller.enqueue(encoder.encode(`data: ${JSON.stringify({ tool: toolName, messageId })}\n\n`));
-                      }
-                    }
-                  } catch {
-                    // Not valid JSON — skip
+                    const args = JSON.parse(tc.arguments);
+                    result = await executeToolCall(tc.name, args, user.id);
+                  } catch (err) {
+                    result = { error: err instanceof Error ? err.message : 'Tool execution failed' };
                   }
+
+                  loopMessages.push({
+                    role: 'tool',
+                    content: JSON.stringify(result),
+                    tool_call_id: tc.id,
+                  });
                 }
+
+                // Make a new streaming request with tool results
+                currentStream = await streamOpenClaw(loopMessages, user.id);
+              } else {
+                // No more tool calls — done
+                break;
               }
             }
           } catch (err) {
-            console.error('[chat/stream] Stream read error:', err);
+            console.error('[chat/stream] Stream error:', err);
           } finally {
+            controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
             controller.close();
-            // Persist completed chat
             if (fullReply) {
               persistChatData(user.id, message, fullReply, messageId, history).catch(() => {});
             }

--- a/app/api/compass/update-trip/route.ts
+++ b/app/api/compass/update-trip/route.ts
@@ -7,6 +7,7 @@ interface UpdateFields {
   dates?: string;
   city?: string;
   focus?: string[];
+  accommodation?: string;
 }
 
 interface Change {
@@ -22,7 +23,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { contextKey, dates, city, focus } = body;
+    const { contextKey, dates, city, focus, accommodation } = body;
 
     if (!contextKey || typeof contextKey !== 'string') {
       return NextResponse.json({ error: 'contextKey is required' }, { status: 400 });
@@ -33,11 +34,12 @@ export async function POST(request: NextRequest) {
     if (dates !== undefined) updates.dates = dates;
     if (city !== undefined) updates.city = city;
     if (focus !== undefined) updates.focus = focus;
+    if (accommodation !== undefined) updates.accommodation = accommodation;
 
     // No updates provided
     if (Object.keys(updates).length === 0) {
       return NextResponse.json(
-        { error: 'At least one of dates, city, or focus is required' },
+        { error: 'At least one of dates, city, focus, or accommodation is required' },
         { status: 400 },
       );
     }
@@ -83,6 +85,10 @@ export async function POST(request: NextRequest) {
         changes.push({ field: 'focus', value: focus });
         context.focus = focus;
       }
+    }
+    if (accommodation !== undefined && context.accommodation !== accommodation) {
+      changes.push({ field: 'accommodation', value: accommodation });
+      context.accommodation = accommodation;
     }
 
     // Save updated manifest


### PR DESCRIPTION
## Summary

Implements the three concierge tool endpoints that the frontend emergence animations (from 787cb67) are waiting for, plus the critical tool execution loop in the SSE streaming handler.

### API Endpoints

- **POST /api/compass/create-context** — Creates new trip/outing/radar contexts in the user's manifest
- **POST /api/compass/update-trip** — Updates existing context fields (dates, city, focus, accommodation)
- **POST /api/compass/add-discovery** — Adds discoveries to a context's discovery list

### Chat Route Tool Loop

The key missing piece: the SSE streaming handler now properly:
1. Accumulates chunked `tool_calls` deltas from the OpenClaw Gateway
2. Executes tools via internal API endpoints when `finish_reason === 'tool_calls'`
3. Feeds tool results back to the LLM for a follow-up response
4. Loops up to 5 rounds (e.g., create trip → add discoveries in one conversation turn)
5. Forwards tool names (`create-context`, `update-trip`, `add-discovery`) as SSE events so ChatWidget can fire emergence animations

### Tool Definitions

OpenAI function-calling tool schemas are passed to the gateway in every chat request. The concierge's system prompt (via `buildUserContext`) includes instructions on when to use each tool.

### Type Changes

- Added `accommodation?: string` to the `Context` interface

### Build

✅ `next build` passes cleanly with all three new API routes.

Fixes #264