### PR TITLE
feat: surface monitoring changes in homepage tray + admin inventory view (#260)

### DIFF
--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -22,6 +22,10 @@ interface MonitoringQueueItem {
   monitorExplanation?: string;
   dueNow: boolean;
   placeId?: string;
+  detectedChanges?: string[];
+  significanceLevel?: string;
+  significanceSummary?: string;
+  observationCount?: number;
 }
 
 interface HomeClientProps {
@@ -140,6 +144,29 @@ const TYPE_MONITOR_ICON: Record<string, string> = {
   general: '📍',
 };
 
+const CHANGE_LABELS: Record<string, string> = {
+  'rating-down': 'Rating dropped',
+  'rating-up': 'Rating improved',
+  'closure-signal': 'Closure detected',
+  'operational-change': 'Status changed',
+  'price-changed': 'Price shifted',
+  'description-changed': 'Description rewritten',
+  'review-count-up': 'More reviews',
+  'review-count-down': 'Reviews disappeared',
+  'availability-changed': 'Availability changed',
+  'construction-signal': 'Construction progress',
+  'sentiment-shift': 'Sentiment shifted',
+  'hours-changed': 'Hours updated',
+  'general-update': 'Updated',
+};
+
+function formatChangeKinds(changes: string[]): string {
+  if (changes.length === 0) return '';
+  const primary = CHANGE_LABELS[changes[0] ?? ''] ?? 'Change detected';
+  if (changes.length === 1) return primary;
+  return `${primary} +${changes.length - 1}`;
+}
+
 function MonitoringQueueTray({ items }: { items: MonitoringQueueItem[] }) {
   const [expanded, setExpanded] = useState(false);
   if (items.length === 0) return null;
@@ -174,6 +201,11 @@ function MonitoringQueueTray({ items }: { items: MonitoringQueueItem[] }) {
               <span className={`monitoring-tray-status monitoring-tray-status-${item.monitorStatus}`}>
                 {item.dueNow ? 'Due now' : STATUS_LABEL[item.monitorStatus] ?? item.monitorStatus}
               </span>
+              {item.detectedChanges && item.detectedChanges.length > 0 && (
+                <span className={`monitoring-tray-changes monitoring-tray-sig-${item.significanceLevel ?? 'noise'}`}>
+                  {item.significanceSummary ?? formatChangeKinds(item.detectedChanges)}
+                </span>
+              )}
             </li>
           );
         })}

--- a/app/admin/AdminClient.tsx
+++ b/app/admin/AdminClient.tsx
@@ -589,8 +589,13 @@ export default function AdminClient() {
 
             {discoActivity.monitoring.nextUp.length > 0 && (
               <div style={{ marginTop: 'var(--space-md)' }}>
-                <div style={{ fontSize: '0.82rem', fontWeight: 600, color: 'var(--text-secondary)', marginBottom: 8 }}>
-                  Monitoring queue
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 8 }}>
+                  <span style={{ fontSize: '0.82rem', fontWeight: 600, color: 'var(--text-secondary)' }}>
+                    Monitoring queue
+                  </span>
+                  <a href="/admin/monitoring" style={{ fontSize: '0.75rem', color: 'var(--color-link, #2563eb)', textDecoration: 'none' }}>
+                    Full inventory →
+                  </a>
                 </div>
                 <div style={{ display: 'grid', gap: 8 }}>
                   {discoActivity.monitoring.nextUp.map((item) => (

--- a/app/admin/monitoring/MonitoringAdminClient.tsx
+++ b/app/admin/monitoring/MonitoringAdminClient.tsx
@@ -1,0 +1,470 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import Link from 'next/link';
+import type { MonitorEntry, MonitorObservation, MonitorChangeKind } from '../../_lib/monitor-inventory';
+import type { SignificanceLevel } from '../../_lib/observation-significance';
+
+interface MonitoringAdminClientProps {
+  entries: MonitorEntry[];
+  updatedAt: string;
+  userId: string;
+}
+
+// ---- Labels & formatting ----
+
+const STATUS_LABEL: Record<string, string> = {
+  priority: '🟠 Priority',
+  active: '🟡 Active',
+  candidate: '🟣 Candidate',
+};
+
+const TYPE_ICON: Record<string, string> = {
+  hospitality: '🍽️',
+  stay: '🏨',
+  development: '🏗️',
+  culture: '🎭',
+  general: '📍',
+};
+
+const SIG_BADGE: Record<string, { icon: string; className: string }> = {
+  critical: { icon: '🔴', className: 'sig-critical' },
+  notable: { icon: '🟡', className: 'sig-notable' },
+  routine: { icon: '⚪', className: 'sig-routine' },
+  noise: { icon: '·', className: 'sig-noise' },
+};
+
+const CHANGE_LABELS: Record<string, string> = {
+  'rating-down': '📉 Rating dropped',
+  'rating-up': '📈 Rating improved',
+  'closure-signal': '🚫 Closure detected',
+  'operational-change': '⚠️ Status changed',
+  'price-changed': '💰 Price shifted',
+  'description-changed': '📝 Description rewritten',
+  'review-count-up': '📊 More reviews',
+  'review-count-down': '📊 Reviews disappeared',
+  'availability-changed': '🏷️ Availability changed',
+  'construction-signal': '🏗️ Construction progress',
+  'sentiment-shift': '💬 Sentiment shifted',
+  'hours-changed': '🕐 Hours updated',
+  'general-update': '🔄 Updated',
+};
+
+function formatRelative(iso: string | undefined): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return '—';
+  const diffMs = Date.now() - d.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays}d ago`;
+  if (diffDays < 60) return `${Math.round(diffDays / 7)}w ago`;
+  return d.toLocaleDateString('en-CA', { month: 'short', day: 'numeric' });
+}
+
+function formatDue(iso: string | undefined): string {
+  if (!iso) return 'Not scheduled';
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return '—';
+  const diffDays = Math.round((d.getTime() - Date.now()) / (1000 * 60 * 60 * 24));
+  if (diffDays < -1) return `${Math.abs(diffDays)}d overdue`;
+  if (diffDays === -1) return 'Due yesterday';
+  if (diffDays === 0) return 'Due today';
+  if (diffDays === 1) return 'Due tomorrow';
+  if (diffDays <= 7) return `Due in ${diffDays}d`;
+  return `Due ${d.toLocaleDateString('en-CA', { month: 'short', day: 'numeric' })}`;
+}
+
+// ---- Filters ----
+
+type FilterStatus = 'all' | 'priority' | 'active' | 'candidate';
+type FilterType = 'all' | 'hospitality' | 'stay' | 'development' | 'culture' | 'general';
+type SortBy = 'status' | 'significance' | 'lastObserved' | 'nextCheck' | 'name';
+
+// ---- Observation detail panel ----
+
+function ObservationRow({ obs }: { obs: MonitorObservation }) {
+  const sig = SIG_BADGE[obs.significanceLevel ?? 'noise'];
+  return (
+    <div className="mon-obs-row">
+      <span className="mon-obs-date">{formatRelative(obs.observedAt)}</span>
+      <span className="mon-obs-source">{obs.source}</span>
+      {sig && <span className={`mon-obs-sig ${sig.className}`}>{sig.icon}</span>}
+      {obs.changes.length > 0 ? (
+        <span className="mon-obs-changes">
+          {obs.changes.map(c => CHANGE_LABELS[c] ?? c).join(', ')}
+        </span>
+      ) : (
+        <span className="mon-obs-no-change">No changes</span>
+      )}
+      {obs.significanceSummary && (
+        <span className="mon-obs-summary">{obs.significanceSummary}</span>
+      )}
+    </div>
+  );
+}
+
+function EntryDetail({ entry, onClose, onRemove }: {
+  entry: MonitorEntry;
+  onClose: () => void;
+  onRemove: (id: string) => void;
+}) {
+  const [removing, setRemoving] = useState(false);
+
+  const handleRemove = useCallback(async () => {
+    setRemoving(true);
+    try {
+      const res = await fetch(`/api/internal/monitor-inventory?id=${encodeURIComponent(entry.id)}`, {
+        method: 'DELETE',
+      });
+      if (res.ok) {
+        onRemove(entry.id);
+        onClose();
+      }
+    } finally {
+      setRemoving(false);
+    }
+  }, [entry.id, onRemove, onClose]);
+
+  const sig = SIG_BADGE[entry.peakSignificanceLevel ?? 'noise'];
+
+  return (
+    <div className="mon-detail-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="mon-detail-panel">
+        <div className="mon-detail-header">
+          <div>
+            <h2>{entry.name}</h2>
+            <span className="mon-detail-city">{entry.city}</span>
+          </div>
+          <button className="mon-detail-close" onClick={onClose}>✕</button>
+        </div>
+
+        <div className="mon-detail-meta">
+          <span>{TYPE_ICON[entry.monitorType] ?? '📍'} {entry.monitorType}</span>
+          <span>{STATUS_LABEL[entry.monitorStatus] ?? entry.monitorStatus}</span>
+          {sig && entry.peakSignificanceLevel !== 'noise' && (
+            <span className={sig.className}>{sig.icon} Peak: {entry.peakSignificanceLevel}</span>
+          )}
+        </div>
+
+        <div className="mon-detail-dates">
+          <div><strong>Promoted:</strong> {formatRelative(entry.firstPromotedAt)}</div>
+          <div><strong>Last observed:</strong> {formatRelative(entry.lastObservedAt)}</div>
+          <div><strong>Next check:</strong> {formatDue(entry.nextCheckAt)}</div>
+        </div>
+
+        {entry.monitorReasons.length > 0 && (
+          <div className="mon-detail-reasons">
+            <strong>Reasons:</strong> {entry.monitorReasons.join(', ')}
+          </div>
+        )}
+
+        {entry.detectedChangeKinds.length > 0 && (
+          <div className="mon-detail-changes">
+            <strong>All detected changes:</strong>
+            <ul>
+              {entry.detectedChangeKinds.map(c => (
+                <li key={c}>{CHANGE_LABELS[c] ?? c}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {entry.baselineState && (
+          <div className="mon-detail-baseline">
+            <strong>Baseline state:</strong>
+            <div className="mon-detail-state-grid">
+              {entry.baselineState.rating != null && <span>Rating: {entry.baselineState.rating}</span>}
+              {entry.baselineState.reviewCount != null && <span>Reviews: {entry.baselineState.reviewCount}</span>}
+              {entry.baselineState.priceLevel != null && <span>Price: {'$'.repeat(entry.baselineState.priceLevel + 1)}</span>}
+              {entry.baselineState.operationalStatus && <span>Status: {entry.baselineState.operationalStatus}</span>}
+            </div>
+          </div>
+        )}
+
+        {entry.currentState && (
+          <div className="mon-detail-current">
+            <strong>Current state:</strong>
+            <div className="mon-detail-state-grid">
+              {entry.currentState.rating != null && <span>Rating: {entry.currentState.rating}</span>}
+              {entry.currentState.reviewCount != null && <span>Reviews: {entry.currentState.reviewCount}</span>}
+              {entry.currentState.priceLevel != null && <span>Price: {'$'.repeat(entry.currentState.priceLevel + 1)}</span>}
+              {entry.currentState.operationalStatus && <span>Status: {entry.currentState.operationalStatus}</span>}
+              {entry.currentState.description && <span className="mon-detail-desc">"{entry.currentState.description}"</span>}
+            </div>
+          </div>
+        )}
+
+        <div className="mon-detail-observations">
+          <h3>Observations ({entry.observations.length})</h3>
+          {entry.observations.length === 0 ? (
+            <p className="mon-detail-empty">No observations recorded yet.</p>
+          ) : (
+            <div className="mon-obs-list">
+              {entry.observations.map((obs, i) => (
+                <ObservationRow key={`${obs.observedAt}-${i}`} obs={obs} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="mon-detail-actions">
+          <button
+            className="mon-detail-remove"
+            onClick={handleRemove}
+            disabled={removing}
+          >
+            {removing ? 'Removing…' : 'Remove from inventory'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---- Main component ----
+
+export default function MonitoringAdminClient({ entries: initialEntries, updatedAt, userId }: MonitoringAdminClientProps) {
+  const [entries, setEntries] = useState(initialEntries);
+  const [filterStatus, setFilterStatus] = useState<FilterStatus>('all');
+  const [filterType, setFilterType] = useState<FilterType>('all');
+  const [sortBy, setSortBy] = useState<SortBy>('status');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [runningObs, setRunningObs] = useState(false);
+  const [obsResult, setObsResult] = useState<string | null>(null);
+
+  const handleRemove = useCallback((id: string) => {
+    setEntries(prev => prev.filter(e => e.id !== id && e.discoveryId !== id));
+  }, []);
+
+  const runObservations = useCallback(async () => {
+    setRunningObs(true);
+    setObsResult(null);
+    try {
+      const res = await fetch('/api/internal/run-observations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId, limit: 10 }),
+      });
+      const data = await res.json();
+      setObsResult(data.message ?? 'Done');
+      // Refresh inventory
+      const invRes = await fetch('/api/internal/monitor-inventory');
+      if (invRes.ok) {
+        const inv = await invRes.json();
+        setEntries(inv.entries ?? []);
+      }
+    } catch (err) {
+      setObsResult('Error running observations');
+    } finally {
+      setRunningObs(false);
+    }
+  }, [userId]);
+
+  // Apply filters
+  let filtered = entries;
+  if (filterStatus !== 'all') {
+    filtered = filtered.filter(e => e.monitorStatus === filterStatus);
+  }
+  if (filterType !== 'all') {
+    filtered = filtered.filter(e => e.monitorType === filterType);
+  }
+
+  // Apply sort
+  const statusRank: Record<string, number> = { priority: 0, active: 1, candidate: 2 };
+  const sigRank: Record<string, number> = { critical: 3, notable: 2, routine: 1, noise: 0 };
+
+  filtered = [...filtered].sort((a, b) => {
+    switch (sortBy) {
+      case 'status':
+        return (statusRank[a.monitorStatus] ?? 9) - (statusRank[b.monitorStatus] ?? 9);
+      case 'significance':
+        return (sigRank[b.peakSignificanceLevel ?? 'noise'] ?? 0) - (sigRank[a.peakSignificanceLevel ?? 'noise'] ?? 0)
+          || (b.peakSignificanceScore ?? 0) - (a.peakSignificanceScore ?? 0);
+      case 'lastObserved': {
+        const aT = a.lastObservedAt ? new Date(a.lastObservedAt).getTime() : 0;
+        const bT = b.lastObservedAt ? new Date(b.lastObservedAt).getTime() : 0;
+        return bT - aT;
+      }
+      case 'nextCheck': {
+        const aT = a.nextCheckAt ? new Date(a.nextCheckAt).getTime() : Infinity;
+        const bT = b.nextCheckAt ? new Date(b.nextCheckAt).getTime() : Infinity;
+        return aT - bT;
+      }
+      case 'name':
+        return a.name.localeCompare(b.name);
+      default:
+        return 0;
+    }
+  });
+
+  // Stats
+  const totalEntries = entries.length;
+  const dueNow = entries.filter(e => e.nextCheckAt && new Date(e.nextCheckAt) <= new Date()).length;
+  const withChanges = entries.filter(e => e.detectedChangeKinds.length > 0).length;
+  const critical = entries.filter(e => e.hasCriticalChange).length;
+  const byStatus = {
+    priority: entries.filter(e => e.monitorStatus === 'priority').length,
+    active: entries.filter(e => e.monitorStatus === 'active').length,
+    candidate: entries.filter(e => e.monitorStatus === 'candidate').length,
+  };
+
+  const selectedEntry = selectedId ? entries.find(e => e.id === selectedId) : null;
+
+  return (
+    <main className="page mon-admin-page">
+      <div className="page-header">
+        <div className="mon-admin-header">
+          <div>
+            <h1>Monitoring Inventory</h1>
+            <p className="mon-admin-subtitle">
+              Durable monitor entries with observation history and change detection.
+            </p>
+          </div>
+          <div className="mon-admin-header-actions">
+            <button
+              className="mon-admin-run-btn"
+              onClick={runObservations}
+              disabled={runningObs}
+            >
+              {runningObs ? '⏳ Running…' : '▶ Run observations'}
+            </button>
+            <Link href="/admin" className="mon-admin-back">← Admin</Link>
+          </div>
+        </div>
+      </div>
+
+      {/* Stats row */}
+      <div className="mon-admin-stats">
+        <div className="mon-stat">
+          <span className="mon-stat-value">{totalEntries}</span>
+          <span className="mon-stat-label">Total</span>
+        </div>
+        <div className="mon-stat">
+          <span className="mon-stat-value mon-stat-due">{dueNow}</span>
+          <span className="mon-stat-label">Due now</span>
+        </div>
+        <div className="mon-stat">
+          <span className="mon-stat-value">{withChanges}</span>
+          <span className="mon-stat-label">With changes</span>
+        </div>
+        <div className="mon-stat">
+          <span className="mon-stat-value mon-stat-critical">{critical}</span>
+          <span className="mon-stat-label">Critical</span>
+        </div>
+        <div className="mon-stat-divider" />
+        <div className="mon-stat">
+          <span className="mon-stat-value">{byStatus.priority}</span>
+          <span className="mon-stat-label">Priority</span>
+        </div>
+        <div className="mon-stat">
+          <span className="mon-stat-value">{byStatus.active}</span>
+          <span className="mon-stat-label">Active</span>
+        </div>
+        <div className="mon-stat">
+          <span className="mon-stat-value">{byStatus.candidate}</span>
+          <span className="mon-stat-label">Candidate</span>
+        </div>
+      </div>
+
+      {obsResult && (
+        <div className="mon-admin-obs-result">{obsResult}</div>
+      )}
+
+      {/* Filters & sort */}
+      <div className="mon-admin-controls">
+        <div className="mon-admin-filters">
+          <select value={filterStatus} onChange={e => setFilterStatus(e.target.value as FilterStatus)}>
+            <option value="all">All statuses</option>
+            <option value="priority">Priority</option>
+            <option value="active">Active</option>
+            <option value="candidate">Candidate</option>
+          </select>
+          <select value={filterType} onChange={e => setFilterType(e.target.value as FilterType)}>
+            <option value="all">All types</option>
+            <option value="hospitality">Hospitality</option>
+            <option value="stay">Stay</option>
+            <option value="development">Development</option>
+            <option value="culture">Culture</option>
+            <option value="general">General</option>
+          </select>
+        </div>
+        <div className="mon-admin-sort">
+          <label>Sort: </label>
+          <select value={sortBy} onChange={e => setSortBy(e.target.value as SortBy)}>
+            <option value="status">Status</option>
+            <option value="significance">Significance</option>
+            <option value="lastObserved">Last observed</option>
+            <option value="nextCheck">Next check</option>
+            <option value="name">Name</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Entry list */}
+      {filtered.length === 0 ? (
+        <div className="mon-admin-empty">
+          <p>No entries match your filters.</p>
+        </div>
+      ) : (
+        <div className="mon-admin-list">
+          {filtered.map(entry => {
+            const sig = SIG_BADGE[entry.peakSignificanceLevel ?? 'noise'];
+            const isDue = entry.nextCheckAt && new Date(entry.nextCheckAt) <= new Date();
+            return (
+              <div
+                key={entry.id}
+                className={`mon-entry${isDue ? ' mon-entry-due' : ''}${entry.hasCriticalChange ? ' mon-entry-critical' : ''}`}
+                onClick={() => setSelectedId(entry.id)}
+              >
+                <div className="mon-entry-top">
+                  <span className="mon-entry-icon">{TYPE_ICON[entry.monitorType] ?? '📍'}</span>
+                  <span className="mon-entry-name">{entry.name}</span>
+                  <span className={`mon-entry-status mon-entry-status-${entry.monitorStatus}`}>
+                    {STATUS_LABEL[entry.monitorStatus] ?? entry.monitorStatus}
+                  </span>
+                </div>
+                <div className="mon-entry-meta">
+                  <span>{entry.city}</span>
+                  <span>· {entry.type}</span>
+                  <span>· {entry.observations.length} obs</span>
+                  {entry.lastObservedAt && <span>· Last: {formatRelative(entry.lastObservedAt)}</span>}
+                  <span>· {formatDue(entry.nextCheckAt)}</span>
+                </div>
+                {entry.detectedChangeKinds.length > 0 && (
+                  <div className="mon-entry-changes">
+                    {entry.detectedChangeKinds.slice(0, 4).map(c => (
+                      <span key={c} className="mon-change-tag">{CHANGE_LABELS[c] ?? c}</span>
+                    ))}
+                    {entry.detectedChangeKinds.length > 4 && (
+                      <span className="mon-change-more">+{entry.detectedChangeKinds.length - 4}</span>
+                    )}
+                  </div>
+                )}
+                {sig && entry.peakSignificanceLevel && entry.peakSignificanceLevel !== 'noise' && (
+                  <div className={`mon-entry-sig ${sig.className}`}>
+                    {sig.icon} {entry.latestSignificanceSummary ?? entry.peakSignificanceLevel}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="mon-admin-footer">
+        Last updated: {updatedAt ? new Date(updatedAt).toLocaleString() : '—'}
+      </div>
+
+      {/* Detail panel */}
+      {selectedEntry && (
+        <EntryDetail
+          entry={selectedEntry}
+          onClose={() => setSelectedId(null)}
+          onRemove={handleRemove}
+        />
+      )}
+    </main>
+  );
+}

--- a/app/admin/monitoring/page.tsx
+++ b/app/admin/monitoring/page.tsx
@@ -1,0 +1,30 @@
+import { getCurrentUser } from '../../_lib/user';
+import { loadMonitorInventory } from '../../_lib/monitor-inventory';
+import type { MonitorEntry } from '../../_lib/monitor-inventory';
+import MonitoringAdminClient from './MonitoringAdminClient';
+
+export const dynamic = 'force-dynamic';
+
+export default async function MonitoringAdminPage() {
+  const user = await getCurrentUser();
+  if (!user?.isOwner) {
+    return (
+      <main className="page">
+        <div className="page-header">
+          <h1>Monitoring Admin</h1>
+          <p>Admin access required.</p>
+        </div>
+      </main>
+    );
+  }
+
+  const inventory = await loadMonitorInventory(user.id);
+
+  return (
+    <MonitoringAdminClient
+      entries={inventory.entries}
+      updatedAt={inventory.updatedAt}
+      userId={user.id}
+    />
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -6734,3 +6734,490 @@ nextjs-portal { display: none !important; }
 .watch-view-link:hover {
   text-decoration: underline;
 }
+
+/* ---- Monitoring tray: change signals ---- */
+
+.monitoring-tray-changes {
+  display: block;
+  font-size: 0.7rem;
+  margin-top: 2px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.monitoring-tray-sig-critical {
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.08);
+}
+
+.monitoring-tray-sig-notable {
+  color: #d97706;
+  background: rgba(217, 119, 6, 0.08);
+}
+
+.monitoring-tray-sig-routine {
+  color: var(--color-text-muted, #6b7280);
+}
+
+.monitoring-tray-sig-noise {
+  color: var(--color-text-muted, #9ca3af);
+}
+
+/* ---- Admin Monitoring Inventory ---- */
+
+.mon-admin-page {
+  max-width: 960px;
+}
+
+.mon-admin-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.mon-admin-subtitle {
+  color: var(--color-text-muted, #6b7280);
+  font-size: 0.85rem;
+  margin-top: 4px;
+}
+
+.mon-admin-header-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.mon-admin-run-btn {
+  padding: 6px 14px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 6px;
+  background: var(--color-surface, #fff);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.mon-admin-run-btn:hover {
+  background: var(--color-hover, #f3f4f6);
+}
+
+.mon-admin-run-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.mon-admin-back {
+  font-size: 0.8rem;
+  color: var(--color-link, #2563eb);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.mon-admin-stats {
+  display: flex;
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.mon-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.mon-stat-value {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.mon-stat-due {
+  color: #dc2626;
+}
+
+.mon-stat-critical {
+  color: #dc2626;
+}
+
+.mon-stat-label {
+  font-size: 0.7rem;
+  color: var(--color-text-muted, #6b7280);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.mon-stat-divider {
+  width: 1px;
+  height: 32px;
+  background: var(--color-border, #e5e7eb);
+}
+
+.mon-admin-obs-result {
+  padding: 8px 12px;
+  background: var(--color-surface-elevated, #f0fdf4);
+  border: 1px solid #86efac;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  margin-bottom: 12px;
+}
+
+.mon-admin-controls {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.mon-admin-filters {
+  display: flex;
+  gap: 8px;
+}
+
+.mon-admin-filters select,
+.mon-admin-sort select {
+  padding: 4px 8px;
+  font-size: 0.8rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 4px;
+  background: var(--color-surface, #fff);
+}
+
+.mon-admin-sort {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #6b7280);
+}
+
+.mon-admin-empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--color-text-muted, #9ca3af);
+}
+
+.mon-admin-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mon-entry {
+  padding: 10px 14px;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.mon-entry:hover {
+  background: var(--color-hover, #f9fafb);
+}
+
+.mon-entry-due {
+  border-left: 3px solid #dc2626;
+}
+
+.mon-entry-critical {
+  border-left: 3px solid #dc2626;
+  background: rgba(220, 38, 38, 0.02);
+}
+
+.mon-entry-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mon-entry-icon {
+  font-size: 1rem;
+}
+
+.mon-entry-name {
+  font-weight: 500;
+  font-size: 0.9rem;
+  flex: 1;
+}
+
+.mon-entry-status {
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+.mon-entry-status-priority {
+  background: rgba(249, 115, 22, 0.1);
+  color: #ea580c;
+}
+
+.mon-entry-status-active {
+  background: rgba(245, 158, 11, 0.1);
+  color: #d97706;
+}
+
+.mon-entry-status-candidate {
+  background: rgba(147, 51, 234, 0.1);
+  color: #7c3aed;
+}
+
+.mon-entry-meta {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #6b7280);
+  margin-top: 4px;
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.mon-entry-changes {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.mon-change-tag {
+  font-size: 0.65rem;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: rgba(245, 158, 11, 0.1);
+  color: #92400e;
+}
+
+.mon-change-more {
+  font-size: 0.65rem;
+  color: var(--color-text-muted, #9ca3af);
+  padding: 1px 4px;
+}
+
+.mon-entry-sig {
+  font-size: 0.7rem;
+  margin-top: 4px;
+}
+
+.sig-critical {
+  color: #dc2626;
+}
+
+.sig-notable {
+  color: #d97706;
+}
+
+.sig-routine {
+  color: var(--color-text-muted, #6b7280);
+}
+
+.sig-noise {
+  color: var(--color-text-muted, #9ca3af);
+}
+
+.mon-admin-footer {
+  margin-top: 24px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border, #e5e7eb);
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #9ca3af);
+}
+
+/* Detail panel overlay */
+
+.mon-detail-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 100;
+}
+
+.mon-detail-panel {
+  width: 480px;
+  max-width: 90vw;
+  height: 100vh;
+  background: var(--color-surface, #fff);
+  overflow-y: auto;
+  padding: 24px;
+  box-shadow: -4px 0 20px rgba(0, 0, 0, 0.1);
+}
+
+.mon-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 16px;
+}
+
+.mon-detail-header h2 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.mon-detail-city {
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #6b7280);
+}
+
+.mon-detail-close {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 4px;
+  color: var(--color-text-muted, #6b7280);
+}
+
+.mon-detail-meta {
+  display: flex;
+  gap: 12px;
+  font-size: 0.8rem;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.mon-detail-dates {
+  font-size: 0.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.mon-detail-dates strong {
+  color: var(--color-text-muted, #6b7280);
+}
+
+.mon-detail-reasons,
+.mon-detail-changes,
+.mon-detail-baseline,
+.mon-detail-current {
+  font-size: 0.8rem;
+  margin-bottom: 12px;
+}
+
+.mon-detail-changes ul {
+  list-style: none;
+  padding: 0;
+  margin: 4px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.mon-detail-changes li {
+  padding: 2px 8px;
+  background: rgba(245, 158, 11, 0.1);
+  border-radius: 4px;
+  font-size: 0.75rem;
+}
+
+.mon-detail-state-grid {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+  font-size: 0.8rem;
+}
+
+.mon-detail-desc {
+  font-style: italic;
+  color: var(--color-text-muted, #6b7280);
+  flex-basis: 100%;
+}
+
+.mon-detail-observations {
+  margin-top: 16px;
+}
+
+.mon-detail-observations h3 {
+  font-size: 0.9rem;
+  margin: 0 0 8px;
+}
+
+.mon-detail-empty {
+  color: var(--color-text-muted, #9ca3af);
+  font-size: 0.8rem;
+}
+
+.mon-obs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mon-obs-row {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  font-size: 0.75rem;
+  padding: 6px 8px;
+  background: var(--color-hover, #f9fafb);
+  border-radius: 4px;
+  flex-wrap: wrap;
+}
+
+.mon-obs-date {
+  color: var(--color-text-muted, #6b7280);
+  white-space: nowrap;
+  min-width: 60px;
+}
+
+.mon-obs-source {
+  color: var(--color-text-muted, #9ca3af);
+  white-space: nowrap;
+}
+
+.mon-obs-sig {
+  font-size: 0.8rem;
+}
+
+.mon-obs-changes {
+  color: #92400e;
+}
+
+.mon-obs-no-change {
+  color: var(--color-text-muted, #9ca3af);
+  font-style: italic;
+}
+
+.mon-obs-summary {
+  color: var(--color-text-muted, #6b7280);
+  flex-basis: 100%;
+  font-style: italic;
+}
+
+.mon-detail-actions {
+  margin-top: 20px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border, #e5e7eb);
+}
+
+.mon-detail-remove {
+  padding: 6px 14px;
+  font-size: 0.8rem;
+  border: 1px solid #fca5a5;
+  border-radius: 6px;
+  background: rgba(220, 38, 38, 0.05);
+  color: #dc2626;
+  cursor: pointer;
+}
+
+.mon-detail-remove:hover {
+  background: rgba(220, 38, 38, 0.1);
+}
+
+.mon-detail-remove:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,9 @@ import { isTypeCompatible } from './_lib/context-compat';
 import { scoreDiscovery } from './_lib/discovery-score';
 import { rankDiscoveriesForHomepage } from './_lib/discovery-preferences';
 import { annotateDiscoveriesForMonitoring } from './_lib/discovery-monitoring';
-import { bulkPromoteFromAnnotated } from './_lib/monitor-inventory';
+import { bulkPromoteFromAnnotated, loadMonitorInventory } from './_lib/monitor-inventory';
+import type { MonitorChangeKind } from './_lib/monitor-inventory';
+import type { SignificanceLevel } from './_lib/observation-significance';
 import HomeClient from './_components/HomeClient';
 
 export const dynamic = 'force-dynamic';
@@ -204,6 +206,15 @@ export default async function HomePage() {
   // Auto-promote active/priority monitored places into the durable inventory (fire-and-forget)
   bulkPromoteFromAnnotated(user.id, monitoredDiscoveries);
 
+  // Load durable inventory for change signals
+  const inventory = await loadMonitorInventory(user.id);
+  const inventoryById = new Map(
+    inventory.entries.flatMap(e => [
+      [e.id, e],
+      [e.discoveryId, e],
+    ]),
+  );
+
   // Hide contexts with no discoveries in their final ranked bucket (homepage only).
   // Contexts remain accessible in /review and other pages — this suppression is
   // limited to homepage rendering so the page never shows empty carousels.
@@ -239,6 +250,10 @@ export default async function HomePage() {
     monitorExplanation?: string;
     dueNow: boolean;
     placeId?: string;
+    detectedChanges?: MonitorChangeKind[];
+    significanceLevel?: SignificanceLevel;
+    significanceSummary?: string;
+    observationCount?: number;
   }> = monitoredDiscoveries
     .filter(d => d.monitorStatus && d.monitorStatus !== 'none' && (d.monitorDueNow || d.monitorStatus === 'priority'))
     .sort((a, b) => {
@@ -247,19 +262,26 @@ export default async function HomePage() {
       return (rank[a.monitorStatus ?? 'candidate'] ?? 9) - (rank[b.monitorStatus ?? 'candidate'] ?? 9);
     })
     .slice(0, 8)
-    .map(d => ({
-      id: d.id,
-      name: d.name,
-      city: d.city,
-      type: d.type,
-      contextKey: d.contextKey,
-      monitorStatus: d.monitorStatus ?? 'candidate',
-      monitorType: d.monitorType ?? 'general',
-      monitorCadence: d.monitorCadence,
-      monitorExplanation: d.monitorExplanation,
-      dueNow: Boolean(d.monitorDueNow),
-      placeId: d.place_id,
-    }));
+    .map(d => {
+      const inv = inventoryById.get(d.place_id ?? d.id) ?? inventoryById.get(d.id);
+      return {
+        id: d.id,
+        name: d.name,
+        city: d.city,
+        type: d.type,
+        contextKey: d.contextKey,
+        monitorStatus: d.monitorStatus ?? 'candidate',
+        monitorType: d.monitorType ?? 'general',
+        monitorCadence: d.monitorCadence,
+        monitorExplanation: d.monitorExplanation,
+        dueNow: Boolean(d.monitorDueNow),
+        placeId: d.place_id,
+        detectedChanges: inv?.detectedChangeKinds,
+        significanceLevel: inv?.peakSignificanceLevel,
+        significanceSummary: inv?.latestSignificanceSummary,
+        observationCount: inv?.observations?.length ?? 0,
+      };
+    });
 
   return (
     <HomeClient


### PR DESCRIPTION
## What this does

Continues the durable monitoring system from #260 by surfacing change signals and building an admin interface.

### Homepage monitoring tray enhancements
- Tray items now show detected change kinds from the durable monitor inventory (rating drops, closures, price shifts, etc.)
- Significance level badges (critical/notable/routine) with summary text
- Change data flows from the persisted inventory through the homepage server component

### Admin monitoring inventory (`/admin/monitoring`)
- Stats dashboard: total entries, due now, with changes, critical count, breakdown by status
- Filterable by monitor status (priority/active/candidate) and type (hospitality/stay/development/culture/general)
- Sortable by status, significance, last observed, next check, or name
- Click any entry to expand a detail panel with:
  - Observation history timeline with significance scoring
  - Baseline vs current state comparison
  - All detected change kinds
  - Monitor reasons and dimensions
- "Run observations" button to trigger the observation runner
- Remove entries from inventory
- Link from admin dashboard → full inventory

### Admin dashboard
- "Full inventory →" link in the monitoring queue section

Fixes #260