### PR TITLE
feat: conversational object emergence — trip creation animation from chat to homepage (#258)

### DIFF
--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -215,6 +215,7 @@ export default function HomeClient({
 
   // Listen for new trip creation from chat and mark the key as emerging
   useEffect(() => {
+    const timers: ReturnType<typeof setTimeout>[] = [];
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<{ key: string }>).detail;
       if (!detail?.key) return;
@@ -223,21 +224,26 @@ export default function HomeClient({
         next.add(detail.key);
         return next;
       });
-      // Remove the emerging flag after the animation completes (600ms animation + buffer)
-      setTimeout(() => {
+      // Remove the emerging flag after the animation completes (700ms animation + buffer)
+      const timer = setTimeout(() => {
         setEmergingKeys(prev => {
           const next = new Set(prev);
           next.delete(detail.key);
           return next;
         });
       }, 1200);
+      timers.push(timer);
     };
     window.addEventListener('compass-trip-created', handler);
-    return () => window.removeEventListener('compass-trip-created', handler);
+    return () => {
+      window.removeEventListener('compass-trip-created', handler);
+      timers.forEach(clearTimeout);
+    };
   }, []);
 
   // Listen for trip attribute attachments from chat
   useEffect(() => {
+    const timers: ReturnType<typeof setTimeout>[] = [];
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<{ key: string; attributes: Array<{ field: string; value: string }> }>).detail;
       if (!detail?.key || !detail.attributes?.length) return;
@@ -246,16 +252,20 @@ export default function HomeClient({
         [detail.key]: detail.attributes,
       }));
       // Clear attribute pills after animation
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         setAttachingAttrs(prev => {
           const next = { ...prev };
           delete next[detail.key];
           return next;
         });
       }, 2500);
+      timers.push(timer);
     };
     window.addEventListener('compass-trip-attributes', handler);
-    return () => window.removeEventListener('compass-trip-attributes', handler);
+    return () => {
+      window.removeEventListener('compass-trip-attributes', handler);
+      timers.forEach(clearTimeout);
+    };
   }, []);
 
   // Refresh homepage immediately when chat or other client actions mutate Compass data.

--- a/app/globals.css
+++ b/app/globals.css
@@ -422,6 +422,19 @@ a:hover {
   border-radius: 12px;
   position: relative;
   z-index: 1;
+  will-change: transform, opacity, box-shadow;
+}
+
+/* Respect user preference for reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .section-emerging {
+    animation: none;
+    opacity: 1;
+  }
+  .section-attr-pill {
+    animation: none;
+    opacity: 1;
+  }
 }
 
 /* Attribute pills — animate in when chat attaches trip details */


### PR DESCRIPTION
## Summary

Implements the first slice of conversational object emergence in Compass V2. When a user describes a new trip in chat, the newly created context visibly animates into the homepage — making it feel like conversation is creating structure.

Fixes #258

## What's in this PR

The core emergence pipeline was built directly on staging (commits 787cb67, fe55f41, e72afad). This PR adds polish on top:

### Accessibility & Performance
- **`prefers-reduced-motion` support** — disables emergence and attribute pill animations for users who prefer reduced motion
- **`will-change` GPU hint** on `.section-emerging` for smoother animation compositing
- **Timer cleanup** — `setTimeout` timers in HomeClient emergence and attribute attachment handlers are now properly cleared on unmount

### Existing emergence pipeline (on staging)
- **`GET /api/contexts`** endpoint for pre/post chat context diffing
- **ChatWidget** snapshots context keys before each send, detects `create-context`/`update-trip` tool calls in SSE stream, diffs after completion, dispatches `compass-trip-created` and `compass-trip-attributes` CustomEvents
- **HomeClient** listens for events, applies `.section-emerging` class (slide-up + spring scale + blue glow pulse) and animated attribute pills
- Race condition fix: emergence events sequenced before `compass-data-changed` refresh

## Architecture
- Event-driven CustomEvents allow any future component to react to trip creation
- Pre/post diff approach supports attachment of more recognized attributes (dates, city, focus)
- Same infrastructure powers #259 (attribute attachment)

## Build verification
- ✅ `next build` passes

## Not in this slice
- Spatial 'fly from chat bubble to section' animation (follow-up — all event data is available)