### PR TITLE
fix: discoveries not appearing on focused homepage (#271)

### DIFF
--- a/app/_lib/chat/tools/add-to-compass.ts
+++ b/app/_lib/chat/tools/add-to-compass.ts
@@ -8,7 +8,7 @@
  * a single turn. Places without photos are filtered from display until enriched.
  */
 
-import { setUserData, getUserData } from '../../user-data';
+import { setUserData, getUserData, getUserManifest } from '../../user-data';
 import type { Discovery, DiscoveryType, UserDiscoveries } from '../../types';
 import { resolveCity } from './resolve-city';
 
@@ -88,6 +88,34 @@ export async function addToCompass(
     // Derive city from actual place data, not from LLM context (fixes #187)
     const resolvedCity = await resolveCity(input.place_id, input.address, input.city);
 
+    // Resolve contextKey against the user's manifest to prevent LLM key mismatches
+    // e.g. LLM may hallucinate "trip:tokyo-november-2024" when the real key is "trip:tokyo-november-2027"
+    let resolvedContextKey = input.contextKey || '';
+    if (resolvedContextKey) {
+      try {
+        const manifest = await getUserManifest(userId);
+        if (manifest?.contexts?.length) {
+          const exact = manifest.contexts.find(c => c.key === resolvedContextKey);
+          if (!exact) {
+            // Fuzzy match: compare slug portions (strip year variants)
+            const inputSlug = resolvedContextKey.split(':').slice(1).join(':');
+            const inputBase = inputSlug.replace(/-\d{4}$/, '');
+            const match = manifest.contexts.find(c => {
+              const cSlug = c.key.split(':').slice(1).join(':');
+              const cBase = cSlug.replace(/-\d{4}$/, '');
+              return cBase === inputBase || cSlug.includes(inputBase) || inputBase.includes(cBase);
+            });
+            if (match) {
+              console.log(`[add_to_compass] Fixed contextKey: "${resolvedContextKey}" → "${match.key}"`);
+              resolvedContextKey = match.key;
+            }
+          }
+        }
+      } catch {
+        // Fall through with original key
+      }
+    }
+
     const discovery: Discovery = {
       id: discoveryId,
       place_id: input.place_id,
@@ -98,7 +126,7 @@ export async function addToCompass(
       rating: input.rating,
       heroImage: undefined,
       images: undefined,
-      contextKey: input.contextKey || '',
+      contextKey: resolvedContextKey,
       source: 'chat:recommendation',
       discoveredAt: new Date().toISOString(),
       placeIdStatus: input.place_id ? 'verified' : 'missing',

--- a/app/_lib/user-data.ts
+++ b/app/_lib/user-data.ts
@@ -222,10 +222,11 @@ function inferTypeFromName(name: string | undefined | null): string {
 }
 
 function normalizeContextKey(key: string | undefined | null): string {
-  if (!key || key === 'undefined' || !key.includes(':')) return 'radar:toronto-experiences';
+  if (!key || key === 'undefined') return '';
+  if (!key.includes(':')) return '';
   let k = key;
   // Map known non-standard prefixes
-  if (k.startsWith('home:')) return 'radar:toronto-experiences';
+  if (k.startsWith('home:')) return '';
   if (k.startsWith('section:')) k = k.replace(/^section:/, 'radar:');
   // Strip user prefix (e.g. "john:outing:..." → "outing:...")
   if (!k.startsWith('trip:') && !k.startsWith('outing:') && !k.startsWith('radar:')) {
@@ -233,7 +234,7 @@ function normalizeContextKey(key: string | undefined | null): string {
     if (m && m[1] && m[2]) k = m[1] + m[2];
     if (k.startsWith('section:')) k = k.replace(/^section:/, 'radar:');
   }
-  if (!k.includes(':')) return 'radar:toronto-experiences';
+  if (!k.includes(':')) return '';
   return k;
 }
 


### PR DESCRIPTION
## Problem
When testing the Seb user, discoveries added via `add_to_compass` didn't appear on the focused homepage — showed 'No discoveries yet' despite data being persisted.

## Root Cause
Two-layer contextKey mismatch:

1. **`normalizeContextKey()` rewrote empty keys to wrong default**: When a discovery had an empty/missing contextKey (common when LLM omits it), normalization mapped it to `'radar:toronto-experiences'`. This broke the page.tsx empty-key check (`!d.contextKey || d.contextKey === ''`) because by the time page.tsx sees the data, the key is already `'radar:toronto-experiences'` — which then fails fuzzy matching against trip contexts like `trip:tokyo-november-2027`.

2. **LLM year hallucination**: The LLM sometimes generates contextKeys with wrong years (e.g. `trip:tokyo-november-2024` when the actual context is `trip:tokyo-november-2027`), causing exact and fuzzy matches to fail.

## Fix
1. **`normalizeContextKey()`**: Return `''` for empty/missing/malformed keys instead of hardcoded `'radar:toronto-experiences'`. This lets page.tsx's existing empty-key-defaults-to-first-context logic work correctly.

2. **`add-to-compass` tool**: Resolve the LLM-provided contextKey against the user's actual manifest with fuzzy slug matching (strips year suffixes). E.g. `trip:tokyo-november-2024` → matches `trip:tokyo-november-2027`.

## Testing
- Build passes ✅
- Empty contextKey discoveries now correctly default to first context (active trip)
- Year-mismatched contextKeys are resolved at write time

Fixes #271