### PR TITLE
fix: give chat richer awareness of saved trips

### DIFF
--- a/app/_lib/chat/system-prompt.ts
+++ b/app/_lib/chat/system-prompt.ts
@@ -57,7 +57,7 @@ CONTEXT SWITCHING — keep the homepage in sync with the conversation:
   - "Show me the cottage trip"
 - After create_context for a brand-new trip, you do NOT need to call set_active_context — the app auto-switches on create_context.
 - If the user asks about a context that does not exist yet, call create_context instead (do NOT call set_active_context with a made-up key).
-- Use the exact key from ACTIVE CONTEXTS (e.g. \`trip:nyc-solo-trip\`), not a free-form label.
+- Use the exact key from KNOWN CONTEXTS (e.g. \`trip:nyc-solo-trip\`), not a free-form label.
 
 CONTEXTUAL EDITING — for corrections, additions, and removals:
 When the user is scoped to a specific context (see ACTIVE CHAT TARGET below), they may ask you to:
@@ -119,16 +119,201 @@ export interface ChatTargetInfo {
   cardPlaceId?: string;
 }
 
+export interface KnownContextDiscovery {
+  contextKey: string;
+  name: string;
+  type: string;
+  city: string;
+  address?: string;
+  discoveredAt?: string;
+}
+
 export interface ChatContext {
   userCode: string;
   userCity: string;
   preferences: UserPreferences | null;
   manifest: UserManifest | null;
   recentDiscoveries: Array<{ name: string; type: string; city: string }>;
+  knownDiscoveries?: KnownContextDiscovery[];
   /** The explicitly focused context key (for contextual chat targeting) */
   activeContextKey?: string;
   /** Card-level targeting — a specific place the user is chatting about */
   chatTarget?: ChatTargetInfo;
+}
+
+type RichContext = Context & Record<string, unknown>;
+
+function truncate(value: string, max = 180): string {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= max) return normalized;
+  return `${normalized.slice(0, max - 1).trimEnd()}…`;
+}
+
+function isContextActive(context: Context): boolean {
+  if (context.status) return context.status === 'active';
+  return Boolean(context.active);
+}
+
+function getContextStatus(context: RichContext): string {
+  if (typeof context.status === 'string' && context.status.length > 0) return context.status;
+  return context.active ? 'active' : 'inactive';
+}
+
+function getStringList(value: unknown, limit = 4): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      if (typeof item === 'string') return item.trim();
+      if (item && typeof item === 'object' && typeof (item as { name?: unknown }).name === 'string') {
+        return ((item as { name: string }).name || '').trim();
+      }
+      return '';
+    })
+    .filter(Boolean)
+    .slice(0, limit);
+}
+
+function getPeopleSummary(context: RichContext): string | null {
+  if (!Array.isArray(context.people)) return null;
+  const people = context.people
+    .map((person) => {
+      if (!person || typeof person !== 'object') return null;
+      const name = typeof person.name === 'string' ? person.name.trim() : '';
+      if (!name) return null;
+      const relation = typeof person.relation === 'string' ? person.relation.trim() : '';
+      return relation ? `${name} (${relation})` : name;
+    })
+    .filter((person): person is string => Boolean(person))
+    .slice(0, 4);
+
+  return people.length > 0 ? people.join(', ') : null;
+}
+
+function getAccommodationSummary(context: RichContext): string | null {
+  if (context.accommodation && typeof context.accommodation === 'object') {
+    const accommodation = context.accommodation as Record<string, unknown>;
+    const name = typeof accommodation.name === 'string' ? accommodation.name.trim() : '';
+    const address = typeof accommodation.address === 'string' ? accommodation.address.trim() : '';
+    const status = typeof accommodation.status === 'string' ? accommodation.status.trim() : '';
+    const parts = [name, address, status ? `status: ${status}` : ''].filter(Boolean);
+    if (parts.length > 0) return parts.join(', ');
+  }
+
+  const name = typeof context.accommodationName === 'string' ? context.accommodationName.trim() : '';
+  const address = typeof context.accommodationAddress === 'string' ? context.accommodationAddress.trim() : '';
+  const parts = [name, address].filter(Boolean);
+  return parts.length > 0 ? parts.join(', ') : null;
+}
+
+function getBaseSummary(context: RichContext): string | null {
+  if (!context.base || typeof context.base !== 'object') return null;
+  const base = context.base as Record<string, unknown>;
+  const address = typeof base.address === 'string' ? base.address.trim() : '';
+  const host = typeof base.host === 'string' ? base.host.trim() : '';
+  const zone = typeof base.zone === 'string' ? base.zone.trim() : '';
+  const parts = [address, host ? `host: ${host}` : '', zone ? `zone: ${zone}` : ''].filter(Boolean);
+  return parts.length > 0 ? parts.join(', ') : null;
+}
+
+function getTravelSummary(context: RichContext): string | null {
+  if (!context.travel || typeof context.travel !== 'object') return null;
+  const travel = context.travel as Record<string, unknown>;
+
+  if (typeof travel.note === 'string' && travel.note.trim()) {
+    return truncate(travel.note, 140);
+  }
+
+  const outbound = travel.outbound && typeof travel.outbound === 'object'
+    ? travel.outbound as Record<string, unknown>
+    : null;
+  const inbound = travel.return && typeof travel.return === 'object'
+    ? travel.return as Record<string, unknown>
+    : null;
+
+  const segments = [outbound, inbound]
+    .filter((segment): segment is Record<string, unknown> => Boolean(segment))
+    .map((segment) => {
+      const from = typeof segment.from === 'string' ? segment.from.trim() : '';
+      const to = typeof segment.to === 'string' ? segment.to.trim() : '';
+      const departs = typeof segment.departs === 'string' ? segment.departs.trim() : '';
+      const arrives = typeof segment.arrives === 'string' ? segment.arrives.trim() : '';
+      if (!from && !to) return '';
+      const route = [from, to].filter(Boolean).join(' → ');
+      const timing = [departs ? `departs ${departs}` : '', arrives ? `arrives ${arrives}` : ''].filter(Boolean).join(', ');
+      return [route, timing].filter(Boolean).join(' ');
+    })
+    .filter(Boolean);
+
+  return segments.length > 0 ? segments.join(' | ') : null;
+}
+
+function getContextDiscoveries(
+  context: Context,
+  discoveries: KnownContextDiscovery[] = [],
+  limit = 3,
+): string[] {
+  return discoveries
+    .filter((discovery) => discovery.contextKey === context.key)
+    .sort((a, b) => {
+      const aPriority = a.type === 'accommodation' || a.type === 'hotel' ? 0 : 1;
+      const bPriority = b.type === 'accommodation' || b.type === 'hotel' ? 0 : 1;
+      if (aPriority !== bPriority) return aPriority - bPriority;
+      return new Date(b.discoveredAt || 0).getTime() - new Date(a.discoveredAt || 0).getTime();
+    })
+    .slice(0, limit)
+    .map((discovery) => {
+      const location = discovery.address || discovery.city;
+      return `${discovery.name} (${discovery.type}${location ? `, ${location}` : ''})`;
+    });
+}
+
+function formatContextSummary(
+  context: Context,
+  discoveries: KnownContextDiscovery[] = [],
+  detailLevel: 'concise' | 'full' = 'concise',
+): string {
+  const richContext = context as RichContext;
+  const status = getContextStatus(richContext);
+  const bookingStatus = typeof richContext.bookingStatus === 'string' ? richContext.bookingStatus.trim() : '';
+  const headerParts = [context.type, status, bookingStatus ? `booking: ${bookingStatus}` : ''].filter(Boolean);
+  const lines: string[] = [
+    `- ${context.emoji || '📍'} ${context.label} [${headerParts.join(', ')}]`,
+    `  Key: ${context.key}`,
+  ];
+
+  const facts = [
+    context.city ? `Location: ${context.city}` : '',
+    context.dates ? `Dates: ${context.dates}` : '',
+    context.focus?.length ? `Focus: ${context.focus.join(', ')}` : '',
+  ].filter(Boolean);
+  if (facts.length > 0) lines.push(`  ${facts.join(' · ')}`);
+
+  const accommodation = getAccommodationSummary(richContext);
+  const base = getBaseSummary(richContext);
+  const travel = getTravelSummary(richContext);
+  const people = getPeopleSummary(richContext);
+  const priorities = getStringList(richContext.priorities);
+  const mustDo = getStringList(richContext.mustDo);
+  const places = getContextDiscoveries(context, discoveries, detailLevel === 'full' ? 3 : 2);
+
+  const extras = [
+    accommodation ? `Accommodation: ${accommodation}` : '',
+    base ? `Base: ${base}` : '',
+    travel ? `Travel: ${travel}` : '',
+    people ? `People: ${people}` : '',
+    typeof richContext.purpose === 'string' && richContext.purpose.trim() ? `Purpose: ${truncate(richContext.purpose, 170)}` : '',
+    typeof richContext.notes === 'string' && richContext.notes.trim() ? `Notes: ${truncate(richContext.notes, 170)}` : '',
+    priorities.length > 0 ? `Priorities: ${priorities.join(', ')}` : '',
+    mustDo.length > 0 ? `Must do: ${mustDo.join(', ')}` : '',
+    places.length > 0 ? `Known places: ${places.join('; ')}` : '',
+  ].filter(Boolean);
+
+  const maxExtras = detailLevel === 'full' ? 6 : 2;
+  for (const extra of extras.slice(0, maxExtras)) {
+    lines.push(`  ${extra}`);
+  }
+
+  return lines.join('\n');
 }
 
 /**
@@ -173,18 +358,35 @@ Be curious and warm. Get to know them naturally.`;
     }
   }
 
-  // Add active contexts (trips, outings, radars)
-  const activeContexts = context.manifest?.contexts?.filter((c: Context) => c.active) || [];
-  if (activeContexts.length > 0) {
-    prompt += `\n\n## ACTIVE CONTEXTS\n`;
-    for (const ctx of activeContexts) {
-      const dates = ctx.dates ? ` (${ctx.dates})` : '';
-      const focus = ctx.focus?.length ? ` — Focus: ${ctx.focus.join(', ')}` : '';
-      prompt += `- ${ctx.emoji} ${ctx.label}${dates}${focus}\n`;
-      prompt += `  Key: ${ctx.key}\n`;
+  // Add known contexts with rich trip facts
+  const allContexts = context.manifest?.contexts || [];
+  if (allContexts.length > 0) {
+    const activeContexts = allContexts.filter(isContextActive);
+    const prioritizedKeys = new Set<string>([
+      ...activeContexts.map((ctx) => ctx.key),
+      ...(context.activeContextKey ? [context.activeContextKey] : []),
+    ]);
+
+    prompt += `\n\n## KNOWN CONTEXTS\nThese are the user's existing trips, outings, radars, and saved planning contexts. Treat these as already-known facts from the app. Do not ask the user to repeat details that are already listed here.`;
+
+    const prioritizedContexts = allContexts.filter((ctx) => prioritizedKeys.has(ctx.key));
+    const otherContexts = allContexts.filter((ctx) => !prioritizedKeys.has(ctx.key));
+
+    if (prioritizedContexts.length > 0) {
+      prompt += `\n\n### PRIORITY CONTEXTS\n`;
+      for (const ctx of prioritizedContexts) {
+        prompt += `${formatContextSummary(ctx, context.knownDiscoveries, 'full')}\n`;
+      }
+    }
+
+    if (otherContexts.length > 0) {
+      prompt += `\n### OTHER KNOWN CONTEXTS\n`;
+      for (const ctx of otherContexts) {
+        prompt += `${formatContextSummary(ctx, context.knownDiscoveries, ctx.type === 'trip' ? 'full' : 'concise')}\n`;
+      }
     }
   } else {
-    prompt += `\n\n## CONTEXTS\nNo active trips, outings, or radars. If the user mentions an upcoming trip or outing, help them set it up.`;
+    prompt += `\n\n## CONTEXTS\nNo saved trips, outings, or radars yet. If the user mentions an upcoming trip or outing, help them set it up.`;
   }
 
   // Add recent discoveries
@@ -199,7 +401,7 @@ Be curious and warm. Get to know them naturally.`;
   if (context.activeContextKey) {
     const targeted = context.manifest?.contexts?.find((c: Context) => c.key === context.activeContextKey);
     if (targeted) {
-      prompt += `\n\n## ACTIVE CHAT TARGET\nThe user is currently focused on: **${targeted.emoji || '\ud83d\udccd'} ${targeted.label}** (key: \`${targeted.key}\`)${targeted.city ? ` in ${targeted.city}` : ''}${targeted.dates ? ` — ${targeted.dates}` : ''}.\n\nWhen the user talks about places, adding things, or updating details — apply them to THIS context. Use contextKey: \`${targeted.key}\` in all add_to_compass and update_trip calls unless they explicitly mention a different trip.`;
+      prompt += `\n\n## ACTIVE CHAT TARGET\nThe user is currently focused on: **${targeted.emoji || '📍'} ${targeted.label}** (key: \`${targeted.key}\`)${targeted.city ? ` in ${targeted.city}` : ''}${targeted.dates ? ` — ${targeted.dates}` : ''}.\n\nKnown facts for this target:\n${formatContextSummary(targeted, context.knownDiscoveries, 'full')}\n\nWhen the user talks about places, adding things, or updating details, apply them to THIS context. Use contextKey: \`${targeted.key}\` in all add_to_compass and update_trip calls unless they explicitly mention a different trip.`;
 
       // Card-level targeting — user tapped a specific place card to chat about it
       if (context.chatTarget?.cardName) {
@@ -210,7 +412,7 @@ Be curious and warm. Get to know them naturally.`;
   }
 
   // Add contextKey instruction
-  prompt += `\n\n## CONTEXTKEY USAGE\nWhen recommending places, use the appropriate contextKey from the ACTIVE CONTEXTS above in your add_to_compass calls. Match the city and focus areas to the context. If no context matches, omit contextKey.`;
+  prompt += `\n\n## CONTEXTKEY USAGE\nWhen recommending places, use the appropriate contextKey from the KNOWN CONTEXTS above in your add_to_compass calls. Match the city and focus areas to the context. If no context matches, omit contextKey.`;
 
   return prompt;
 }

--- a/app/_lib/chat/tools.ts
+++ b/app/_lib/chat/tools.ts
@@ -149,11 +149,11 @@ export const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'set_active_context',
-    description: 'Switch the homepage focus to a specific existing trip/outing/radar context. Call this whenever the conversation shifts to discuss a different context than the one the user is currently viewing — e.g. the user says "let\'s review the NYC trip" or "actually, what about Boston?". This does NOT create a new context (use create_context for that) and does NOT add or update discoveries — it just signals the app to switch the visible context. Use the exact context key from the ACTIVE CONTEXTS list.',
+    description: 'Switch the homepage focus to a specific existing trip/outing/radar context. Call this whenever the conversation shifts to discuss a different context than the one the user is currently viewing — e.g. the user says "let\'s review the NYC trip" or "actually, what about Boston?". This does NOT create a new context (use create_context for that) and does NOT add or update discoveries — it just signals the app to switch the visible context. Use the exact context key from the KNOWN CONTEXTS list.',
     input_schema: {
       type: 'object' as const,
       properties: {
-        contextKey: { type: 'string' as const, description: 'The exact context key to focus, e.g. trip:nyc-solo-trip or trip:boston-august-2026. Must match one of the keys in ACTIVE CONTEXTS.' },
+        contextKey: { type: 'string' as const, description: 'The exact context key to focus, e.g. trip:nyc-solo-trip or trip:boston-august-2026. Must match one of the keys in KNOWN CONTEXTS.' },
       },
       required: ['contextKey'],
     },

--- a/app/_lib/chat/user-context.ts
+++ b/app/_lib/chat/user-context.ts
@@ -3,7 +3,7 @@
  *
  * This replaces the old monolithic system prompt — the Concierge agent's
  * personality and tool definitions now live in OpenClaw's agent config.
- * We only need to inject who the user is, their preferences, and active contexts
+ * We only need to inject who the user is, their preferences, and known contexts
  * so the agent can personalize its responses.
  */
 
@@ -25,6 +25,50 @@ interface RecentDiscovery {
   name: string;
   type: string;
   city: string;
+}
+
+type RichContext = Context & Record<string, unknown>;
+
+function truncate(value: string, max = 160): string {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= max) return normalized;
+  return `${normalized.slice(0, max - 1).trimEnd()}…`;
+}
+
+function isContextActive(context: Context): boolean {
+  if (context.status) return context.status === 'active';
+  return Boolean(context.active);
+}
+
+function summarizeContext(context: Context): string {
+  const raw = context as RichContext;
+  const status = typeof raw.status === 'string' && raw.status.length > 0
+    ? raw.status
+    : raw.active ? 'active' : 'inactive';
+  const bookingStatus = typeof raw.bookingStatus === 'string' ? raw.bookingStatus : '';
+  const facts = [
+    context.city ? `Location: ${context.city}` : '',
+    context.dates ? `Dates: ${context.dates}` : '',
+    context.focus?.length ? `Focus: ${context.focus.join(', ')}` : '',
+    bookingStatus ? `Booking: ${bookingStatus}` : '',
+  ].filter(Boolean);
+
+  const extras = [
+    raw.accommodation && typeof raw.accommodation === 'object'
+      ? `Accommodation: ${[
+          typeof (raw.accommodation as { name?: unknown }).name === 'string' ? (raw.accommodation as { name: string }).name : '',
+          typeof (raw.accommodation as { address?: unknown }).address === 'string' ? (raw.accommodation as { address: string }).address : '',
+        ].filter(Boolean).join(', ')}`
+      : '',
+    typeof raw.purpose === 'string' && raw.purpose.trim() ? `Purpose: ${truncate(raw.purpose)}` : '',
+    typeof raw.notes === 'string' && raw.notes.trim() ? `Notes: ${truncate(raw.notes)}` : '',
+  ].filter(Boolean);
+
+  return [
+    `- ${context.emoji || '📍'} ${context.label} [${context.type}, ${status}${bookingStatus ? `, booking: ${bookingStatus}` : ''}] [key: ${context.key}]`,
+    ...(facts.length > 0 ? [`  ${facts.join(' · ')}`] : []),
+    ...extras.slice(0, 2).map((extra) => `  ${extra}`),
+  ].join('\n');
 }
 
 export function buildUserContext(
@@ -53,17 +97,20 @@ export function buildUserContext(
     }
   }
 
-  // Active contexts (trips, outings, radars)
-  const activeContexts = manifest?.contexts?.filter((c: Context) => c.active) || [];
-  if (activeContexts.length > 0) {
-    const ctxLines = activeContexts.map((ctx: Context) => {
-      const dates = ctx.dates ? ` (${ctx.dates})` : '';
-      const focus = ctx.focus?.length ? ` — Focus: ${ctx.focus.join(', ')}` : '';
-      return `- ${ctx.emoji || '📍'} ${ctx.label}${dates}${focus}  [key: ${ctx.key}]`;
-    });
-    parts.push(`## Active Contexts\n${ctxLines.join('\n')}`);
+  const allContexts = manifest?.contexts || [];
+  if (allContexts.length > 0) {
+    const activeContexts = allContexts.filter(isContextActive);
+    const otherContexts = allContexts.filter((context) => !isContextActive(context));
+
+    if (activeContexts.length > 0) {
+      parts.push(`## Active Contexts\n${activeContexts.map(summarizeContext).join('\n')}`);
+    }
+
+    if (otherContexts.length > 0) {
+      parts.push(`## Other Known Contexts\n${otherContexts.map(summarizeContext).join('\n')}`);
+    }
   } else {
-    parts.push(`## Contexts\nNo active trips, outings, or radars.`);
+    parts.push(`## Contexts\nNo saved trips, outings, or radars.`);
   }
 
   // Recent discoveries
@@ -79,7 +126,7 @@ export function buildUserContext(
 
 When the user wants to plan or create a trip, outing, or radar, use the "create-context" tool.
 
-When the user mentions dates, city, focus areas, or accommodation for an existing trip, use the "update-trip" tool.
+When the user mentions dates, city, focus areas, accommodation, or other known trip details for an existing trip, use the "update-trip" tool.
 
 When you find or recommend places (restaurants, bars, cafes, etc.), use the "add-discovery" tool to save them to the user's radar or trip.
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -281,10 +281,23 @@ export async function POST(request: NextRequest) {
       getUserDiscoveries(user.id),
     ]);
 
-    const recentDiscoveries = (discoveries?.discoveries || [])
+    const allDiscoveries = discoveries?.discoveries || [];
+
+    const recentDiscoveries = allDiscoveries
       .sort((a: Discovery, b: Discovery) => new Date(b.discoveredAt).getTime() - new Date(a.discoveredAt).getTime())
       .slice(0, 5)
       .map((d: Discovery) => ({ name: d.name, type: d.type, city: d.city }));
+
+    const knownDiscoveries = allDiscoveries
+      .filter((d: Discovery) => Boolean(d.contextKey))
+      .map((d: Discovery) => ({
+        contextKey: d.contextKey,
+        name: d.name,
+        type: d.type,
+        city: d.city,
+        address: d.address,
+        discoveredAt: d.discoveredAt,
+      }));
 
     const history: ChatMessage[] = clientHistory || (await getChatHistory(user.id));
 
@@ -295,6 +308,7 @@ export async function POST(request: NextRequest) {
       preferences,
       manifest,
       recentDiscoveries,
+      knownDiscoveries,
       activeContextKey: typeof activeContextKey === 'string' ? activeContextKey : undefined,
       chatTarget: chatTarget && typeof chatTarget === 'object' ? {
         cardId: typeof chatTarget.cardId === 'string' ? chatTarget.cardId : undefined,

--- a/tests/system-prompt-context.test.ts
+++ b/tests/system-prompt-context.test.ts
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildSystemPrompt, type ChatContext } from '../app/_lib/chat/system-prompt';
+
+test('buildSystemPrompt includes rich facts for known trip contexts', () => {
+  const context: ChatContext = {
+    userCode: 'john',
+    userCity: 'Toronto',
+    preferences: null,
+    manifest: {
+      updatedAt: '2026-04-10T00:00:00.000Z',
+      contexts: [
+        {
+          key: 'trip:cottage-july-2026',
+          label: 'Ontario Cottage',
+          emoji: '🏊',
+          type: 'trip',
+          city: 'Lake Huron',
+          dates: 'July 2026 (3+ weeks)',
+          focus: ['waterfront', 'swimming'],
+          active: true,
+        },
+        {
+          key: 'trip:boston-summer-2026',
+          label: 'Boston Long Weekend',
+          emoji: '🦞',
+          type: 'trip',
+          city: 'Boston',
+          dates: 'Late August 2026',
+          focus: ['food', 'history'],
+          active: false,
+          status: 'archived',
+        },
+      ],
+    },
+    recentDiscoveries: [],
+    knownDiscoveries: [
+      {
+        contextKey: 'trip:cottage-july-2026',
+        name: 'The Lookout',
+        type: 'accommodation',
+        city: 'Port Albert',
+        address: 'Port Albert',
+        discoveredAt: '2026-03-15T00:00:00.000Z',
+      },
+    ],
+  };
+
+  const prompt = buildSystemPrompt(context);
+
+  assert.match(prompt, /## KNOWN CONTEXTS/);
+  assert.match(prompt, /Ontario Cottage/);
+  assert.match(prompt, /Location: Lake Huron/);
+  assert.match(prompt, /Known places: The Lookout \(accommodation, Port Albert\)/);
+  assert.match(prompt, /Boston Long Weekend/);
+  assert.match(prompt, /archived/);
+});
+
+test('buildSystemPrompt expands active chat target with trip details', () => {
+  const context: ChatContext = {
+    userCode: 'john',
+    userCity: 'Toronto',
+    preferences: null,
+    manifest: {
+      updatedAt: '2026-04-10T00:00:00.000Z',
+      contexts: [
+        {
+          key: 'trip:nyc-april-2026',
+          label: 'NYC Solo Trip',
+          emoji: '🗽',
+          type: 'trip',
+          city: 'New York',
+          dates: '2026-04-27 to 2026-04-30',
+          focus: ['galleries', 'jazz'],
+          active: true,
+          bookingStatus: 'fully-booked',
+          accommodation: {
+            name: "Arnold's",
+            address: '126 Leonard St',
+            status: 'booked',
+          },
+          people: [
+            { name: 'Dessa', relation: 'daughter' },
+          ],
+          purpose: "Dessa's art show + Brooklyn exploration",
+          notes: 'Stay in Williamsburg and focus on galleries.',
+        },
+      ],
+    },
+    recentDiscoveries: [],
+    activeContextKey: 'trip:nyc-april-2026',
+  };
+
+  const prompt = buildSystemPrompt(context);
+
+  assert.match(prompt, /## ACTIVE CHAT TARGET/);
+  assert.match(prompt, /Known facts for this target:/);
+  assert.match(prompt, /Accommodation: Arnold's, 126 Leonard St, status: booked/);
+  assert.match(prompt, /People: Dessa \(daughter\)/);
+  assert.match(prompt, /Purpose: Dessa's art show \+ Brooklyn exploration/);
+});


### PR DESCRIPTION
Closes #291.

Improves in-app chat awareness of existing trips and saved trip details.

Changes:
- include all known contexts, not just active ones
- inject richer per-context facts into chat prompt context
- include location, dates, focus, booking status, accommodation/base, travel, people, purpose, notes, priorities, and a few known places tied to each context
- align tool wording with KNOWN CONTEXTS instead of only ACTIVE CONTEXTS

Validation:
- npx tsx --test tests/system-prompt-context.test.ts
- npx eslint app/_lib/chat/system-prompt.ts app/_lib/chat/user-context.ts app/api/chat/route.ts app/_lib/chat/tools.ts tests/system-prompt-context.test.ts
- npx tsc --noEmit --pretty false