### PR TITLE
feat: auto-switch homepage to context discussed in chat

### DIFF
--- a/app/_components/ChatWidget.tsx
+++ b/app/_components/ChatWidget.tsx
@@ -250,6 +250,13 @@ export default function ChatWidget() {
               if (['add-to-compass', 'save-discovery', 'edit-discovery', 'remove-discovery'].includes(parsed.toolResult)) {
                 window.dispatchEvent(new CustomEvent('compass-data-changed'));
               }
+              // Auto-switch homepage when tool targets a different context
+              if (parsed.contextKey && parsed.contextKey !== activeContextKeyRef.current) {
+                activeContextKeyRef.current = parsed.contextKey;
+                window.dispatchEvent(new CustomEvent('compass-chat-context-switch', {
+                  detail: { key: parsed.contextKey },
+                }));
+              }
             }
           } catch {
             // skip non-JSON lines

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -165,8 +165,10 @@ async function executeToolLoop(
             userId,
           );
           // Emit toolResult event so frontend can refresh
+          // Include contextKey so frontend can auto-switch homepage
+          const toolContextKey = (toolBlock.input as Record<string, unknown>)?.contextKey as string | undefined;
           controller.enqueue(encoder.encode(
-            `data: ${JSON.stringify({ toolResult: frontendToolName, messageId })}\n\n`
+            `data: ${JSON.stringify({ toolResult: frontendToolName, messageId, ...(toolContextKey ? { contextKey: toolContextKey } : {}) })}\n\n`
           ));
           toolResults.push({
             type: 'tool_result',


### PR DESCRIPTION
## Summary

When the user talks about an existing trip (e.g. "plan a trip to Barcelona" and Barcelona already exists), the homepage now auto-switches to that context — not just for newly created trips.

## Changes

**app/api/chat/route.ts**
- Include `contextKey` from tool inputs in SSE `toolResult` events sent to the frontend

**app/_components/ChatWidget.tsx**  
- Detect `contextKey` in streamed tool results
- When it differs from the current active context, update the ref and emit `compass-chat-context-switch` event

**app/_components/HomeClient.tsx**
- No changes needed — already listens for `compass-chat-context-switch` events

## How it works

1. User says "add restaurants to my Barcelona trip"
2. Concierge calls `add-to-compass` with `contextKey: 'trip:barcelona-...' `
3. API streams `{ toolResult: 'add-to-compass', contextKey: 'trip:barcelona-...' }`
4. ChatWidget detects context differs from active → emits switch event
5. HomeClient switches the displayed context to Barcelona

Fixes #285