### PR TITLE
fix: harden repeated chat context switches

### DIFF
--- a/app/_components/ChatWidget.tsx
+++ b/app/_components/ChatWidget.tsx
@@ -252,12 +252,12 @@ export default function ChatWidget() {
                 window.dispatchEvent(new CustomEvent('compass-data-changed'));
               }
               // Auto-switch homepage whenever a tool targets a specific
-              // context. This is the deterministic signal for both the
-              // existing-trip flow (add-to-compass, update-trip,
-              // edit-discovery, save-discovery, set-active-context) and
-              // the new-trip flow (create-context, where the route
-              // derives the key from the tool input).
-              if (parsed.contextKey && parsed.contextKey !== activeContextKeyRef.current) {
+              // context. Always forward the signal, even if our local ref
+              // already matches the target key: the ref is only a mirror of
+              // homepage state, and suppressing a "duplicate" event can drop
+              // a legitimate return-hop repair if the UI/router fell out of
+              // sync with chat state.
+              if (parsed.contextKey) {
                 activeContextKeyRef.current = parsed.contextKey;
                 window.dispatchEvent(new CustomEvent('compass-chat-context-switch', {
                   detail: { key: parsed.contextKey },

--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -367,6 +367,9 @@ export default function HomeClient({
       if (!detail?.key) return;
       if (contexts.some(c => c.key === detail.key)) {
         applyActiveKey(detail.key);
+        // Mirror manual context selection: broadcast immediately so
+        // chat-scoped UI stays aligned on multi-hop conversational switches.
+        broadcastActiveContext(detail.key);
       } else {
         pendingContextKeyRef.current = detail.key;
         // Persist immediately so a subsequent mount/hydration cycle
@@ -376,7 +379,7 @@ export default function HomeClient({
     };
     window.addEventListener('compass-chat-context-switch', handler);
     return () => window.removeEventListener('compass-chat-context-switch', handler);
-  }, [contexts, applyActiveKey]);
+  }, [contexts, applyActiveKey, broadcastActiveContext]);
 
   // Triage change listener
   useEffect(() => {

--- a/app/_lib/chat/system-prompt.ts
+++ b/app/_lib/chat/system-prompt.ts
@@ -55,6 +55,7 @@ CONTEXT SWITCHING — keep the homepage in sync with the conversation:
   - "Actually, what about the Paris trip?"
   - "Switch to my weekend outing"
   - "Show me the cottage trip"
+  - Returning to a trip you were discussing earlier in the chat, e.g. Ontario → NYC → Ontario. Every hop between existing contexts needs its own set_active_context call.
 - After create_context for a brand-new trip, you do NOT need to call set_active_context — the app auto-switches on create_context.
 - If the user asks about a context that does not exist yet, call create_context instead (do NOT call set_active_context with a made-up key).
 - Use the exact key from ACTIVE CONTEXTS (e.g. \`trip:nyc-solo-trip\`), not a free-form label.

--- a/tests/home-context-switch.test.ts
+++ b/tests/home-context-switch.test.ts
@@ -112,6 +112,25 @@ function initialState(): SwitchState {
 }
 
 // ---------------------------------------------------------------------------
+// Tiny helper modelling ChatWidget's toolResult -> switch-event forwarding.
+// The key regression for #289 is that "already on this key" dedupe is unsafe:
+// the ref can drift ahead of actual homepage state, so the event still needs
+// to fire to repair the UI on a return hop.
+// ---------------------------------------------------------------------------
+function forwardToolResultContextKey(
+  refKey: string | null,
+  parsedContextKey: string | undefined,
+): { nextRefKey: string | null; dispatchedKeys: string[] } {
+  if (!parsedContextKey) {
+    return { nextRefKey: refKey, dispatchedKeys: [] };
+  }
+  return {
+    nextRefKey: parsedContextKey,
+    dispatchedKeys: [parsedContextKey],
+  };
+}
+
+// ---------------------------------------------------------------------------
 describe('route.resolveTargetContextKey', () => {
   test('create_context derives key from type + label (matches tool slug)', () => {
     const key = resolveTargetContextKey('create_context', { type: 'trip', label: 'Barcelona November 2026' });
@@ -252,5 +271,31 @@ describe('HomeClient chat switch reducer (issue #287)', () => {
     assert.equal(s.activeKey, 'trip:c');
     // Final localStorage reflects the last switch.
     assert.equal(s.localStorage, 'trip:c');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('ChatWidget toolResult forwarding (issue #289)', () => {
+  test('re-emits a switch event even when the local ref already matches the target key', () => {
+    const result = forwardToolResultContextKey('trip:nyc-solo-trip', 'trip:nyc-solo-trip');
+    assert.equal(result.nextRefKey, 'trip:nyc-solo-trip');
+    assert.deepEqual(result.dispatchedKeys, ['trip:nyc-solo-trip']);
+  });
+
+  test('multi-hop existing-trip switches forward every hop in order', () => {
+    let refKey: string | null = 'trip:nyc-solo-trip';
+    const dispatched: string[] = [];
+
+    for (const hop of ['trip:ontario-cottage-july-2026', 'trip:nyc-solo-trip']) {
+      const result = forwardToolResultContextKey(refKey, hop);
+      refKey = result.nextRefKey;
+      dispatched.push(...result.dispatchedKeys);
+    }
+
+    assert.equal(refKey, 'trip:nyc-solo-trip');
+    assert.deepEqual(dispatched, [
+      'trip:ontario-cottage-july-2026',
+      'trip:nyc-solo-trip',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- always forward chat toolResult context switches, even on return hops
- immediately rebroadcast applied chat switches in HomeClient
- clarify prompt guidance for repeated existing-trip pivots
- add regression coverage for multi-hop switching

Closes #289