### PR TITLE
feat: single-track focused homepage with pinned chat (#266)

### DIFF
--- a/app/_components/ChatWidget.module.css
+++ b/app/_components/ChatWidget.module.css
@@ -1,232 +1,47 @@
 /* ============================================================
-   ChatWidget - Light Warm Design (inspired by Claude.ai)
-   Clean, airy, premium — warm cream tones with deep shadows
+   ChatWidget - Pinned Bottom Layout (Single-Track Homepage)
+   Always visible at bottom, messages flow upward
    ============================================================ */
 
-.chatRoot {
+/* ---- Pinned Container ---- */
+.chatPinned {
   position: fixed;
   bottom: 0;
   left: 0;
   right: 0;
   z-index: 150;
+  display: flex;
+  flex-direction: column;
+  background: transparent;
   pointer-events: none;
-  color-scheme: light;
+  max-height: 60px; /* just the input bar */
+  transition: max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.chatRoot > * {
+.chatPinned > * {
   pointer-events: auto;
 }
 
-/* ---- Collapsed State ---- */
-.chatCollapsed {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: min(960px, calc(100% - 32px));
-  margin: 0 auto;
-  padding: 8px 16px;
-  padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
-  background: #f5f0e8;
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  border-bottom: none;
-  border-top-left-radius: 20px;
-  border-top-right-radius: 20px;
-  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.08), 0 -1px 8px rgba(0, 0, 0, 0.04);
-  cursor: pointer;
-  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1),
-              box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+.chatPinnedExpanded {
+  max-height: 70vh;
 }
 
-.chatCollapsed:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 -8px 40px rgba(0, 0, 0, 0.12), 0 -2px 12px rgba(0, 0, 0, 0.06);
-}
-
-.chatCollapsed::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: linear-gradient(90deg,
-    transparent 0%,
-    rgba(196, 112, 75, 0.2) 30%,
-    rgba(196, 112, 75, 0.3) 50%,
-    rgba(196, 112, 75, 0.2) 70%,
-    transparent 100%);
-}
-
-/* ---- Collapsed Input Section ---- */
-.chatCollapsedInput {
+/* ---- Messages Area ---- */
+.chatMessagesArea {
   flex: 1;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.chatCollapsedField {
-  flex: 1;
-  background: #faf7f2;
-  border: 1px solid #e0dbd2;
-  border-radius: 28px;
-  padding: 12px 20px;
-  color: #4a4640;
-  font-size: 0.9rem;
-  outline: none;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06), 0 1px 4px rgba(0, 0, 0, 0.04), inset 0 1px 2px rgba(255, 255, 255, 0.8);
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.chatCollapsedField::placeholder {
-  color: #9a958c;
-}
-
-.chatCollapsedField:focus {
-  border-color: #c4704b;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.06), inset 0 1px 2px rgba(255, 255, 255, 0.8);
-}
-
-.chatCollapsedSend {
-  width: 42px;
-  height: 42px;
-  border: none;
-  border-radius: 50%;
-  background: #c4704b;
-  color: white;
-  font-size: 1rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 2px 8px rgba(196, 112, 75, 0.25);
-}
-
-.chatCollapsedSend:hover:not(:disabled) {
-  transform: scale(1.05);
-  box-shadow: 0 4px 16px rgba(196, 112, 75, 0.35);
-}
-
-.chatCollapsedSend:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-/* ---- Last Message Preview ---- */
-.chatPreview {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  min-width: 0;
-  padding: 0 8px;
-}
-
-.chatPreviewIcon {
-  font-size: 1.2rem;
-  flex-shrink: 0;
-}
-
-.chatPreviewText {
-  font-size: 0.85rem;
-  color: #6f6a62 !important;
-  white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 180px;
-}
-
-.chatPreviewPlaceholder {
-  color: #8f897f !important;
-  font-size: 0.85rem;
-}
-
-/* ---- Expanded State ---- */
-.chatExpanded {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  width: 100%;
-  height: 65vh;
-  max-height: 600px;
   display: flex;
   flex-direction: column;
   background: linear-gradient(
     to bottom,
-    rgba(240, 237, 232, 0) 0%,
-    rgba(240, 237, 232, 0.15) 60%,
-    rgba(240, 237, 232, 0.85) 100%
+    rgba(245, 240, 232, 0) 0%,
+    rgba(245, 240, 232, 0.6) 15%,
+    rgba(245, 240, 232, 0.95) 40%,
+    rgba(245, 240, 232, 1) 100%
   );
-  border-radius: 0;
-  border: none;
-  box-shadow: none;
-  transition: height 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  min-height: 0;
 }
 
-.chatExpanded::before {
-  display: none;
-}
-
-/* ---- Drag Handle ---- */
-.chatDragHandle {
-  display: none;
-}
-
-.chatDragHandleBar {
-  display: none;
-}
-
-.chatDragHandle:hover .chatDragHandleBar {
-  display: none;
-}
-
-/* ---- Header ---- */
-.chatHeader {
-  display: none;
-}
-
-.chatHeaderTitle {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.chatHeaderIcon {
-  font-size: 1.2rem;
-}
-
-.chatHeaderText {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: #2d2a26 !important;
-}
-
-.chatCollapseBtn {
-  width: 44px;
-  height: 44px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  border-radius: 50%;
-  background: #e8e3db;
-  color: #6f6a62 !important;
-  font-size: 1rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  flex-shrink: 0;
-}
-
-.chatCollapseBtn:hover {
-  background: #ddd8cf;
-  color: #2d2a26 !important;
-}
-
-/* ---- Messages Area ---- */
 .chatMessages {
   flex: 1;
   overflow-y: auto;
@@ -244,17 +59,116 @@
   background: transparent;
 }
 
-.chatMessages::-webkit-scrollbar-track {
-  background: transparent;
-}
-
 .chatMessages::-webkit-scrollbar-thumb {
   background: rgba(0, 0, 0, 0.15);
   border-radius: 3px;
 }
 
-.chatMessages::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 0, 0, 0.25);
+/* ---- Input Bar (always visible) ---- */
+.chatInputBar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 16px;
+  padding-bottom: calc(6px + env(safe-area-inset-bottom, 4px));
+  background: #f5f0e8;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+  box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.06);
+}
+
+.chatInputForm {
+  display: flex;
+  gap: 8px;
+  flex: 1;
+  max-width: 960px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.chatInputField {
+  flex: 1;
+  background: #faf7f2;
+  border: 1px solid #e0dbd2;
+  border-radius: 28px;
+  padding: 10px 18px;
+  color: #4a4640;
+  font-size: 0.9rem;
+  outline: none;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06), inset 0 1px 2px rgba(255, 255, 255, 0.8);
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  resize: none;
+  min-height: 40px;
+  max-height: 100px;
+  overflow-y: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  font-family: inherit;
+}
+
+.chatInputField::-webkit-scrollbar {
+  display: none;
+}
+
+.chatInputField::placeholder {
+  color: #9a958c;
+}
+
+.chatInputField:focus {
+  border-color: #c4704b;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1), inset 0 1px 2px rgba(255, 255, 255, 0.8);
+}
+
+.chatInputField:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.chatSendButton {
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 50%;
+  background: #c4704b;
+  color: white;
+  font-size: 1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 2px 10px rgba(196, 112, 75, 0.3);
+  flex-shrink: 0;
+}
+
+.chatSendButton:hover:not(:disabled) {
+  transform: scale(1.05);
+  background: #b5633f;
+}
+
+.chatSendButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.chatMinimizeBtn {
+  width: 32px;
+  height: 32px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 50%;
+  background: #e8e3db;
+  color: #6f6a62;
+  font-size: 0.9rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: all 0.15s;
+}
+
+.chatMinimizeBtn:hover {
+  background: #ddd8cf;
+  color: #2d2a26;
 }
 
 /* ---- Empty State ---- */
@@ -266,7 +180,7 @@
   justify-content: center;
   text-align: center;
   padding: 32px;
-  color: #8a857c !important;
+  color: #8a857c;
 }
 
 .chatEmptyIcon {
@@ -278,7 +192,7 @@
 .chatEmptyTitle {
   font-size: 1.1rem;
   font-weight: 600;
-  color: #2d2a26 !important;
+  color: #2d2a26;
   margin-bottom: 4px;
 }
 
@@ -286,10 +200,10 @@
   font-size: 0.9rem;
   line-height: 1.5;
   max-width: 280px;
-  color: #8a857c !important;
+  color: #8a857c;
 }
 
-/* ---- Individual Messages ---- */
+/* ---- Messages ---- */
 .chatMessage {
   display: flex;
   flex-direction: column;
@@ -312,7 +226,7 @@
   align-items: flex-start;
 }
 
-/* ---- Message Bubbles ---- */
+/* ---- Bubbles ---- */
 .chatBubble {
   padding: 8px 16px;
   border-radius: 20px;
@@ -331,81 +245,32 @@
 
 .chatBubbleAssistant {
   background: #f7f4ef;
-  color: #2d2a26 !important;
+  color: #2d2a26;
   border-bottom-left-radius: 6px;
   border: 1px solid rgba(0, 0, 0, 0.03);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.10), 0 2px 6px rgba(0, 0, 0, 0.06);
 }
 
-/* ---- Message Timestamp ---- */
 .chatTimestamp {
   font-size: 0.7rem;
-  color: #8a857c !important;
+  color: #8a857c;
   margin-top: 2px;
   padding: 0 4px;
   opacity: 0.85;
 }
 
-/* ---- Markdown Content Styling ---- */
-.chatMarkdown p {
-  margin: 0;
-}
+/* ---- Markdown ---- */
+.chatMarkdown p { margin: 0; }
+.chatMarkdown p + p { margin-top: 4px; }
+.chatMarkdown a { color: #c4704b; text-decoration: underline; text-underline-offset: 2px; }
+.chatMarkdown a:hover { opacity: 0.8; }
+.chatMarkdown strong { font-weight: 600; }
+.chatMarkdown em { font-style: italic; }
+.chatMarkdown code { background: rgba(0, 0, 0, 0.06); padding: 1px 5px; border-radius: 4px; font-size: 0.85em; }
+.chatMarkdown ul, .chatMarkdown ol { margin: 4px 0; padding-left: 1.2em; }
+.chatMarkdown li { margin: 2px 0; }
 
-.chatMarkdown p + p {
-  margin-top: 4px;
-}
-
-.chatMarkdown a {
-  color: #c4704b;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-
-.chatMarkdown a:hover {
-  opacity: 0.8;
-}
-
-.chatBubbleUser .chatMarkdown a {
-  color: #c4704b;
-}
-
-.chatMarkdown strong {
-  font-weight: 600;
-}
-
-.chatMarkdown em {
-  font-style: italic;
-}
-
-.chatMarkdown code {
-  background: rgba(0, 0, 0, 0.06);
-  padding: 1px 5px;
-  border-radius: 4px;
-  font-size: 0.85em;
-}
-
-.chatBubbleUser .chatMarkdown code {
-  background: rgba(0, 0, 0, 0.06);
-}
-
-.chatMarkdown ul,
-.chatMarkdown ol {
-  margin: 4px 0;
-  padding-left: 1.2em;
-}
-
-.chatMarkdown li {
-  margin: 2px 0;
-}
-
-/* ---- Streaming Response ---- */
-.chatStreaming {
-  display: flex;
-  flex-direction: column;
-  max-width: 85%;
-  align-self: flex-start;
-}
-
+/* ---- Streaming ---- */
 .chatStreamCursor {
   display: inline-block;
   width: 2px;
@@ -421,7 +286,7 @@
   51%, 100% { opacity: 0; }
 }
 
-/* ---- Tool Status Indicator ---- */
+/* ---- Tool Status ---- */
 .chatToolStatus {
   display: flex;
   align-items: center;
@@ -429,7 +294,7 @@
   padding: 4px 8px;
   font-size: 0.8rem;
   font-style: italic;
-  color: #8a857c !important;
+  color: #8a857c;
   animation: tool-pulse 1.5s ease-in-out infinite;
 }
 
@@ -438,7 +303,7 @@
   50% { opacity: 0.8; }
 }
 
-/* ---- Typing Indicator ---- */
+/* ---- Typing ---- */
 .chatTyping {
   display: flex;
   align-items: center;
@@ -454,20 +319,15 @@
   animation: typing-bounce 1.4s infinite ease-in-out;
 }
 
-.chatTypingDot:nth-child(2) {
-  animation-delay: 0.2s;
-}
-
-.chatTypingDot:nth-child(3) {
-  animation-delay: 0.4s;
-}
+.chatTypingDot:nth-child(2) { animation-delay: 0.2s; }
+.chatTypingDot:nth-child(3) { animation-delay: 0.4s; }
 
 @keyframes typing-bounce {
   0%, 60%, 100% { transform: translateY(0); opacity: 0.3; }
   30% { transform: translateY(-4px); opacity: 0.7; }
 }
 
-/* ---- Error Message ---- */
+/* ---- Error ---- */
 .chatError {
   color: #c0392b;
   font-size: 0.85rem;
@@ -478,141 +338,28 @@
   border: 1px solid rgba(192, 57, 43, 0.12);
 }
 
-/* ---- Input Area (Expanded) ---- */
-.chatInputArea {
-  display: flex;
-  gap: 8px;
-  padding: 8px 16px;
-  padding-bottom: calc(8px + env(safe-area-inset-bottom, 8px));
-  background: transparent;
-  border-top: none;
-  max-width: 960px;
-  margin: 0 auto;
-  width: 100%;
-}
-
-.chatInput {
-  flex: 1;
-  background: #faf7f2;
-  border: 1px solid #e0dbd2;
-  border-radius: 28px;
-  padding: 12px 20px;
-  color: #4a4640;
-  font-size: 0.9rem;
-  outline: none;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06), 0 1px 4px rgba(0, 0, 0, 0.04), inset 0 1px 2px rgba(255, 255, 255, 0.8);
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  resize: none;
-  min-height: 44px;
-  max-height: 120px;
-  overflow-y: auto;
-  scrollbar-width: none; /* Firefox */
-  -ms-overflow-style: none; /* IE/Edge */
-}
-
-.chatInput::-webkit-scrollbar {
-  display: none; /* Chrome/Safari */
-}
-
-.chatInput::placeholder {
-  color: #9a958c;
-}
-
-.chatInput:focus {
-  border-color: #c4704b;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.06), inset 0 1px 2px rgba(255, 255, 255, 0.8);
-}
-
-.chatInput:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.chatSendBtn {
-  width: 44px;
-  height: 44px;
-  border: none;
-  border-radius: 50%;
-  background: #c4704b;
-  color: white;
-  font-size: 1.1rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 2px 10px rgba(196, 112, 75, 0.3);
-  flex-shrink: 0;
-  opacity: 1;
-}
-
-.chatSendBtn:hover:not(:disabled) {
-  transform: scale(1.05);
-  background: #b5633f;
-  box-shadow: 0 4px 16px rgba(196, 112, 75, 0.4);
-}
-
-.chatSendBtn:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-/* ---- Mobile Styles ---- */
+/* ---- Mobile ---- */
 @media (max-width: 640px) {
-  .chatExpanded {
-    height: 85vh;
-    width: calc(100% - 16px);
-    border-radius: 0;
-  }
-
-  .chatCollapsed {
-    width: calc(100% - 16px);
-    padding: 4px 8px;
-    padding-bottom: calc(4px + env(safe-area-inset-bottom, 0px));
-  }
-
-  .chatPreview {
-    display: none;
-  }
-
-  .chatPreviewText {
-    max-width: 140px;
+  .chatPinnedExpanded {
+    max-height: 80vh;
   }
 
   .chatMessage {
     max-width: 92%;
   }
 
-  .chatInputArea {
+  .chatInputBar {
     padding: 4px 8px;
     padding-bottom: calc(4px + env(safe-area-inset-bottom, 4px));
-    gap: 4px;
   }
 
-  .chatSendBtn,
-  .chatCollapseBtn {
-    width: 40px;
-    height: 40px;
+  .chatSendButton {
+    width: 38px;
+    height: 38px;
   }
-}
 
-/* ---- Animation for auto-expand ---- */
-.chatAutoExpand {
-  animation: auto-expand-in 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-@keyframes auto-expand-in {
-  from { transform: translateY(100%); opacity: 0; }
-  to { transform: translateY(0); opacity: 1; }
-}
-
-/* ---- New message indicator ---- */
-.chatNewMessage {
-  animation: new-message-flash 0.6s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-@keyframes new-message-flash {
-  0% { box-shadow: 0 0 0 0 rgba(196, 112, 75, 0.3); }
-  50% { box-shadow: 0 0 0 6px rgba(196, 112, 75, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(196, 112, 75, 0); }
+  .chatInputField {
+    padding: 8px 14px;
+    font-size: 16px; /* Prevent iOS zoom */
+  }
 }

--- a/app/_components/ChatWidget.tsx
+++ b/app/_components/ChatWidget.tsx
@@ -6,32 +6,23 @@ import styles from './ChatWidget.module.css';
 
 /**
  * Lightweight markdown→HTML for chat messages.
- * Handles: links, bold, italic, inline code, line breaks.
  */
 function renderMarkdown(text: string): string {
   const html = text
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    // Links: [text](url)
     .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
-    // Bare URLs
     .replace(/(^|[\s(])(https?:\/\/[^\s)<]+)/g, '$1<a href="$2" target="_blank" rel="noopener noreferrer">$2</a>')
-    // Bold
     .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
     .replace(/__([^_]+)__/g, '<strong>$1</strong>')
-    // Italic
     .replace(/\*([^*]+)\*/g, '<em>$1</em>')
     .replace(/_([^_]+)_/g, '<em>$1</em>')
-    // Inline code
     .replace(/`([^`]+)`/g, '<code>$1</code>')
-    // Line breaks
     .replace(/\n/g, '<br/>');
-
   return html;
 }
 
-/** Friendly labels for tool calls */
 const TOOL_LABELS: Record<string, string> = {
   'web-search': '🔍 Searching the web…',
   'lookup-place': '📍 Looking up a place…',
@@ -41,33 +32,12 @@ const TOOL_LABELS: Record<string, string> = {
   'create-context': '📋 Creating context…',
 };
 
-/** Format timestamp for display */
 function formatTime(isoString: string): string {
   const date = new Date(isoString);
   return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
-/** Get last message preview text */
-function getLastMessagePreview(messages: ChatMessage[]): string | null {
-  if (messages.length === 0) return null;
-  const lastMsg = messages[messages.length - 1];
-  if (!lastMsg) return null;
-  const preview = lastMsg.content.substring(0, 50);
-  return preview + (lastMsg.content.length > 50 ? '...' : '');
-}
-
-/** Check if there was recent activity (within 5 minutes) */
-function hasRecentActivity(messages: ChatMessage[]): boolean {
-  if (messages.length === 0) return false;
-  const lastMsg = messages[messages.length - 1];
-  if (!lastMsg) return false;
-  const lastMsgTime = new Date(lastMsg.timestamp).getTime();
-  const now = Date.now();
-  return now - lastMsgTime < 5 * 60 * 1000;
-}
-
 export default function ChatWidget() {
-  const [isExpanded, setIsExpanded] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -75,165 +45,42 @@ export default function ChatWidget() {
   const [streamContent, setStreamContent] = useState('');
   const [toolStatus, setToolStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [justExpanded, setJustExpanded] = useState(false);
-  const [autoExpanded, setAutoExpanded] = useState(false);
+  const [chatExpanded, setChatExpanded] = useState(false);
 
-  // Track tool calls used in this chat turn
+  // Active context key — synced from homepage
+  const activeContextKeyRef = useRef<string | null>(null);
+
   const createContextUsed = useRef(false);
-  const updateTripUsed = useRef<string | null>(null); // stores contextKey if update_trip was used
-  // Snapshot of context state before the chat turn
+  const updateTripUsed = useRef<string | null>(null);
   const preContextKeys = useRef<Set<string>>(new Set());
   const preContextSnapshots = useRef<Record<string, { dates?: string; city?: string; focus?: string[] }>>({});
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const collapsedInputRef = useRef<HTMLInputElement>(null);
-  const expandedInputRef = useRef<HTMLTextAreaElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const abortRef = useRef<AbortController | null>(null);
-  const dragStartY = useRef<number>(0);
-  const isDragging = useRef<boolean>(false);
 
-  // Load persisted state from localStorage on mount
+  // Listen for context switches from homepage
   useEffect(() => {
-    try {
-      const saved = localStorage.getItem('chat-widget-state');
-      if (saved) {
-        const parsed = JSON.parse(saved);
-        if (parsed.isExpanded) {
-          setIsExpanded(true);
-          setJustExpanded(true);
-          setTimeout(() => setJustExpanded(false), 400);
-        }
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ key: string }>).detail;
+      if (detail?.key) {
+        activeContextKeyRef.current = detail.key;
       }
-    } catch {
-      // Ignore localStorage errors
-    }
+    };
+    window.addEventListener('compass-context-switched', handler);
+    return () => window.removeEventListener('compass-context-switched', handler);
   }, []);
 
-  // History is intentionally NOT loaded on mount — start with a clean slate.
-  // Only the current session's messages accumulate in state.
-  // To restore history loading, uncomment:
-  // useEffect(() => {
-  //   if (isExpanded && messages.length === 0) loadChatHistory();
-  // }, [isExpanded]);
-
-  // Check for auto-expand on new messages
+  // Auto-scroll to bottom
   useEffect(() => {
-    if (messages.length > 0 && !isExpanded) {
-      const lastMsg = messages[messages.length - 1];
-      if (lastMsg && lastMsg.role === 'assistant') {
-        // Auto-expand on new incoming message
-        handleExpand(true);
-        setAutoExpanded(true);
-        setTimeout(() => setAutoExpanded(false), 600);
-      }
-    }
-  }, [messages]);
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, streamContent, toolStatus]);
 
-  // Check for recent activity to auto-expand on mount
+  // Focus input on mount
   useEffect(() => {
-    if (messages.length > 0 && hasRecentActivity(messages) && !isExpanded) {
-      handleExpand(true);
-      setAutoExpanded(true);
-      setTimeout(() => setAutoExpanded(false), 600);
-    }
+    inputRef.current?.focus();
   }, []);
 
-  // Auto-scroll to bottom on new messages or stream updates
-  // Use 'instant' when expanding to avoid scrolling through old messages
-  const justExpandedRef = useRef(false);
-  useEffect(() => {
-    if (isExpanded && !justExpandedRef.current) {
-      justExpandedRef.current = true;
-      // Jump to bottom instantly when first expanding
-      setTimeout(() => {
-        messagesEndRef.current?.scrollIntoView({ behavior: 'instant' });
-      }, 50);
-    } else {
-      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [messages, streamContent, toolStatus, isExpanded]);
-
-  // Reset justExpanded when collapsing
-  useEffect(() => {
-    if (!isExpanded) justExpandedRef.current = false;
-  }, [isExpanded]);
-
-  // Focus input when expanding
-  useEffect(() => {
-    if (isExpanded) {
-      setTimeout(() => expandedInputRef.current?.focus(), 100);
-    }
-  }, [isExpanded]);
-
-  // Save state to localStorage when it changes
-  useEffect(() => {
-    try {
-      localStorage.setItem('chat-widget-state', JSON.stringify({ isExpanded }));
-    } catch {
-      // Ignore localStorage errors
-    }
-  }, [isExpanded]);
-
-  function handleExpand(expanded: boolean) {
-    setIsExpanded(expanded);
-    if (expanded) {
-      setJustExpanded(true);
-      setTimeout(() => setJustExpanded(false), 400);
-    }
-  }
-
-  function handleToggle() {
-    handleExpand(!isExpanded);
-  }
-
-  function handleDragStart(e: React.MouseEvent | React.TouchEvent) {
-    isDragging.current = true;
-    if ('touches' in e && e.touches && e.touches[0]) {
-      dragStartY.current = e.touches[0].clientY;
-    } else if ('clientY' in e) {
-      dragStartY.current = e.clientY;
-    }
-  }
-
-  function handleDragMove(e: React.MouseEvent | React.TouchEvent) {
-    if (!isDragging.current) return;
-    let currentY: number;
-    if ('touches' in e && e.touches && e.touches[0]) {
-      currentY = e.touches[0].clientY;
-    } else if ('clientY' in e) {
-      currentY = e.clientY;
-    } else {
-      return;
-    }
-    const diff = currentY - dragStartY.current;
-    if (diff > 50) {
-      // Dragged down enough to collapse
-      handleExpand(false);
-      isDragging.current = false;
-    }
-  }
-
-  function handleDragEnd() {
-    isDragging.current = false;
-  }
-
-  async function loadChatHistory() {
-    try {
-      const res = await fetch('/api/chat/history');
-      if (res.ok) {
-        const data = await res.json();
-        if (data.messages) {
-          setMessages(data.messages);
-        }
-      }
-    } catch (e) {
-      console.error('[chat] Failed to load history:', e);
-    }
-  }
-
-  /**
-   * Process an SSE stream from the chat API.
-   */
   const processStream = useCallback(async (response: Response) => {
     const reader = response.body?.getReader();
     if (!reader) throw new Error('No response body');
@@ -248,10 +95,8 @@ export default function ChatWidget() {
         if (done) break;
 
         buffer += decoder.decode(value, { stream: true });
-
-        // Process complete SSE lines
         const lines = buffer.split('\n');
-        buffer = lines.pop() || ''; // keep incomplete line in buffer
+        buffer = lines.pop() || '';
 
         for (const line of lines) {
           if (!line.startsWith('data: ')) continue;
@@ -264,24 +109,20 @@ export default function ChatWidget() {
             if (parsed.content) {
               accumulated += parsed.content;
               setStreamContent(accumulated);
-              setToolStatus(null); // clear tool status when content starts flowing
+              setToolStatus(null);
             }
 
             if (parsed.tool) {
               const label = TOOL_LABELS[parsed.tool] || `⚙️ Using ${parsed.tool}…`;
               setToolStatus(label);
-              // Track context creation so we can emit an emergence event after stream
               if (parsed.tool === 'create-context') {
                 createContextUsed.current = true;
               }
               if (parsed.tool === 'update-trip') {
-                // We'll resolve the key after the stream via context diff
                 updateTripUsed.current = '__any__';
               }
             }
 
-            // When a tool completes (add-to-compass, save-discovery), refresh the page
-            // so new discoveries appear immediately
             if (parsed.toolResult && typeof window !== 'undefined') {
               if (['add-to-compass', 'save-discovery'].includes(parsed.toolResult)) {
                 window.dispatchEvent(new CustomEvent('compass-data-changed'));
@@ -311,7 +152,10 @@ export default function ChatWidget() {
     createContextUsed.current = false;
     updateTripUsed.current = null;
 
-    // Snapshot current context state before we send so we can diff after
+    // Expand chat area on send
+    if (!chatExpanded) setChatExpanded(true);
+
+    // Snapshot contexts
     fetch('/api/contexts')
       .then(r => r.ok ? r.json() : null)
       .then(data => {
@@ -327,12 +171,6 @@ export default function ChatWidget() {
       })
       .catch(() => {});
 
-    // Expand if collapsed when sending
-    if (!isExpanded) {
-      handleExpand(true);
-    }
-
-    // Add user message immediately
     const userMessage: ChatMessage = {
       role: 'user',
       content: trimmed,
@@ -341,7 +179,6 @@ export default function ChatWidget() {
     setMessages((prev) => [...prev, userMessage]);
     setInput('');
 
-    // Create abort controller for this request
     abortRef.current = new AbortController();
 
     try {
@@ -351,6 +188,7 @@ export default function ChatWidget() {
         body: JSON.stringify({
           message: trimmed,
           history: messages,
+          contextKey: activeContextKeyRef.current,
         }),
         signal: abortRef.current.signal,
       });
@@ -362,13 +200,11 @@ export default function ChatWidget() {
       const contentType = res.headers.get('content-type') || '';
 
       if (contentType.includes('text/event-stream')) {
-        // Streaming response
         setLoading(false);
         setStreaming(true);
 
         const fullReply = await processStream(res);
 
-        // Add completed message to history
         if (fullReply) {
           const assistantMessage: ChatMessage = {
             role: 'assistant',
@@ -378,16 +214,12 @@ export default function ChatWidget() {
           setMessages((prev) => [...prev, assistantMessage]);
         }
 
-        // Notify visible pages that Compass data may have changed.
-        // If emergence events are pending, delay the refresh so the animation plays first.
         const hasEmergenceEvents = createContextUsed.current || updateTripUsed.current;
         if (typeof window !== 'undefined' && !hasEmergenceEvents) {
           window.dispatchEvent(new CustomEvent('compass-data-changed'));
         }
 
-        // If create-context or update-trip was used, diff contexts and emit emergence events
         if (hasEmergenceEvents && typeof window !== 'undefined') {
-          // Small delay to let Blob writes settle
           setTimeout(async () => {
             try {
               const res = await fetch('/api/contexts');
@@ -395,15 +227,17 @@ export default function ChatWidget() {
                 const data = await res.json();
                 const allCtxs = data.contexts as Array<{ key: string; label: string; type: string; emoji: string; dates?: string; city?: string; focus?: string[] }>;
 
-                // New contexts → emergence animation
                 const newCtxs = allCtxs.filter(c => !preContextKeys.current.has(c.key));
                 for (const ctx of newCtxs) {
                   window.dispatchEvent(new CustomEvent('compass-trip-created', {
                     detail: { key: ctx.key, label: ctx.label, type: ctx.type, emoji: ctx.emoji },
                   }));
+                  // Signal the homepage to switch to the new context
+                  window.dispatchEvent(new CustomEvent('compass-chat-context-switch', {
+                    detail: { key: ctx.key },
+                  }));
                 }
 
-                // Updated contexts → attribute attachment events
                 if (updateTripUsed.current) {
                   for (const ctx of allCtxs) {
                     const prev = preContextSnapshots.current[ctx.key];
@@ -430,7 +264,6 @@ export default function ChatWidget() {
             } catch {
               // non-critical
             }
-            // Now safe to refresh — animation has been triggered
             window.dispatchEvent(new CustomEvent('compass-data-changed'));
           }, 800);
         }
@@ -439,7 +272,6 @@ export default function ChatWidget() {
         setStreaming(false);
         setToolStatus(null);
       } else {
-        // Non-streaming JSON response (fallback)
         const data = await res.json();
         const assistantMessage: ChatMessage = {
           role: 'assistant',
@@ -455,7 +287,7 @@ export default function ChatWidget() {
 
     } catch (e) {
       if (e instanceof Error && e.name === 'AbortError') {
-        // User cancelled — no error
+        // User cancelled
       } else {
         console.error('[chat] Send failed:', e);
         setError('Failed to send. Try again?');
@@ -469,156 +301,101 @@ export default function ChatWidget() {
     }
   }
 
-  const lastPreview = getLastMessagePreview(messages);
-
-  // Render collapsed state
-  if (!isExpanded) {
-    return (
-      <div className={styles.chatRoot}>
-        <div className={styles.chatCollapsed}>
-          {/* Input section */}
-          <div
-            className={styles.chatCollapsedInput}
-            onClick={(e) => {
-              e.stopPropagation();
-              handleExpand(true);
-            }}
-          >
-            <input
-              ref={collapsedInputRef}
-              type="text"
-              className={styles.chatCollapsedField}
-              placeholder="Type a message..."
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey) {
-                  e.preventDefault();
-                  handleSend(e as unknown as React.FormEvent);
-                }
-              }}
-              disabled={loading || streaming}
-            />
-            <button
-              type="button"
-              className={styles.chatCollapsedSend}
-              disabled={loading || streaming || !input.trim()}
-              onClick={(e) => {
-                e.stopPropagation();
-                handleSend(e as unknown as React.FormEvent);
-              }}
-            >
-              ➤
-            </button>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Render expanded state
   return (
-    <div
-      className={`${styles.chatRoot} ${autoExpanded ? styles.chatAutoExpand : ''}`}
-      onMouseMove={handleDragMove}
-      onMouseUp={handleDragEnd}
-      onMouseLeave={handleDragEnd}
-      onTouchMove={handleDragMove}
-      onTouchEnd={handleDragEnd}
-    >
-      <div
-        className={`${styles.chatExpanded} ${justExpanded || autoExpanded ? styles.chatAutoExpand : ''}`}
-      >
-        {/* Drag handle */}
-        <div
-          className={styles.chatDragHandle}
-          onMouseDown={handleDragStart}
-          onTouchStart={handleDragStart}
-        >
-          <div className={styles.chatDragHandleBar} />
-        </div>
-
-        {/* Messages */}
-        <div className={styles.chatMessages}>
-          {messages.length === 0 && !loading && !streaming && (
-            <div className={styles.chatEmpty}>
-              <div className={styles.chatEmptyIcon}>🧭</div>
-              <div className={styles.chatEmptyTitle}>Hey! I&apos;m your Compass Concierge.</div>
-              <div className={styles.chatEmptyText}>
-                Ask me about restaurants, places to visit, or help planning your next trip.
+    <div className={`${styles.chatPinned} ${chatExpanded ? styles.chatPinnedExpanded : ''}`}>
+      {/* Messages area — only visible when expanded */}
+      {chatExpanded && (
+        <div className={styles.chatMessagesArea}>
+          <div className={styles.chatMessages}>
+            {messages.length === 0 && !loading && !streaming && (
+              <div className={styles.chatEmpty}>
+                <div className={styles.chatEmptyIcon}>🧭</div>
+                <div className={styles.chatEmptyTitle}>Hey! I&apos;m your Compass Concierge.</div>
+                <div className={styles.chatEmptyText}>
+                  Ask me about restaurants, places to visit, or help planning your next trip.
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
-          {messages.map((msg, i) => (
-            <div
-              key={i}
-              className={`${styles.chatMessage} ${
-                msg.role === 'user' ? styles.chatMessageUser : styles.chatMessageAssistant
-              }`}
-            >
+            {messages.map((msg, i) => (
               <div
-                className={`${styles.chatBubble} ${
-                  msg.role === 'user' ? styles.chatBubbleUser : styles.chatBubbleAssistant
+                key={i}
+                className={`${styles.chatMessage} ${
+                  msg.role === 'user' ? styles.chatMessageUser : styles.chatMessageAssistant
                 }`}
               >
-                {msg.role === 'assistant' ? (
+                <div
+                  className={`${styles.chatBubble} ${
+                    msg.role === 'user' ? styles.chatBubbleUser : styles.chatBubbleAssistant
+                  }`}
+                >
+                  {msg.role === 'assistant' ? (
+                    <div
+                      className={styles.chatMarkdown}
+                      dangerouslySetInnerHTML={{ __html: renderMarkdown(msg.content) }}
+                    />
+                  ) : (
+                    <div className={styles.chatMarkdown}>{msg.content}</div>
+                  )}
+                </div>
+                <span className={styles.chatTimestamp}>{formatTime(msg.timestamp)}</span>
+              </div>
+            ))}
+
+            {streaming && streamContent && (
+              <div className={`${styles.chatMessage} ${styles.chatMessageAssistant}`}>
+                <div className={`${styles.chatBubble} ${styles.chatBubbleAssistant}`}>
                   <div
                     className={styles.chatMarkdown}
-                    dangerouslySetInnerHTML={{ __html: renderMarkdown(msg.content) }}
+                    dangerouslySetInnerHTML={{ __html: renderMarkdown(streamContent) }}
                   />
-                ) : (
-                  <div className={styles.chatMarkdown}>{msg.content}</div>
-                )}
+                  <span className={styles.chatStreamCursor} />
+                </div>
               </div>
-              <span className={styles.chatTimestamp}>{formatTime(msg.timestamp)}</span>
-            </div>
-          ))}
+            )}
 
-          {/* Streaming response in progress */}
-          {streaming && streamContent && (
-            <div className={`${styles.chatMessage} ${styles.chatMessageAssistant}`}>
-              <div className={`${styles.chatBubble} ${styles.chatBubbleAssistant}`}>
-                <div
-                  className={styles.chatMarkdown}
-                  dangerouslySetInnerHTML={{ __html: renderMarkdown(streamContent) }}
-                />
-                <span className={styles.chatStreamCursor} />
+            {toolStatus && (
+              <div className={`${styles.chatMessage} ${styles.chatMessageAssistant}`}>
+                <div className={styles.chatToolStatus}>{toolStatus}</div>
               </div>
-            </div>
-          )}
+            )}
 
-          {/* Tool-use indicator */}
-          {toolStatus && (
-            <div className={`${styles.chatMessage} ${styles.chatMessageAssistant}`}>
-              <div className={styles.chatToolStatus}>{toolStatus}</div>
-            </div>
-          )}
-
-          {/* Initial loading dots (before first token) */}
-          {loading && (
-            <div className={`${styles.chatMessage} ${styles.chatMessageAssistant}`}>
-              <div className={styles.chatTyping}>
-                <span className={styles.chatTypingDot} />
-                <span className={styles.chatTypingDot} />
-                <span className={styles.chatTypingDot} />
+            {loading && (
+              <div className={`${styles.chatMessage} ${styles.chatMessageAssistant}`}>
+                <div className={styles.chatTyping}>
+                  <span className={styles.chatTypingDot} />
+                  <span className={styles.chatTypingDot} />
+                  <span className={styles.chatTypingDot} />
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
-          {error && (
-            <div className={styles.chatError}>{error}</div>
-          )}
+            {error && (
+              <div className={styles.chatError}>{error}</div>
+            )}
 
-          <div ref={messagesEndRef} />
+            <div ref={messagesEndRef} />
+          </div>
         </div>
+      )}
 
-        {/* Input area */}
-        <form className={styles.chatInputArea} onSubmit={handleSend}>
+      {/* Input area — always visible, pinned to bottom */}
+      <div className={styles.chatInputBar}>
+        {chatExpanded && (
+          <button
+            type="button"
+            className={styles.chatMinimizeBtn}
+            onClick={() => setChatExpanded(false)}
+            aria-label="Minimize chat"
+          >
+            ▾
+          </button>
+        )}
+        <form className={styles.chatInputForm} onSubmit={handleSend}>
           <textarea
-            ref={expandedInputRef}
-            className={styles.chatInput}
-            placeholder="Ask me anything..."
+            ref={inputRef}
+            className={styles.chatInputField}
+            placeholder="Ask me anything…"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => {
@@ -627,23 +404,18 @@ export default function ChatWidget() {
                 handleSend(e as unknown as React.FormEvent);
               }
             }}
+            onFocus={() => {
+              if (messages.length > 0 && !chatExpanded) setChatExpanded(true);
+            }}
             disabled={loading || streaming}
             rows={1}
           />
           <button
             type="submit"
-            className={styles.chatSendBtn}
+            className={styles.chatSendButton}
             disabled={loading || streaming || !input.trim()}
           >
             ➤
-          </button>
-          <button
-            type="button"
-            className={styles.chatCollapseBtn}
-            onClick={() => handleExpand(false)}
-            aria-label="Collapse chat"
-          >
-            ✕
           </button>
         </form>
       </div>

--- a/app/_components/ContextSwitcher.tsx
+++ b/app/_components/ContextSwitcher.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import Twemoji from './Twemoji';
+
+interface ContextOption {
+  key: string;
+  label: string;
+  emoji: string;
+  type: string;
+  dates?: string;
+}
+
+interface ContextSwitcherProps {
+  contexts: ContextOption[];
+  activeKey: string | null;
+  onSelect: (key: string) => void;
+}
+
+const TYPE_EMOJI: Record<string, string> = {
+  trip: '✈️',
+  outing: '🍽️',
+  radar: '📡',
+};
+
+const TYPE_LABEL: Record<string, string> = {
+  trip: 'Trips',
+  outing: 'Outings',
+  radar: 'Radars',
+};
+
+export default function ContextSwitcher({ contexts, activeKey, onSelect }: ContextSwitcherProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const active = contexts.find(c => c.key === activeKey);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  // Group by type
+  const grouped: Record<string, ContextOption[]> = {};
+  for (const ctx of contexts) {
+    if (!grouped[ctx.type]) grouped[ctx.type] = [];
+    grouped[ctx.type]!.push(ctx);
+  }
+
+  return (
+    <div className="ctx-switcher" ref={ref}>
+      <button
+        className="ctx-switcher-trigger"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+      >
+        {active ? (
+          <>
+            <span className="ctx-switcher-emoji">
+              <Twemoji emoji={active.emoji || TYPE_EMOJI[active.type] || '📌'} size="md" />
+            </span>
+            <span className="ctx-switcher-label">{active.label}</span>
+          </>
+        ) : (
+          <span className="ctx-switcher-label">Select a context…</span>
+        )}
+        <span className={`ctx-switcher-chevron${open ? ' ctx-switcher-chevron-open' : ''}`}>▸</span>
+      </button>
+
+      {open && (
+        <div className="ctx-switcher-dropdown" role="listbox">
+          {(['trip', 'outing', 'radar'] as const).map(type => {
+            const items = grouped[type];
+            if (!items || items.length === 0) return null;
+            return (
+              <div key={type} className="ctx-switcher-group">
+                <div className="ctx-switcher-group-label">{TYPE_LABEL[type]}</div>
+                {items.map(ctx => (
+                  <button
+                    key={ctx.key}
+                    className={`ctx-switcher-option${ctx.key === activeKey ? ' ctx-switcher-option-active' : ''}`}
+                    onClick={() => {
+                      onSelect(ctx.key);
+                      setOpen(false);
+                    }}
+                    role="option"
+                    aria-selected={ctx.key === activeKey}
+                  >
+                    <span className="ctx-switcher-option-emoji">
+                      <Twemoji emoji={ctx.emoji || TYPE_EMOJI[ctx.type] || '📌'} size="sm" />
+                    </span>
+                    <span className="ctx-switcher-option-text">
+                      <span className="ctx-switcher-option-label">{ctx.label}</span>
+                      {ctx.dates && <span className="ctx-switcher-option-dates">{ctx.dates}</span>}
+                    </span>
+                    {ctx.key === activeKey && <span className="ctx-switcher-option-check">✓</span>}
+                  </button>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import type { Context, Discovery } from '../_lib/types';
@@ -9,6 +9,7 @@ import PlaceGrid from './PlaceGrid';
 import BriefingBanner from './BriefingBanner';
 import Twemoji from './Twemoji';
 import TripPlanningWidget from './TripPlanningWidget';
+import ContextSwitcher from './ContextSwitcher';
 
 interface MonitoringQueueItem {
   id: string;
@@ -40,25 +41,20 @@ const TYPE_EMOJI: Record<string, string> = {
 
 /**
  * Format dates naturally.
- * "April 27-30, 2026" → "April 27 - 30"
- * "July 2026 (3+ weeks)" → "This July · 3+ weeks"
- * "April 27-30, 2026" (if current year) → "April 27 - 30"
  */
 function formatDateNatural(dates: string | undefined): string | null {
   if (!dates) return null;
 
   const now = new Date();
   const currentYear = now.getFullYear();
-  const currentMonth = now.getMonth(); // 0-indexed
+  const currentMonth = now.getMonth();
 
   const months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
 
-  // Extract parenthetical note (e.g. "(3+ weeks)")
   const parenMatch = dates.match(/\(([^)]+)\)/);
   const note = parenMatch ? parenMatch[1] : null;
   const cleaned = dates.replace(/\s*\([^)]*\)/, '').trim();
 
-  // ISO: "2026-04-27 to 2026-04-30"
   const isoRange = cleaned.match(/^(\d{4})-(\d{2})-(\d{2})\s+to\s+(\d{4})-(\d{2})-(\d{2})$/);
   if (isoRange) {
     const [, , startMo, startDay, endYr, endMo, endDay] = isoRange;
@@ -74,7 +70,6 @@ function formatDateNatural(dates: string | undefined): string | null {
     return `${sMonth} ${parseInt(startDay ?? '0')} - ${eMonth} ${parseInt(endDay ?? '0')}${yearSuffix}`;
   }
 
-  // "April 27-30, 2026"
   const rangeInMonth = cleaned.match(/^(\w+)\s+(\d+)\s*[--]\s*(\d+),?\s+(\d{4})$/);
   if (rangeInMonth) {
     const [, month, startDay, endDay, year] = rangeInMonth;
@@ -87,7 +82,6 @@ function formatDateNatural(dates: string | undefined): string | null {
     return `${prefix}${month} ${startDay} - ${endDay}${yearSuffix}`;
   }
 
-  // "April 27 - May 2, 2026"
   const rangeAcross = cleaned.match(/^(\w+)\s+(\d+)\s*[--]\s*(\w+)\s+(\d+),?\s+(\d{4})$/);
   if (rangeAcross) {
     const [, m1, d1, m2, d2, year] = rangeAcross;
@@ -96,7 +90,6 @@ function formatDateNatural(dates: string | undefined): string | null {
     return `${m1} ${d1} - ${m2} ${d2}${yearSuffix}`;
   }
 
-  // "July 2026"
   const monthYear = cleaned.match(/^(\w+)\s+(\d{4})$/);
   if (monthYear) {
     const [, month, year] = monthYear;
@@ -111,7 +104,6 @@ function formatDateNatural(dates: string | undefined): string | null {
     return result;
   }
 
-  // Fallback: return as-is but strip year if current
   const withoutYear = cleaned.replace(new RegExp(`,?\\s*${currentYear}`), '');
   return note ? `${withoutYear} · ${note}` : withoutYear;
 }
@@ -195,25 +187,80 @@ export default function HomeClient({
   monitoringQueue = [],
 }: HomeClientProps) {
   const router = useRouter();
-  // Mounted state to avoid hydration mismatch from localStorage reads
   const [mounted, setMounted] = useState(false);
-  // Store context counts - initialize with zeros to match server render
-  const [contextCounts, setContextCounts] = useState<Record<string, { saved: number; dismissed: number; resurfaced: number }>>({}); 
-  // Keys that are currently "emerging" (just created from chat) — gets entrance animation
+  const [contextCounts, setContextCounts] = useState<Record<string, { saved: number; dismissed: number; resurfaced: number }>>({});
   const [emergingKeys, setEmergingKeys] = useState<Set<string>>(new Set());
-  // Map of context key → recently-attached attribute pills
   const [attachingAttrs, setAttachingAttrs] = useState<Record<string, Array<{ field: string; value: string }>>>({});
-
-  // Re-render when triage state changes (for saved count badges)
-  // Must be BEFORE any conditional returns (Rules of Hooks)
   const [, setTriageVersion] = useState(0);
+
+  // Active context key — persisted in localStorage
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+
+  // Initialize active key from localStorage or first context
+  useEffect(() => {
+    setMounted(true);
+    // Load all context counts
+    const counts: Record<string, { saved: number; dismissed: number; resurfaced: number }> = {};
+    for (const ctx of contexts) {
+      counts[ctx.key] = getContextCounts(userId, ctx.key);
+    }
+    setContextCounts(counts);
+
+    // Restore active key
+    try {
+      const stored = localStorage.getItem('compass-active-context');
+      if (stored && contexts.some(c => c.key === stored)) {
+        setActiveKey(stored);
+      } else if (contexts.length > 0) {
+        setActiveKey(contexts[0]!.key);
+      }
+    } catch {
+      if (contexts.length > 0) setActiveKey(contexts[0]!.key);
+    }
+  }, [userId, contexts]);
+
+  // Persist active key
+  useEffect(() => {
+    if (!activeKey) return;
+    try {
+      localStorage.setItem('compass-active-context', activeKey);
+    } catch { /* ignore */ }
+  }, [activeKey]);
+
+  // Broadcast active context to chat widget
+  const broadcastActiveContext = useCallback((key: string) => {
+    window.dispatchEvent(new CustomEvent('compass-context-switched', {
+      detail: { key },
+    }));
+  }, []);
+
+  const handleContextSelect = useCallback((key: string) => {
+    setActiveKey(key);
+    broadcastActiveContext(key);
+  }, [broadcastActiveContext]);
+
+  // Listen for chat-driven context switches
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ key: string }>).detail;
+      if (!detail?.key) return;
+      // If the context exists, switch to it
+      if (contexts.some(c => c.key === detail.key)) {
+        setActiveKey(detail.key);
+      }
+    };
+    window.addEventListener('compass-chat-context-switch', handler);
+    return () => window.removeEventListener('compass-chat-context-switch', handler);
+  }, [contexts]);
+
+  // Triage change listener
   useEffect(() => {
     const handler = () => setTriageVersion((v) => v + 1);
     window.addEventListener('triage-changed', handler);
     return () => window.removeEventListener('triage-changed', handler);
   }, []);
 
-  // Listen for new trip creation from chat and mark the key as emerging
+  // Listen for new trip creation from chat
   useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<{ key: string }>).detail;
@@ -223,7 +270,8 @@ export default function HomeClient({
         next.add(detail.key);
         return next;
       });
-      // Remove the emerging flag after the animation completes (600ms animation + buffer)
+      // Switch to the newly created context
+      setActiveKey(detail.key);
       setTimeout(() => {
         setEmergingKeys(prev => {
           const next = new Set(prev);
@@ -245,7 +293,6 @@ export default function HomeClient({
         ...prev,
         [detail.key]: detail.attributes,
       }));
-      // Clear attribute pills after animation
       setTimeout(() => {
         setAttachingAttrs(prev => {
           const next = { ...prev };
@@ -258,7 +305,7 @@ export default function HomeClient({
     return () => window.removeEventListener('compass-trip-attributes', handler);
   }, []);
 
-  // Refresh homepage immediately when chat or other client actions mutate Compass data.
+  // Refresh data when chat mutates
   useEffect(() => {
     let refreshTimer: ReturnType<typeof setTimeout> | null = null;
     const handler = () => {
@@ -274,163 +321,152 @@ export default function HomeClient({
     };
   }, [router]);
 
-  // Initialize from localStorage after mount
+  // Broadcast initial context on mount
   useEffect(() => {
-    setMounted(true);
-    // Load all context counts
-    const counts: Record<string, { saved: number; dismissed: number; resurfaced: number }> = {};
-    for (const ctx of contexts) {
-      counts[ctx.key] = getContextCounts(userId, ctx.key);
+    if (activeKey) {
+      broadcastActiveContext(activeKey);
     }
-    setContextCounts(counts);
-  }, [userId, contexts]);
-
-  // Triage hydration now handled by <TriageHydrator> in root layout
+  }, [activeKey, broadcastActiveContext]);
 
   if (contexts.length === 0) {
     return (
-      <main className="page">
-        <div className="page-header">
+      <main className="page focused-page">
+        <div className="focused-header">
           <h1>🧭 Compass</h1>
-          <p>No active contexts yet. Chat with the concierge to set up your first trip, outing, or radar.</p>
+          <p className="compass-tagline">Your AI travel concierge</p>
+        </div>
+        <div className="focused-empty">
+          <div className="focused-empty-icon">🌍</div>
+          <h2>Where to next?</h2>
+          <p>Start planning by chatting below — tell me about a trip, a dinner out, or a neighbourhood to explore.</p>
         </div>
       </main>
     );
   }
 
+  const ctx = contexts.find(c => c.key === activeKey) || contexts[0]!;
+  const discoveries = discoveryMap[ctx.key] ?? [];
+  const counts = mounted ? (contextCounts[ctx.key] ?? { saved: 0, dismissed: 0, resurfaced: 0 }) : { saved: 0, dismissed: 0, resurfaced: 0 };
+  const naturalDate = formatDateNatural(ctx.dates);
+  const description = buildDescription(ctx);
+  const isEmerging = emergingKeys.has(ctx.key);
+  const landingAttrs = attachingAttrs[ctx.key] ?? [];
+
   return (
-    <main className="page">
-      <div className="page-header compass-header">
-        <h1>🧭 Compass</h1>
-        <p className="compass-tagline">The AI Travel Agent that ensures the best experience on your trips and outings</p>
+    <main className="page focused-page">
+      {/* Header with context switcher */}
+      <div className="focused-header">
+        <div className="focused-header-top">
+          <h1 className="focused-brand">🧭</h1>
+          <ContextSwitcher
+            contexts={contexts.map(c => ({
+              key: c.key,
+              label: c.label,
+              emoji: c.emoji,
+              type: c.type,
+              dates: c.dates,
+            }))}
+            activeKey={activeKey}
+            onSelect={handleContextSelect}
+          />
+        </div>
       </div>
 
-      <BriefingBanner userId={userId} />
-
-      <MonitoringQueueTray items={monitoringQueue} />
-
-      {contexts.map(ctx => {
-        const discoveries = discoveryMap[ctx.key] ?? [];
-        // Use stored counts after mount, or zeros before mount (matches server)
-        const counts = mounted ? (contextCounts[ctx.key] ?? { saved: 0, dismissed: 0, resurfaced: 0 }) : { saved: 0, dismissed: 0, resurfaced: 0 };
-        const naturalDate = formatDateNatural(ctx.dates);
-        const description = buildDescription(ctx);
-
-        const isEmerging = emergingKeys.has(ctx.key);
-        const landingAttrs = attachingAttrs[ctx.key] ?? [];
-        return (
-          <section key={ctx.key} className={`section${isEmerging ? ' section-emerging' : ''}`}>
-            <div className={`section-header${ctx.type === 'trip' ? ' section-header-trip' : ''}`}>
-              <div className="section-header-left">
-                <div className={`section-title-row${ctx.type === 'trip' ? ' section-title-row-trip' : ''}`}>
-                  <span className={ctx.type === 'trip' ? 'section-emoji-trip' : 'section-emoji-large'}>
-                    <Twemoji emoji={ctx.emoji || TYPE_EMOJI[ctx.type] || '📌'} size={ctx.type === 'trip' ? 'xl' : 'lg'} />
-                  </span>
-                  <div className="section-title-text">
-                    <h2 className={ctx.type === 'trip' ? 'section-title-trip' : ''}>{ctx.label}</h2>
-                    <div className="section-meta">
-                      {naturalDate && (
-                        <span className={`section-date${ctx.type === 'trip' ? ' section-date-trip' : ''}`}>{naturalDate}</span>
-                      )}
-                      {/* For non-trip: inline with separator */}
-                      {naturalDate && description && ctx.type !== 'trip' && (
-                        <span className="section-meta-sep">·</span>
-                      )}
-                      {description && ctx.type !== 'trip' && (
-                        <span className="section-desc">{description}</span>
-                      )}
-                    </div>
-                    {/* For trips: description on its own third line */}
-                    {description && ctx.type === 'trip' && (
-                      <div className="section-desc-trip">{description}</div>
-                    )}
-                    {/* Attribute pills — appear when chat attaches new trip attributes */}
-                    {landingAttrs.length > 0 && (
-                      <div className="section-attr-pills">
-                        {landingAttrs.map(attr => (
-                          <span key={attr.field} className="section-attr-pill">
-                            {attr.field === 'dates' ? '📅' : attr.field === 'city' ? '📍' : '🏷'} {attr.value}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-
-              {/* Desktop: trip planning widget inline with header */}
-              {ctx.type === 'trip' && (() => {
-                const raw = ctx as unknown as Record<string, unknown>;
-                return (
-                <div className="section-header-trip-widget">
-                  <TripPlanningWidget
-                    userId={userId}
-                    contextKey={ctx.key}
-                    travel={contextMeta[ctx.key]?.travel as never}
-                    accommodation={contextMeta[ctx.key]?.accommodation as never}
-                    bookingStatus={contextMeta[ctx.key]?.bookingStatus}
-                    savedCount={counts.saved}
-                    purpose={raw.purpose as string | undefined}
-                    people={raw.people as Array<{ name: string; relation?: string }> | undefined}
-                  />
-                </div>
-                );})()}
-
-              <div className="section-header-right">
-                {ctx.type !== 'trip' && counts.saved > 0 && (
-                  <Link
-                    href={`/review/${encodeURIComponent(ctx.key)}?tab=saved`}
-                    className="saved-count-badge"
-                  >
-                    ✓ {counts.saved} saved
-                  </Link>
+      {/* Focused context content */}
+      <div className={`focused-content${isEmerging ? ' section-emerging' : ''}`}>
+        {/* Context hero */}
+        <div className={`focused-hero${ctx.type === 'trip' ? ' focused-hero-trip' : ''}`}>
+          <div className="focused-hero-left">
+            <span className="focused-hero-emoji">
+              <Twemoji emoji={ctx.emoji || TYPE_EMOJI[ctx.type] || '📌'} size={ctx.type === 'trip' ? 'xl' : 'lg'} />
+            </span>
+            <div className="focused-hero-text">
+              <h2 className={`focused-hero-title${ctx.type === 'trip' ? ' focused-hero-title-trip' : ''}`}>{ctx.label}</h2>
+              <div className="focused-hero-meta">
+                {naturalDate && (
+                  <span className={`section-date${ctx.type === 'trip' ? ' section-date-trip' : ''}`}>{naturalDate}</span>
                 )}
-                {ctx.type !== 'trip' && (
-                  <Link
-                    href={`/review/${encodeURIComponent(ctx.key)}`}
-                    className="section-review-link"
-                  >
-                    Review →
-                  </Link>
+                {naturalDate && description && ctx.type !== 'trip' && (
+                  <span className="section-meta-sep">·</span>
+                )}
+                {description && ctx.type !== 'trip' && (
+                  <span className="section-desc">{description}</span>
                 )}
               </div>
+              {description && ctx.type === 'trip' && (
+                <div className="section-desc-trip">{description}</div>
+              )}
+              {landingAttrs.length > 0 && (
+                <div className="section-attr-pills">
+                  {landingAttrs.map(attr => (
+                    <span key={attr.field} className="section-attr-pill">
+                      {attr.field === 'dates' ? '📅' : attr.field === 'city' ? '📍' : '🏷'} {attr.value}
+                    </span>
+                  ))}
+                </div>
+              )}
             </div>
+          </div>
 
-            {/* Mobile: trip planning widget below header */}
-            {ctx.type === 'trip' && (() => {
-              const raw = ctx as unknown as Record<string, unknown>;
-              return (
-              <div className="section-trip-widget-mobile">
-                <TripPlanningWidget
-                  userId={userId}
-                  contextKey={ctx.key}
-                  travel={contextMeta[ctx.key]?.travel as never}
-                  accommodation={contextMeta[ctx.key]?.accommodation as never}
-                  bookingStatus={contextMeta[ctx.key]?.bookingStatus}
-                  savedCount={counts.saved}
-                  purpose={raw.purpose as string | undefined}
-                  people={raw.people as Array<{ name: string; relation?: string }> | undefined}
-                />
-              </div>
-              );})()}
-
-            {discoveries.length > 0 ? (
-              <PlaceGrid
-                discoveries={discoveries}
-                contextKey={ctx.key}
-                userId={userId}
-                layout="carousel"
-              />
-            ) : (
-              <div className="empty-state">
-                <p className="text-muted text-sm">
-                  No discoveries yet - the radar is scanning.
-                </p>
-              </div>
+          <div className="focused-hero-right">
+            {ctx.type !== 'trip' && counts.saved > 0 && (
+              <Link
+                href={`/review/${encodeURIComponent(ctx.key)}?tab=saved`}
+                className="saved-count-badge"
+              >
+                ✓ {counts.saved} saved
+              </Link>
             )}
-          </section>
-        );
-      })}
+            {ctx.type !== 'trip' && (
+              <Link
+                href={`/review/${encodeURIComponent(ctx.key)}`}
+                className="section-review-link"
+              >
+                Review →
+              </Link>
+            )}
+          </div>
+        </div>
+
+        {/* Trip planning widget */}
+        {ctx.type === 'trip' && (() => {
+          const raw = ctx as unknown as Record<string, unknown>;
+          return (
+            <div className="focused-trip-widget">
+              <TripPlanningWidget
+                userId={userId}
+                contextKey={ctx.key}
+                travel={contextMeta[ctx.key]?.travel as never}
+                accommodation={contextMeta[ctx.key]?.accommodation as never}
+                bookingStatus={contextMeta[ctx.key]?.bookingStatus}
+                savedCount={counts.saved}
+                purpose={raw.purpose as string | undefined}
+                people={raw.people as Array<{ name: string; relation?: string }> | undefined}
+              />
+            </div>
+          );
+        })()}
+
+        <BriefingBanner userId={userId} />
+
+        <MonitoringQueueTray items={monitoringQueue.filter(i => i.contextKey === ctx.key)} />
+
+        {/* Discoveries */}
+        {discoveries.length > 0 ? (
+          <PlaceGrid
+            discoveries={discoveries}
+            contextKey={ctx.key}
+            userId={userId}
+            layout="carousel"
+          />
+        ) : (
+          <div className="focused-empty-discoveries">
+            <p className="text-muted text-sm">
+              No discoveries yet — chat below to start exploring.
+            </p>
+          </div>
+        )}
+      </div>
     </main>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -6734,3 +6734,307 @@ nextjs-portal { display: none !important; }
 .watch-view-link:hover {
   text-decoration: underline;
 }
+
+
+/* ============================================================
+   Single-Track Focused Homepage (#266)
+   One context fills the page, chat pinned to bottom
+   ============================================================ */
+
+/* ---- Focused Page Layout ---- */
+.focused-page {
+  padding-bottom: 80px; /* space for pinned chat input */
+}
+
+.focused-header {
+  margin-bottom: var(--space-lg);
+}
+
+.focused-header-top {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.focused-brand {
+  font-size: 1.6rem;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+/* ---- Empty State ---- */
+.focused-empty {
+  text-align: center;
+  padding: var(--space-2xl) var(--space-md);
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.focused-empty-icon {
+  font-size: 3rem;
+  margin-bottom: var(--space-md);
+  opacity: 0.7;
+}
+
+.focused-empty h2 {
+  font-size: 1.5rem;
+  margin-bottom: var(--space-sm);
+}
+
+.focused-empty p {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+/* ---- Focused Content ---- */
+.focused-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+/* ---- Focused Hero (context header) ---- */
+.focused-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.focused-hero-left {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75em;
+  flex: 1;
+  min-width: 0;
+}
+
+.focused-hero-emoji {
+  flex-shrink: 0;
+}
+
+.focused-hero-emoji .twemoji-img {
+  height: 2.8em !important;
+  width: 2.8em !important;
+}
+
+.focused-hero-trip .focused-hero-emoji .twemoji-img {
+  height: 4em !important;
+  width: 4em !important;
+}
+
+.focused-hero-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.focused-hero-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 2px;
+}
+
+.focused-hero-title-trip {
+  font-size: 1.85rem !important;
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.focused-hero-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.focused-hero-right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-shrink: 0;
+}
+
+/* ---- Trip Widget on Focused Page ---- */
+.focused-trip-widget {
+  /* Full width on mobile, contained on desktop */
+}
+
+@media (min-width: 768px) {
+  .focused-trip-widget {
+    max-width: 500px;
+  }
+}
+
+/* ---- Empty Discoveries ---- */
+.focused-empty-discoveries {
+  padding: var(--space-xl) var(--space-md);
+  text-align: center;
+  border: 1px dashed var(--card-border);
+  border-radius: var(--radius-md);
+}
+
+/* ---- Context Switcher ---- */
+.ctx-switcher {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.ctx-switcher-trigger {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  transition: all var(--transition-fast);
+  min-height: 44px;
+}
+
+.ctx-switcher-trigger:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-sm);
+}
+
+.ctx-switcher-emoji {
+  flex-shrink: 0;
+}
+
+.ctx-switcher-label {
+  flex: 1;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ctx-switcher-chevron {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.ctx-switcher-chevron-open {
+  transform: rotate(90deg);
+}
+
+.ctx-switcher-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: var(--bg-elevated);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: 200;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding: var(--space-xs) 0;
+  animation: ctx-dropdown-in 0.15s ease-out;
+}
+
+@keyframes ctx-dropdown-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.ctx-switcher-group {
+  padding: var(--space-xs) 0;
+}
+
+.ctx-switcher-group + .ctx-switcher-group {
+  border-top: 1px solid var(--card-border);
+}
+
+.ctx-switcher-group-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  padding: var(--space-xs) var(--space-md);
+}
+
+.ctx-switcher-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  width: 100%;
+  padding: var(--space-sm) var(--space-md);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--transition-fast);
+  min-height: 44px;
+}
+
+.ctx-switcher-option:hover {
+  background: var(--bg-secondary);
+}
+
+.ctx-switcher-option-active {
+  background: rgba(59, 130, 246, 0.06);
+}
+
+.ctx-switcher-option-emoji {
+  flex-shrink: 0;
+}
+
+.ctx-switcher-option-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.ctx-switcher-option-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ctx-switcher-option-dates {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.ctx-switcher-option-check {
+  color: var(--accent);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+/* ---- Mobile adjustments ---- */
+@media (max-width: 640px) {
+  .focused-page {
+    padding-bottom: 70px;
+  }
+
+  .focused-hero {
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  .focused-hero-right {
+    align-self: flex-start;
+  }
+
+  .focused-hero-title-trip {
+    font-size: 1.5rem !important;
+  }
+}


### PR DESCRIPTION
## Summary

Redesigns the Compass homepage from a multi-context stacked list into a **single-track focused view** where one trip/context fills the page and the chat drives which context is shown.

### Changes

**New: `ContextSwitcher.tsx`**
- Header dropdown component for switching between trips/outings/radars
- Grouped by type (Trips, Outings, Radars) with active indicator
- Mobile-friendly with 44px touch targets

**Restructured: `HomeClient.tsx`**
- Shows ONE focused context at a time instead of mapping over all contexts
- Active context persisted in localStorage
- Listens for `compass-chat-context-switch` events to follow chat focus
- Listens for `compass-trip-created` to auto-switch to new contexts
- Emergence animations and attribute pills preserved
- Monitoring queue filtered to active context

**Restructured: `ChatWidget.tsx`**
- Pinned to bottom of page (not a floating overlay)
- Always visible input bar — no need to tap to open
- Messages area expands upward on first send/focus
- Passes `contextKey` to chat API (backend support from commit 407a398)
- Listens for `compass-context-switched` to track homepage focus

**Layout (`globals.css`)**
- New `.focused-page` layout with bottom padding for pinned chat
- Context switcher dropdown styles
- Focused hero section for single-context display
- Mobile-first responsive breakpoints

### Two-directional flow
- **Top → down**: Context header, trip widget, discoveries flow downward
- **Bottom → up**: Chat pinned to bottom, messages flow upward
- Chat creates/switches contexts that appear in the content above

### What's preserved
- Emergence animations (`section-emerging`, `attrPill`)
- Tool event detection (create-context, update-trip, add-to-compass)
- `compass-data-changed` refresh mechanism
- Triage/save/dismiss functionality
- All existing discovery cards and place grid

### Build verification
- ✅ `npx next build` passes
- No Playwright tests configured

Fixes #266