### PR TITLE
fix: homepage auto-switches to newly created context from chat

### DIFF
--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import type { Context, Discovery } from '../_lib/types';
@@ -249,8 +249,10 @@ export default function HomeClient({
 
   // Active context key — persisted in localStorage
   const [activeKey, setActiveKey] = useState<string | null>(null);
+  const initializedRef = useRef(false);
 
-  // Initialize active key from localStorage or first context
+  // Initialize active key from localStorage on first mount;
+  // on subsequent context refreshes, keep current key if still valid.
   useEffect(() => {
     setMounted(true);
     // Load all context counts
@@ -260,16 +262,26 @@ export default function HomeClient({
     }
     setContextCounts(counts);
 
-    // Restore active key
-    try {
-      const stored = localStorage.getItem('compass-active-context');
-      if (stored && contexts.some(c => c.key === stored)) {
-        setActiveKey(stored);
-      } else if (contexts.length > 0) {
-        setActiveKey(contexts[0]!.key);
+    if (!initializedRef.current) {
+      // First mount: restore from localStorage
+      initializedRef.current = true;
+      try {
+        const stored = localStorage.getItem('compass-active-context');
+        if (stored && contexts.some(c => c.key === stored)) {
+          setActiveKey(stored);
+        } else if (contexts.length > 0) {
+          setActiveKey(contexts[0]!.key);
+        }
+      } catch {
+        if (contexts.length > 0) setActiveKey(contexts[0]!.key);
       }
-    } catch {
-      if (contexts.length > 0) setActiveKey(contexts[0]!.key);
+    } else {
+      // Subsequent context refreshes (e.g. after router.refresh()):
+      // keep the current activeKey if it's still valid, otherwise fall back
+      setActiveKey(prev => {
+        if (prev && contexts.some(c => c.key === prev)) return prev;
+        return contexts.length > 0 ? contexts[0]!.key : null;
+      });
     }
   }, [userId, contexts]);
 
@@ -327,6 +339,7 @@ export default function HomeClient({
       });
       // Switch to the newly created context
       setActiveKey(detail.key);
+      broadcastActiveContext(detail.key);
       // Refresh server data to load the new context
       router.refresh();
       // Remove the emerging flag after the animation completes (700ms animation + buffer)
@@ -344,7 +357,7 @@ export default function HomeClient({
       window.removeEventListener('compass-trip-created', handler);
       timers.forEach(clearTimeout);
     };
-  }, [router]);
+  }, [router, broadcastActiveContext]);
 
   // Listen for trip attribute attachments from chat
   useEffect(() => {


### PR DESCRIPTION
Fixes #277

## Problem
When a user creates a new trip via chat, the homepage stayed on the old trip because `router.refresh()` re-triggered the initialization useEffect, which restored the activeKey from localStorage — overriding the key just set by the `compass-trip-created` handler.

## Fix
- Added `initializedRef` to distinguish first mount from subsequent context refreshes
- **First mount**: restores activeKey from localStorage (existing behavior)
- **Subsequent refreshes** (e.g. after `router.refresh()`): preserves the current activeKey if it's still valid in the updated contexts list
- Added `broadcastActiveContext` call in the `compass-trip-created` handler so the ChatWidget stays synced

## Flow after fix
1. User says 'plan a trip to Barcelona'
2. `create_context` tool executes → new context created
3. ChatWidget detects tool call → emits `compass-trip-created`
4. HomeClient receives event → sets activeKey to new context key + broadcasts
5. `router.refresh()` fetches updated contexts from server
6. useEffect re-runs but preserves current activeKey (not overwritten from localStorage)
7. ContextSwitcher updates → Barcelona now shown with emergence animation

Build passes ✅