### PR TITLE
feat: contextual chat editing — edit and remove discoveries via scoped chat

### DIFF
--- a/app/_components/ChatWidget.tsx
+++ b/app/_components/ChatWidget.tsx
@@ -28,6 +28,8 @@ const TOOL_LABELS: Record<string, string> = {
   'lookup-place': '📍 Looking up a place…',
   'save-discovery': '💾 Saving discovery…',
   'add-to-compass': '🧭 Adding to your Compass…',
+  'edit-discovery': '✏️ Updating a place…',
+  'remove-discovery': '🗑️ Removing a place…',
   'update-trip': '✈️ Updating trip…',
   'create-context': '📋 Creating context…',
 };
@@ -124,7 +126,7 @@ export default function ChatWidget() {
             }
 
             if (parsed.toolResult && typeof window !== 'undefined') {
-              if (['add-to-compass', 'save-discovery'].includes(parsed.toolResult)) {
+              if (['add-to-compass', 'save-discovery', 'edit-discovery', 'remove-discovery'].includes(parsed.toolResult)) {
                 window.dispatchEvent(new CustomEvent('compass-data-changed'));
               }
             }

--- a/app/_lib/chat/system-prompt.ts
+++ b/app/_lib/chat/system-prompt.ts
@@ -46,6 +46,27 @@ WRITE BACK WORKFLOW — for trip management:
 - User wants to focus on food/history/etc → call update_trip with focus array
 - ALWAYS confirm what you saved: "Done — I've added Legal Sea Foods to your Boston trip ✓"
 
+CONTEXTUAL EDITING — for corrections, additions, and removals:
+When the user is scoped to a specific context (see ACTIVE CHAT TARGET below), they may ask you to:
+- CORRECT fields: "Actually the address is 123 Main St" → call edit_discovery with the place name and updates
+- CHANGE type: "That's actually a bar, not a restaurant" → call edit_discovery with updates.type
+- MOVE places: "Move that to my NYC trip" → call edit_discovery with updates.contextKey
+- REMOVE places: "Remove that museum" or "Drop the hotel" → call remove_discovery
+- UPDATE trip details: "Make this a November trip" → call update_trip with new dates
+- REFINE focus: "Add boutique hotels as a focus" → call update_trip with updated focus array
+- ENRICH descriptions: "Add a note about their wine list" → call edit_discovery with updates.description
+
+For each edit, ALWAYS confirm what changed:
+- "✏️ Updated [Place Name]: type changed from restaurant → bar"
+- "🗑️ Removed [Place Name] from your [Context Label]"
+- "✅ Updated [Context Label]: dates changed to November 15–18"
+
+Distinguish between:
+- ADD intent ("add a boutique hotel preference") → update_trip focus or add_to_compass
+- CORRECT intent ("actually it's on Queen St") → edit_discovery
+- REMOVE intent ("take out the museum") → remove_discovery
+- REFINE intent ("shift toward quieter places") → update_trip focus/notes
+
 LINK FORMAT — for every place you mention:
 - Format: **[Place Name](https://compass-ai-agent.vercel.app/placecards/PLACE_ID)** · [📍 Map](https://www.google.com/maps/place/?q=place_id:PLACE_ID) · Rating ★ · $$$
 - The PLACE_ID comes from lookup_place results (the "id" or "place_id" field)

--- a/app/_lib/chat/tools.ts
+++ b/app/_lib/chat/tools.ts
@@ -107,6 +107,47 @@ export const TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'edit_discovery',
+    description: 'Edit/update fields on an existing discovery in the user\'s Compass. Use when the user wants to correct a place\'s name, change its type, update the address, adjust the rating, move it to a different context, or add a description. E.g. "Change that to a bar" or "Actually the address is 123 Main St".',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        name: { type: 'string' as const, description: 'Name of the discovery to edit (fuzzy-matched)' },
+        contextKey: { type: 'string' as const, description: 'Context key to search within, e.g. trip:boston-august-2026' },
+        updates: {
+          type: 'object' as const,
+          description: 'Fields to update on the discovery',
+          properties: {
+            name: { type: 'string' as const, description: 'New name for the place' },
+            city: { type: 'string' as const, description: 'Corrected city' },
+            type: {
+              type: 'string' as const,
+              enum: ['restaurant', 'bar', 'cafe', 'grocery', 'gallery', 'museum', 'theatre', 'music-venue', 'hotel', 'experience', 'shop', 'park', 'architecture', 'development', 'accommodation', 'neighbourhood'] as DiscoveryType[],
+              description: 'Corrected place type',
+            },
+            address: { type: 'string' as const, description: 'Corrected address' },
+            rating: { type: 'number' as const, description: 'Updated rating' },
+            contextKey: { type: 'string' as const, description: 'Move to a different context key' },
+            description: { type: 'string' as const, description: 'Updated description' },
+          },
+        },
+      },
+      required: ['name', 'contextKey', 'updates'],
+    },
+  },
+  {
+    name: 'remove_discovery',
+    description: 'Remove a discovery from the user\'s Compass. Use when the user wants to drop, remove, or dismiss a specific place. E.g. "Remove that museum" or "Drop the hotel".',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        name: { type: 'string' as const, description: 'Name of the discovery to remove (fuzzy-matched)' },
+        contextKey: { type: 'string' as const, description: 'Context key to search within, e.g. trip:boston-august-2026' },
+      },
+      required: ['name', 'contextKey'],
+    },
+  },
+  {
     name: 'create_context',
     description: 'Create a new trip, outing, or radar context in the user\'s manifest. Use when the user says they\'re planning a new trip, want a new outing, or want to track a new city/radar. E.g. "I\'m planning a trip to Boston in August" or "set up a Boston trip for me".',
     input_schema: {

--- a/app/_lib/chat/tools/edit-discovery.ts
+++ b/app/_lib/chat/tools/edit-discovery.ts
@@ -1,0 +1,140 @@
+/**
+ * edit_discovery tool — Edit fields on an existing discovery in the user's Compass.
+ * Called by Concierge when the user wants to correct, refine, or enrich
+ * a discovery within their targeted context.
+ *
+ * Examples:
+ * - "Change that restaurant to a bar"
+ * - "Actually the address is 123 Main St"
+ * - "Update the rating to 4.5"
+ */
+
+import { getUserData, setUserData } from '../../user-data';
+import type { Discovery, DiscoveryType, UserDiscoveries } from '../../types';
+
+export interface EditDiscoveryInput {
+  /** Name of the discovery to edit (fuzzy-matched) */
+  name: string;
+  /** Context key to search within (required for scoping) */
+  contextKey: string;
+  /** Fields to update */
+  updates: {
+    name?: string;
+    city?: string;
+    type?: DiscoveryType;
+    address?: string;
+    rating?: number;
+    contextKey?: string;  // move to a different context
+    description?: string;
+  };
+}
+
+/**
+ * Fuzzy match a discovery by name within a context.
+ * Returns the best match index or -1.
+ */
+function findDiscoveryByName(
+  discoveries: Discovery[],
+  name: string,
+  contextKey: string,
+): number {
+  const nameLower = name.toLowerCase().trim();
+
+  // 1. Exact match within context
+  const exactIdx = discoveries.findIndex(
+    d => d.contextKey === contextKey && d.name.toLowerCase() === nameLower,
+  );
+  if (exactIdx !== -1) return exactIdx;
+
+  // 2. Partial/fuzzy match within context
+  const partialIdx = discoveries.findIndex(
+    d => d.contextKey === contextKey && (
+      d.name.toLowerCase().includes(nameLower) ||
+      nameLower.includes(d.name.toLowerCase())
+    ),
+  );
+  if (partialIdx !== -1) return partialIdx;
+
+  // 3. Exact match across all contexts (fallback)
+  const globalIdx = discoveries.findIndex(
+    d => d.name.toLowerCase() === nameLower,
+  );
+  return globalIdx;
+}
+
+export async function editDiscovery(
+  userId: string,
+  input: EditDiscoveryInput,
+): Promise<string> {
+  try {
+    let discData: UserDiscoveries | null = null;
+    try {
+      discData = await getUserData<'discoveries'>(userId, 'discoveries');
+    } catch {
+      return '❌ No discoveries found. Nothing to edit.';
+    }
+
+    if (!discData?.discoveries?.length) {
+      return '❌ No discoveries found. Nothing to edit.';
+    }
+
+    const idx = findDiscoveryByName(discData.discoveries, input.name, input.contextKey);
+    if (idx === -1) {
+      // Suggest available discoveries in this context
+      const inContext = discData.discoveries
+        .filter(d => d.contextKey === input.contextKey)
+        .map(d => d.name)
+        .slice(0, 5);
+      const hint = inContext.length > 0
+        ? ` Available in this context: ${inContext.join(', ')}`
+        : ' No discoveries in this context.';
+      return `❌ Could not find "${input.name}" to edit.${hint}`;
+    }
+
+    const discovery = discData.discoveries[idx]!;
+    const changes: string[] = [];
+
+    if (input.updates.name) {
+      changes.push(`name: "${discovery.name}" → "${input.updates.name}"`);
+      discovery.name = input.updates.name;
+    }
+    if (input.updates.city) {
+      changes.push(`city: "${discovery.city}" → "${input.updates.city}"`);
+      discovery.city = input.updates.city;
+    }
+    if (input.updates.type) {
+      changes.push(`type: ${discovery.type} → ${input.updates.type}`);
+      discovery.type = input.updates.type;
+    }
+    if (input.updates.address) {
+      changes.push(`address → "${input.updates.address}"`);
+      discovery.address = input.updates.address;
+    }
+    if (input.updates.rating !== undefined) {
+      changes.push(`rating: ${discovery.rating ?? 'none'} → ${input.updates.rating}`);
+      discovery.rating = input.updates.rating;
+    }
+    if (input.updates.contextKey) {
+      changes.push(`moved to context: ${input.updates.contextKey}`);
+      discovery.contextKey = input.updates.contextKey;
+    }
+    if (input.updates.description) {
+      changes.push(`description updated`);
+      discovery.description = input.updates.description;
+    }
+
+    if (changes.length === 0) {
+      return `ℹ️ No changes specified for "${discovery.name}".`;
+    }
+
+    discData.discoveries[idx] = discovery;
+    discData.updatedAt = new Date().toISOString();
+    await setUserData(userId, 'discoveries', discData);
+
+    console.log(`[edit_discovery] ✅ Edited "${discovery.name}" for user ${userId}: ${changes.join('; ')}`);
+    return `✅ Updated "${discovery.name}": ${changes.join(', ')}`;
+  } catch (e) {
+    console.error('[edit_discovery] Failed:', e);
+    return `Failed to edit discovery: ${e}`;
+  }
+}

--- a/app/_lib/chat/tools/remove-discovery.ts
+++ b/app/_lib/chat/tools/remove-discovery.ts
@@ -1,0 +1,142 @@
+/**
+ * remove_discovery tool — Remove/dismiss a discovery from a context.
+ * Called by Concierge when the user wants to remove a place.
+ *
+ * Examples:
+ * - "Remove that museum"
+ * - "Take out Legal Sea Foods"
+ * - "Drop the hotel, keep the restaurants"
+ */
+
+import { put, list } from '@vercel/blob';
+import { getUserData, setUserData } from '../../user-data';
+import type { Discovery, UserDiscoveries } from '../../types';
+
+export interface RemoveDiscoveryInput {
+  /** Name of the discovery to remove (fuzzy-matched) */
+  name: string;
+  /** Context key to search within */
+  contextKey: string;
+}
+
+const BLOB_PREFIX = 'users';
+
+type TriageEntry = { state: string; updatedAt: string; previousState?: string };
+type ContextTriage = { triage: Record<string, TriageEntry>; seen?: Record<string, unknown> };
+type TriageStore = Record<string, ContextTriage>;
+
+function triageBlobPath(userId: string) {
+  return `${BLOB_PREFIX}/${userId}/triage.json`;
+}
+
+async function loadTriageStore(userId: string): Promise<TriageStore> {
+  try {
+    const { blobs } = await list({ prefix: triageBlobPath(userId) });
+    if (!blobs[0]) return {};
+    const res = await fetch(blobs[0].url);
+    if (!res.ok) return {};
+    return (await res.json()) as TriageStore;
+  } catch {
+    return {};
+  }
+}
+
+async function saveTriageStore(userId: string, store: TriageStore): Promise<void> {
+  await put(triageBlobPath(userId), JSON.stringify(store), {
+    access: 'public',
+    contentType: 'application/json',
+    addRandomSuffix: false,
+  });
+}
+
+/**
+ * Find discovery by name in context (fuzzy).
+ */
+function findDiscoveryByName(
+  discoveries: Discovery[],
+  name: string,
+  contextKey: string,
+): number {
+  const nameLower = name.toLowerCase().trim();
+
+  // Exact match within context
+  const exactIdx = discoveries.findIndex(
+    d => d.contextKey === contextKey && d.name.toLowerCase() === nameLower,
+  );
+  if (exactIdx !== -1) return exactIdx;
+
+  // Partial match within context
+  const partialIdx = discoveries.findIndex(
+    d => d.contextKey === contextKey && (
+      d.name.toLowerCase().includes(nameLower) ||
+      nameLower.includes(d.name.toLowerCase())
+    ),
+  );
+  if (partialIdx !== -1) return partialIdx;
+
+  // Global fallback
+  return discoveries.findIndex(d => d.name.toLowerCase() === nameLower);
+}
+
+export async function removeDiscovery(
+  userId: string,
+  input: RemoveDiscoveryInput,
+): Promise<string> {
+  try {
+    let discData: UserDiscoveries | null = null;
+    try {
+      discData = await getUserData<'discoveries'>(userId, 'discoveries');
+    } catch {
+      return '❌ No discoveries found. Nothing to remove.';
+    }
+
+    if (!discData?.discoveries?.length) {
+      return '❌ No discoveries found. Nothing to remove.';
+    }
+
+    const idx = findDiscoveryByName(discData.discoveries, input.name, input.contextKey);
+    if (idx === -1) {
+      const inContext = discData.discoveries
+        .filter(d => d.contextKey === input.contextKey)
+        .map(d => d.name)
+        .slice(0, 5);
+      const hint = inContext.length > 0
+        ? ` Available: ${inContext.join(', ')}`
+        : ' No discoveries in this context.';
+      return `❌ Could not find "${input.name}" to remove.${hint}`;
+    }
+
+    const discovery = discData.discoveries[idx]!;
+    const removedName = discovery.name;
+    const removedId = discovery.id;
+
+    // Remove from discoveries array
+    discData.discoveries.splice(idx, 1);
+    discData.updatedAt = new Date().toISOString();
+    await setUserData(userId, 'discoveries', discData);
+
+    // Mark as dismissed in triage store
+    try {
+      const store = await loadTriageStore(userId);
+      if (!store[input.contextKey]) {
+        store[input.contextKey] = { triage: {}, seen: {} };
+      }
+      const existing = store[input.contextKey]!.triage[removedId];
+      store[input.contextKey]!.triage[removedId] = {
+        state: 'dismissed',
+        updatedAt: new Date().toISOString(),
+        previousState: existing?.state || undefined,
+      };
+      await saveTriageStore(userId, store);
+    } catch (e) {
+      // Triage update is best-effort
+      console.warn('[remove_discovery] Triage update failed (non-critical):', e);
+    }
+
+    console.log(`[remove_discovery] ✅ Removed "${removedName}" from ${input.contextKey} for user ${userId}`);
+    return `✅ Removed "${removedName}" from your Compass.`;
+  } catch (e) {
+    console.error('[remove_discovery] Failed:', e);
+    return `Failed to remove discovery: ${e}`;
+  }
+}

--- a/app/_lib/chat/tools/runner.ts
+++ b/app/_lib/chat/tools/runner.ts
@@ -6,6 +6,8 @@ import { braveSearch } from './web-search';
 import { lookupPlace } from './lookup-place';
 import { addToCompass, type AddToCompassInput } from './add-to-compass';
 import { saveDiscovery, type SaveDiscoveryInput } from './save-discovery';
+import { editDiscovery, type EditDiscoveryInput } from './edit-discovery';
+import { removeDiscovery, type RemoveDiscoveryInput } from './remove-discovery';
 import { updateTrip, type UpdateTripInput } from './update-trip';
 import { createContext, type CreateContextInput } from './create-context';
 
@@ -14,6 +16,8 @@ export type ToolName =
   | 'lookup_place'
   | 'add_to_compass'
   | 'save_discovery'
+  | 'edit_discovery'
+  | 'remove_discovery'
   | 'update_trip'
   | 'create_context';
 
@@ -21,6 +25,8 @@ export type ToolInput =
   | { query: string }
   | AddToCompassInput
   | SaveDiscoveryInput
+  | EditDiscoveryInput
+  | RemoveDiscoveryInput
   | UpdateTripInput
   | CreateContextInput;
 
@@ -45,6 +51,10 @@ export async function runToolCall(
       return addToCompass(userId, input as unknown as AddToCompassInput);
     case 'save_discovery':
       return saveDiscovery(userId, input as unknown as SaveDiscoveryInput);
+    case 'edit_discovery':
+      return editDiscovery(userId, input as unknown as EditDiscoveryInput);
+    case 'remove_discovery':
+      return removeDiscovery(userId, input as unknown as RemoveDiscoveryInput);
     case 'update_trip':
       return updateTrip(userId, input as unknown as UpdateTripInput);
     case 'create_context':

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -32,6 +32,8 @@ function mapToolName(name: string): string {
     'update_trip': 'update-trip',
     'add_to_compass': 'add-to-compass',
     'save_discovery': 'save-discovery',
+    'edit_discovery': 'edit-discovery',
+    'remove_discovery': 'remove-discovery',
     'web_search': 'web-search',
     'lookup_place': 'lookup-place',
   };


### PR DESCRIPTION
## Summary

Adds two new chat tools that let users **correct, enrich, and remove** discoveries when chat is scoped to a specific context (trip/outing/radar).

## Changes

### New Tools
- **`edit_discovery`** — Edit fields on an existing discovery (name, city, type, address, rating, description, or move to another context). Fuzzy-matches by name within the active context.
- **`remove_discovery`** — Remove a discovery from the user's Compass and mark it as dismissed in triage. Fuzzy-matches by name.

### Updated Files
- **`tools.ts`** — Added tool definitions for `edit_discovery` and `remove_discovery`
- **`runner.ts`** — Registered new tool handlers
- **`system-prompt.ts`** — Added CONTEXTUAL EDITING section teaching the AI to distinguish add/correct/remove/refine intents and confirm changes
- **`ChatWidget.tsx`** — Added tool status labels and data-changed events for new tools
- **`route.ts`** — Added tool name mapping for SSE events

## How It Works

When chat is scoped to a context (via `activeContextKey`), the user can say things like:
- "Actually make this a November trip" → `update_trip` with new dates
- "Change that to a bar" → `edit_discovery` with `updates.type`
- "Remove that museum" → `remove_discovery`
- "Add a note about their wine list" → `edit_discovery` with `updates.description`

The AI confirms every change with a clear before/after summary.

## Testing
- ✅ Build passes
- ✅ All 10 Playwright tests pass

Fixes #262