### PR TITLE
feat: contextual chat targeting — chat into specific cards and sections

### DIFF
--- a/app/_components/ChatWidget.module.css
+++ b/app/_components/ChatWidget.module.css
@@ -64,6 +64,72 @@
   border-radius: 3px;
 }
 
+/* ---- Chat Target Bar ---- */
+.chatTargetBar {
+  display: flex;
+  justify-content: center;
+  padding: 4px 16px;
+  background: rgba(245, 240, 232, 0.95);
+  pointer-events: auto;
+}
+
+.chatTargetPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  background: #ede8e0;
+  border: 1px solid rgba(196, 112, 75, 0.25);
+  border-radius: 20px;
+  font-size: 0.8rem;
+  color: #4a4640;
+  animation: target-appear 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes target-appear {
+  from { opacity: 0; transform: scale(0.9) translateY(4px); }
+  to { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+.chatTargetEmoji {
+  font-size: 0.9rem;
+}
+
+.chatTargetLabel {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 240px;
+}
+
+.chatTargetLabel strong {
+  color: #c4704b;
+  font-weight: 600;
+}
+
+.chatTargetClear {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.08);
+  color: #6f6a62;
+  font-size: 0.65rem;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s;
+  line-height: 1;
+  padding: 0;
+}
+
+.chatTargetClear:hover {
+  background: rgba(0, 0, 0, 0.15);
+  color: #2d2a26;
+}
+
 /* ---- Input Bar (always visible) ---- */
 .chatInputBar {
   display: flex;

--- a/app/_components/ChatWidget.tsx
+++ b/app/_components/ChatWidget.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useRef, useEffect, useCallback } from 'react';
 import type { ChatMessage } from '../_lib/types';
+import type { ChatTarget } from '../_lib/chat-target';
+import { chatTargetPill, CHAT_TARGET_EVENT, CHAT_TARGET_CLEAR_EVENT } from '../_lib/chat-target';
 import styles from './ChatWidget.module.css';
 
 /**
@@ -50,6 +52,10 @@ export default function ChatWidget() {
   // Active context key — synced from homepage
   const activeContextKeyRef = useRef<string | null>(null);
 
+  // Chat target — card/section-level targeting
+  const [chatTarget, setChatTarget] = useState<ChatTarget | null>(null);
+  const chatTargetRef = useRef<ChatTarget | null>(null);
+
   const createContextUsed = useRef(false);
   const updateTripUsed = useRef<string | null>(null);
   const preContextKeys = useRef<Set<string>>(new Set());
@@ -69,6 +75,32 @@ export default function ChatWidget() {
     };
     window.addEventListener('compass-context-switched', handler);
     return () => window.removeEventListener('compass-context-switched', handler);
+  }, []);
+
+  // Listen for chat target events (card-level targeting)
+  useEffect(() => {
+    const handleTarget = (e: Event) => {
+      const target = (e as CustomEvent<ChatTarget>).detail;
+      if (target) {
+        setChatTarget(target);
+        chatTargetRef.current = target;
+        // Also set the context key
+        activeContextKeyRef.current = target.contextKey;
+        // Expand chat and focus input
+        setChatExpanded(true);
+        setTimeout(() => inputRef.current?.focus(), 100);
+      }
+    };
+    const handleClear = () => {
+      setChatTarget(null);
+      chatTargetRef.current = null;
+    };
+    window.addEventListener(CHAT_TARGET_EVENT, handleTarget);
+    window.addEventListener(CHAT_TARGET_CLEAR_EVENT, handleClear);
+    return () => {
+      window.removeEventListener(CHAT_TARGET_EVENT, handleTarget);
+      window.removeEventListener(CHAT_TARGET_CLEAR_EVENT, handleClear);
+    };
   }, []);
 
   // Auto-scroll to bottom
@@ -140,6 +172,11 @@ export default function ChatWidget() {
     return accumulated;
   }, []);
 
+  function clearChatTarget() {
+    setChatTarget(null);
+    chatTargetRef.current = null;
+  }
+
   async function handleSend(e: React.FormEvent) {
     e.preventDefault();
     const trimmed = input.trim();
@@ -181,15 +218,29 @@ export default function ChatWidget() {
 
     abortRef.current = new AbortController();
 
+    // Build request body with chat target context
+    const currentTarget = chatTargetRef.current;
+    const requestBody: Record<string, unknown> = {
+      message: trimmed,
+      history: messages,
+      contextKey: activeContextKeyRef.current,
+    };
+
+    // Add card-level targeting if active
+    if (currentTarget?.card) {
+      requestBody.chatTarget = {
+        cardId: currentTarget.card.id,
+        cardName: currentTarget.card.name,
+        cardType: currentTarget.card.type,
+        cardPlaceId: currentTarget.card.placeId,
+      };
+    }
+
     try {
       const res = await fetch('/api/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          message: trimmed,
-          history: messages,
-          contextKey: activeContextKeyRef.current,
-        }),
+        body: JSON.stringify(requestBody),
         signal: abortRef.current.signal,
       });
 
@@ -301,6 +352,9 @@ export default function ChatWidget() {
     }
   }
 
+  // Compute target pill display
+  const targetPill = chatTarget ? chatTargetPill(chatTarget) : null;
+
   return (
     <div className={`${styles.chatPinned} ${chatExpanded ? styles.chatPinnedExpanded : ''}`}>
       {/* Messages area — only visible when expanded */}
@@ -312,7 +366,7 @@ export default function ChatWidget() {
                 <div className={styles.chatEmptyIcon}>🧭</div>
                 <div className={styles.chatEmptyTitle}>Hey! I&apos;m your Compass Concierge.</div>
                 <div className={styles.chatEmptyText}>
-                  Ask me about restaurants, places to visit, or help planning your next trip.
+                  Ask me anything about restaurants, places to visit, or help planning your next trip.
                 </div>
               </div>
             )}
@@ -379,6 +433,24 @@ export default function ChatWidget() {
         </div>
       )}
 
+      {/* Target pill — shows what chat is scoped to */}
+      {targetPill && (
+        <div className={styles.chatTargetBar}>
+          <div className={styles.chatTargetPill}>
+            <span className={styles.chatTargetEmoji}>{targetPill.emoji}</span>
+            <span className={styles.chatTargetLabel}>Chatting about <strong>{targetPill.label}</strong></span>
+            <button
+              type="button"
+              className={styles.chatTargetClear}
+              onClick={clearChatTarget}
+              aria-label="Clear chat target"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* Input area — always visible, pinned to bottom */}
       <div className={styles.chatInputBar}>
         {chatExpanded && (
@@ -395,7 +467,7 @@ export default function ChatWidget() {
           <textarea
             ref={inputRef}
             className={styles.chatInputField}
-            placeholder="Ask me anything…"
+            placeholder={chatTarget?.card ? `Ask about ${chatTarget.card.name}…` : 'Ask me anything…'}
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => {

--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -544,6 +544,9 @@ export default function HomeClient({
           <PlaceGrid
             discoveries={discoveries}
             contextKey={ctx.key}
+            contextLabel={ctx.label}
+            contextEmoji={ctx.emoji}
+            contextType={ctx.type}
             userId={userId}
             layout="carousel"
           />

--- a/app/_components/PlaceCard.tsx
+++ b/app/_components/PlaceCard.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import Link from 'next/link';
 import type { Discovery } from '../_lib/types';
+import { dispatchChatTarget } from '../_lib/chat-target';
 import TypeBadge from './TypeBadge';
 import TriageButtons from './TriageButtons';
 import { resolveImageUrlClient } from '../_lib/image-url';
@@ -11,10 +12,13 @@ import { getMonitoringExplanation, getMonitorStatusLabel } from '../_lib/discove
 interface PlaceCardProps {
   discovery: Discovery;
   contextKey: string;
+  contextLabel?: string;
+  contextEmoji?: string;
+  contextType?: 'trip' | 'outing' | 'radar';
   userId?: string;
 }
 
-export default function PlaceCard({ discovery, contextKey, userId }: PlaceCardProps) {
+export default function PlaceCard({ discovery, contextKey, contextLabel, contextEmoji, contextType, userId }: PlaceCardProps) {
   const { id, place_id, name, type } = discovery;
   // Ensure rating is a number (V1 data may have strings like "4.5")
   const rating = discovery.rating != null ? Number(discovery.rating) : null;
@@ -73,6 +77,23 @@ export default function PlaceCard({ discovery, contextKey, userId }: PlaceCardPr
     : null;
   const monitorExplanation = getMonitoringExplanation(discovery);
 
+  const handleChatInto = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dispatchChatTarget({
+      contextKey,
+      contextLabel: contextLabel || contextKey,
+      contextEmoji,
+      contextType,
+      card: {
+        id: id,
+        name,
+        type,
+        placeId: place_id,
+      },
+    });
+  }, [contextKey, contextLabel, contextEmoji, contextType, id, name, type, place_id]);
+
   return (
     <div style={{ position: 'relative' }}>
       <Link href={`/placecards/${place_id || id}?context=${encodeURIComponent(contextKey)}`} className="place-card">
@@ -128,6 +149,14 @@ export default function PlaceCard({ discovery, contextKey, userId }: PlaceCardPr
           <TriageButtons userId={userId} contextKey={contextKey} placeId={place_id} size="sm" />
         </div>
       )}
+      <button
+        className="place-card-chat-btn"
+        onClick={handleChatInto}
+        aria-label={`Chat about ${name}`}
+        title={`Chat about ${name}`}
+      >
+        💬
+      </button>
     </div>
   );
 }

--- a/app/_components/PlaceGrid.tsx
+++ b/app/_components/PlaceGrid.tsx
@@ -8,6 +8,9 @@ import PlaceCard from './PlaceCard';
 interface PlaceGridProps {
   discoveries: Discovery[];
   contextKey: string;
+  contextLabel?: string;
+  contextEmoji?: string;
+  contextType?: 'trip' | 'outing' | 'radar';
   userId?: string;
   showFilters?: boolean;
   layout?: 'grid' | 'carousel';
@@ -27,6 +30,9 @@ function filterVisible(discoveries: Discovery[], userId: string | undefined, con
 export default function PlaceGrid({
   discoveries,
   contextKey,
+  contextLabel,
+  contextEmoji,
+  contextType,
   userId,
   layout = 'grid',
 }: PlaceGridProps) {
@@ -110,6 +116,9 @@ export default function PlaceGrid({
               <PlaceCard
                 discovery={discovery}
                 contextKey={contextKey}
+                contextLabel={contextLabel}
+                contextEmoji={contextEmoji}
+                contextType={contextType}
                 userId={userId}
               />
             </div>
@@ -130,6 +139,9 @@ export default function PlaceGrid({
             key={discovery.id}
             discovery={discovery}
             contextKey={contextKey}
+            contextLabel={contextLabel}
+            contextEmoji={contextEmoji}
+            contextType={contextType}
             userId={userId}
           />
         ))}

--- a/app/_lib/chat-target.ts
+++ b/app/_lib/chat-target.ts
@@ -1,0 +1,97 @@
+/**
+ * Contextual Chat Target — defines what the chat is scoped to.
+ *
+ * Supports three levels of targeting:
+ * 1. Global (no target) — normal chat behavior
+ * 2. Context-level — scoped to a trip, outing, or radar
+ * 3. Card-level — scoped to a specific discovery/place within a context
+ */
+
+export interface ChatTargetCard {
+  /** Discovery ID or place_id */
+  id: string;
+  /** Place name */
+  name: string;
+  /** Place type (restaurant, bar, etc.) */
+  type: string;
+  /** Place ID for Google Maps links */
+  placeId?: string;
+}
+
+export interface ChatTarget {
+  /** Context key (e.g. "trip:siena-2026", "outing:dinner-tonight") */
+  contextKey: string;
+  /** Human-readable context label */
+  contextLabel: string;
+  /** Context emoji */
+  contextEmoji?: string;
+  /** Context type */
+  contextType?: 'trip' | 'outing' | 'radar';
+
+  /** Optional: target a specific card/place within the context */
+  card?: ChatTargetCard;
+}
+
+/**
+ * Custom event types for chat targeting.
+ */
+export const CHAT_TARGET_EVENT = 'compass-chat-target' as const;
+export const CHAT_TARGET_CLEAR_EVENT = 'compass-chat-target-clear' as const;
+
+/**
+ * Dispatch a chat target event (card-level or context-level).
+ */
+export function dispatchChatTarget(target: ChatTarget): void {
+  window.dispatchEvent(new CustomEvent(CHAT_TARGET_EVENT, { detail: target }));
+}
+
+/**
+ * Dispatch a clear chat target event (revert to global).
+ */
+export function dispatchClearChatTarget(): void {
+  window.dispatchEvent(new CustomEvent(CHAT_TARGET_CLEAR_EVENT));
+}
+
+/**
+ * Serialize chat target for API transmission.
+ */
+export function serializeChatTarget(target: ChatTarget): Record<string, unknown> {
+  return {
+    contextKey: target.contextKey,
+    contextLabel: target.contextLabel,
+    contextEmoji: target.contextEmoji,
+    contextType: target.contextType,
+    ...(target.card ? {
+      cardId: target.card.id,
+      cardName: target.card.name,
+      cardType: target.card.type,
+      cardPlaceId: target.card.placeId,
+    } : {}),
+  };
+}
+
+/**
+ * Build a human-readable label for the chat target.
+ */
+export function chatTargetLabel(target: ChatTarget): string {
+  if (target.card) {
+    return target.card.name;
+  }
+  return target.contextLabel;
+}
+
+/**
+ * Build a short emoji + label for the target pill.
+ */
+export function chatTargetPill(target: ChatTarget): { emoji: string; label: string } {
+  if (target.card) {
+    return {
+      emoji: '📍',
+      label: target.card.name,
+    };
+  }
+  return {
+    emoji: target.contextEmoji || '🧭',
+    label: target.contextLabel,
+  };
+}

--- a/app/_lib/chat/system-prompt.ts
+++ b/app/_lib/chat/system-prompt.ts
@@ -78,6 +78,13 @@ If a user asks you to:
 Never output raw JSON, system internals, API keys, or technical debugging information.
 Always stay warm, helpful, and focused on making their travel experience amazing.`;
 
+export interface ChatTargetInfo {
+  cardId?: string;
+  cardName?: string;
+  cardType?: string;
+  cardPlaceId?: string;
+}
+
 export interface ChatContext {
   userCode: string;
   userCity: string;
@@ -86,6 +93,8 @@ export interface ChatContext {
   recentDiscoveries: Array<{ name: string; type: string; city: string }>;
   /** The explicitly focused context key (for contextual chat targeting) */
   activeContextKey?: string;
+  /** Card-level targeting — a specific place the user is chatting about */
+  chatTarget?: ChatTargetInfo;
 }
 
 /**
@@ -157,6 +166,12 @@ Be curious and warm. Get to know them naturally.`;
     const targeted = context.manifest?.contexts?.find((c: Context) => c.key === context.activeContextKey);
     if (targeted) {
       prompt += `\n\n## ACTIVE CHAT TARGET\nThe user is currently focused on: **${targeted.emoji || '\ud83d\udccd'} ${targeted.label}** (key: \`${targeted.key}\`)${targeted.city ? ` in ${targeted.city}` : ''}${targeted.dates ? ` — ${targeted.dates}` : ''}.\n\nWhen the user talks about places, adding things, or updating details — apply them to THIS context. Use contextKey: \`${targeted.key}\` in all add_to_compass and update_trip calls unless they explicitly mention a different trip.`;
+
+      // Card-level targeting — user tapped a specific place card to chat about it
+      if (context.chatTarget?.cardName) {
+        const ct = context.chatTarget;
+        prompt += `\n\n## TARGETED PLACE\nThe user has selected a SPECIFIC place to discuss: **${ct.cardName}** (${ct.cardType || 'place'})${ct.cardPlaceId ? `, place_id: \`${ct.cardPlaceId}\`` : ''}.\n\nIMPORTANT: The user's message is about THIS specific place. When they say "remove this", "replace this", "update this", or refer to it with pronouns — they mean **${ct.cardName}**. Apply all actions (save, update, remove, replace) to this place specifically. If they ask to replace it, search for alternatives in the same category/context and suggest replacements.`;
+      }
     }
   }
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -202,7 +202,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { message, history: clientHistory, contextKey: activeContextKey } = await request.json();
+    const { message, history: clientHistory, contextKey: activeContextKey, chatTarget } = await request.json();
 
     if (!message || typeof message !== 'string') {
       return NextResponse.json({ error: 'message is required' }, { status: 400 });
@@ -247,6 +247,12 @@ export async function POST(request: NextRequest) {
       manifest,
       recentDiscoveries,
       activeContextKey: typeof activeContextKey === 'string' ? activeContextKey : undefined,
+      chatTarget: chatTarget && typeof chatTarget === 'object' ? {
+        cardId: typeof chatTarget.cardId === 'string' ? chatTarget.cardId : undefined,
+        cardName: typeof chatTarget.cardName === 'string' ? chatTarget.cardName : undefined,
+        cardType: typeof chatTarget.cardType === 'string' ? chatTarget.cardType : undefined,
+        cardPlaceId: typeof chatTarget.cardPlaceId === 'string' ? chatTarget.cardPlaceId : undefined,
+      } : undefined,
     };
 
     const systemPrompt = buildSystemPrompt(chatContext);

--- a/app/globals.css
+++ b/app/globals.css
@@ -1190,6 +1190,52 @@ a:hover {
   gap: 4px;
 }
 
+.place-card-chat-btn {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  z-index: 10;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(245, 240, 232, 0.9);
+  backdrop-filter: blur(8px);
+  font-size: 0.85rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+}
+
+/* Show on card hover (desktop) */
+*:hover > .place-card-chat-btn {
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* Always show on touch (mobile) */
+@media (hover: none) {
+  .place-card-chat-btn {
+    opacity: 0.85;
+    transform: scale(1);
+  }
+}
+
+.place-card-chat-btn:hover {
+  background: var(--accent);
+  color: white;
+  transform: scale(1.1);
+}
+
+.place-card-chat-btn:active {
+  transform: scale(0.95);
+}
+
 
 /* ---- 20. Place Grid ---- */
 


### PR DESCRIPTION
## Summary

Implements contextual chat targeting so users can chat directly into a specific place card, scoping the conversation to that object.

### What's included

**Chat Target Model** (`app/_lib/chat-target.ts`)
- `ChatTarget` interface supporting context-level and card-level targeting
- Event-based system (`compass-chat-target` / `compass-chat-target-clear`) for cross-component communication
- Helper functions for serialization and display

**PlaceCard 💬 Button**
- Each place card now has a chat button (💬) that appears on hover (desktop) or always visible (mobile/touch)
- Tapping it dispatches a `ChatTarget` event scoped to that specific place
- Passes full context: place name, type, ID, and parent context info

**ChatWidget Target Pill**
- Visual indicator bar above the input showing what chat is scoped to
- Displays emoji + "Chatting about **Place Name**" with clear (✕) button
- Input placeholder updates to reflect the targeted place
- Chat auto-expands and focuses when a target is set

**API & System Prompt Enhancement**
- `POST /api/chat` now accepts `chatTarget` with card-level info (cardId, cardName, cardType, cardPlaceId)
- System prompt builds a `## TARGETED PLACE` section when card targeting is active
- LLM is instructed to resolve pronouns ("remove this", "replace this") to the targeted place
- All actions (save, update, remove, replace) are scoped to the targeted card

**No breaking changes** — existing global chat behavior is fully preserved. The chat target system is purely additive.

### Build
✅ `next build` passes

Fixes #261