### PR TITLE
fix(#290): keep chat place links on active origin

### DIFF
--- a/app/_lib/app-url.ts
+++ b/app/_lib/app-url.ts
@@ -1,0 +1,50 @@
+export interface AppUrlOptions {
+  appOrigin?: string;
+  contextKey?: string;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+export function getDefaultAppOrigin(): string {
+  const envAppUrl = process.env.NEXT_PUBLIC_APP_URL?.trim();
+  if (envAppUrl) {
+    return trimTrailingSlash(envAppUrl);
+  }
+
+  const vercelUrl = process.env.VERCEL_URL?.trim();
+  if (vercelUrl) {
+    const withProtocol = vercelUrl.startsWith('http://') || vercelUrl.startsWith('https://')
+      ? vercelUrl
+      : `https://${vercelUrl}`;
+    return trimTrailingSlash(withProtocol);
+  }
+
+  return 'https://compass-v2-lake.vercel.app';
+}
+
+export function resolveAppOrigin(appOrigin?: string): string {
+  if (appOrigin?.trim()) {
+    return trimTrailingSlash(appOrigin.trim());
+  }
+  return getDefaultAppOrigin();
+}
+
+export function buildPlaceCardPath(placeId: string, contextKey?: string): string {
+  const basePath = `/placecards/${encodeURIComponent(placeId)}`;
+  if (!contextKey) {
+    return basePath;
+  }
+
+  const search = new URLSearchParams({ context: contextKey });
+  return `${basePath}?${search.toString()}`;
+}
+
+export function buildPlaceCardUrl(placeId: string, options: AppUrlOptions = {}): string {
+  return `${resolveAppOrigin(options.appOrigin)}${buildPlaceCardPath(placeId, options.contextKey)}`;
+}
+
+export function buildPlaceCardTemplate(appOrigin?: string): string {
+  return `${resolveAppOrigin(appOrigin)}/placecards/PLACE_ID`;
+}

--- a/app/_lib/chat/system-prompt.ts
+++ b/app/_lib/chat/system-prompt.ts
@@ -3,6 +3,7 @@
  * Defines the AI assistant's personality, capabilities, and workflow.
  */
 
+import { buildPlaceCardTemplate } from '../app-url';
 import type { UserPreferences, UserManifest, Context } from '../types';
 
 export const SYSTEM_PROMPT = `You are the Compass Concierge — a warm, knowledgeable travel companion with real research abilities.
@@ -81,7 +82,7 @@ Distinguish between:
 - REFINE intent ("shift toward quieter places") → update_trip focus/notes
 
 LINK FORMAT — for every place you mention:
-- Format: **[Place Name](https://compass-ai-agent.vercel.app/placecards/PLACE_ID)** · [📍 Map](https://www.google.com/maps/place/?q=place_id:PLACE_ID) · Rating ★ · $$$
+- Format: **[Place Name](__COMPASS_PLACE_URL__)** · [📍 Map](https://www.google.com/maps/place/?q=place_id:PLACE_ID) · Rating ★ · $$$
 - The PLACE_ID comes from lookup_place results (the "id" or "place_id" field)
 - If you don't have a place_id, still link to Google Maps using the address
 
@@ -136,8 +137,11 @@ export interface ChatContext {
  * @param context - User context for building personalized prompt
  * @returns Enriched system prompt string
  */
-export function buildSystemPrompt(context: ChatContext | null): string {
-  let prompt = SYSTEM_PROMPT;
+export function buildSystemPrompt(
+  context: ChatContext | null,
+  options: { appOrigin?: string } = {},
+): string {
+  let prompt = SYSTEM_PROMPT.replace('__COMPASS_PLACE_URL__', buildPlaceCardTemplate(options.appOrigin));
 
   if (!context) {
     // No user context - drive onboarding

--- a/app/_lib/chat/tools/add-to-compass.ts
+++ b/app/_lib/chat/tools/add-to-compass.ts
@@ -8,6 +8,7 @@
  * a single turn. Places without photos are filtered from display until enriched.
  */
 
+import { buildPlaceCardUrl } from '../../app-url';
 import { setUserData, getUserData, getUserManifest } from '../../user-data';
 import type { Discovery, DiscoveryType, PlaceImage, UserDiscoveries } from '../../types';
 import { resolveCity } from './resolve-city';
@@ -127,6 +128,7 @@ async function enrichPhotosAsync(userId: string, discoveryId: string, placeId: s
 export async function addToCompass(
   userId: string,
   input: AddToCompassInput,
+  options: { appOrigin?: string } = {},
 ): Promise<string> {
   try {
     // Generate unique ID for the discovery
@@ -220,13 +222,19 @@ export async function addToCompass(
     }
 
     // Build response URLs
+    const compassUrl = input.place_id
+      ? buildPlaceCardUrl(input.place_id, {
+          appOrigin: options.appOrigin,
+          contextKey: resolvedContextKey || undefined,
+        })
+      : null;
     const mapsUrl = input.place_id
       ? `https://www.google.com/maps/place/?q=place_id:${input.place_id}`
       : (input.address
         ? `https://www.google.com/maps/search/${encodeURIComponent(input.name + ' ' + resolvedCity)}`
         : null);
 
-    return `✅ Added "${input.name}" to Compass!${mapsUrl ? ` [Map](${mapsUrl})` : ''} Photos will load shortly.`;
+    return `✅ Added "${input.name}" to Compass!${compassUrl ? ` [Compass](${compassUrl})` : ''}${mapsUrl ? ` [Map](${mapsUrl})` : ''} Photos will load shortly.`;
   } catch (e) {
     console.error('[add_to_compass] Failed:', e);
     return `Failed to add "${input.name}" to Compass: ${e}`;

--- a/app/_lib/chat/tools/runner.ts
+++ b/app/_lib/chat/tools/runner.ts
@@ -44,6 +44,7 @@ export async function runToolCall(
   name: ToolName,
   input: Record<string, unknown>,
   userId: string,
+  options: { appOrigin?: string } = {},
 ): Promise<string> {
   switch (name) {
     case 'web_search':
@@ -51,9 +52,9 @@ export async function runToolCall(
     case 'lookup_place':
       return lookupPlace(input.query as string);
     case 'add_to_compass':
-      return addToCompass(userId, input as unknown as AddToCompassInput);
+      return addToCompass(userId, input as unknown as AddToCompassInput, options);
     case 'save_discovery':
-      return saveDiscovery(userId, input as unknown as SaveDiscoveryInput);
+      return saveDiscovery(userId, input as unknown as SaveDiscoveryInput, options);
     case 'edit_discovery':
       return editDiscovery(userId, input as unknown as EditDiscoveryInput);
     case 'remove_discovery':

--- a/app/_lib/chat/tools/save-discovery.ts
+++ b/app/_lib/chat/tools/save-discovery.ts
@@ -5,6 +5,7 @@
  */
 
 import { put, list } from '@vercel/blob';
+import { buildPlaceCardUrl } from '../../app-url';
 import { getUserData, setUserData } from '../../user-data';
 import { promoteToInventory } from '../../monitor-inventory';
 import type { Discovery, DiscoveryType, UserDiscoveries } from '../../types';
@@ -55,7 +56,11 @@ async function saveTriageStore(userId: string, store: TriageStore): Promise<void
   });
 }
 
-export async function saveDiscovery(userId: string, input: SaveDiscoveryInput): Promise<string> {
+export async function saveDiscovery(
+  userId: string,
+  input: SaveDiscoveryInput,
+  options: { appOrigin?: string } = {},
+): Promise<string> {
   try {
     const discoveryId = `disco_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
@@ -134,10 +139,13 @@ export async function saveDiscovery(userId: string, input: SaveDiscoveryInput): 
     }
 
     const compassUrl = input.place_id
-      ? `https://compass-ai-agent.vercel.app/placecards/${input.place_id}`
+      ? buildPlaceCardUrl(input.place_id, {
+          appOrigin: options.appOrigin,
+          contextKey: input.contextKey,
+        })
       : null;
 
-    return `✅ Saved "${input.name}" to ${input.contextKey}${compassUrl ? ` — ${compassUrl}` : ''}`;
+    return `✅ Saved "${input.name}" to ${input.contextKey}${compassUrl ? ` [Compass](${compassUrl})` : ''}`;
   } catch (e) {
     console.error('[save_discovery] Failed:', e);
     return `Failed to save discovery: ${e}`;

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -117,6 +117,7 @@ async function executeToolLoop(
   systemPrompt: string,
   messages: any[],
   userId: string,
+  appOrigin: string,
   encoder: TextEncoder,
   controller: ReadableStreamDefaultController,
   messageId: string,
@@ -194,6 +195,7 @@ async function executeToolLoop(
             toolBlock.name as ToolName,
             toolBlock.input as Record<string, unknown>,
             userId,
+            { appOrigin },
           );
           // Emit toolResult event so frontend can refresh
           // Include contextKey so frontend can auto-switch homepage. For
@@ -304,7 +306,8 @@ export async function POST(request: NextRequest) {
       } : undefined,
     };
 
-    const systemPrompt = buildSystemPrompt(chatContext);
+    const appOrigin = request.nextUrl.origin;
+    const systemPrompt = buildSystemPrompt(chatContext, { appOrigin });
 
     // Build conversation history — cap at last 20 messages, truncate long content
     const MAX_CONTENT = 2000;
@@ -334,6 +337,7 @@ export async function POST(request: NextRequest) {
             systemPrompt,
             anthropicMessages,
             user.id,
+            appOrigin,
             encoder,
             controller,
             messageId,

--- a/tests/chat-origin-links.test.ts
+++ b/tests/chat-origin-links.test.ts
@@ -1,0 +1,54 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildPlaceCardPath, buildPlaceCardTemplate, buildPlaceCardUrl, resolveAppOrigin } from '../app/_lib/app-url';
+import { buildSystemPrompt, type ChatContext } from '../app/_lib/chat/system-prompt';
+
+describe('chat placecard links stay origin-aware', () => {
+  test('buildPlaceCardUrl prefers the current request origin', () => {
+    const url = buildPlaceCardUrl('ChIJ123', {
+      appOrigin: 'http://localhost:3002/',
+      contextKey: 'trip:boston-aug-2026',
+    });
+
+    assert.equal(url, 'http://localhost:3002/placecards/ChIJ123?context=trip%3Aboston-aug-2026');
+  });
+
+  test('resolveAppOrigin falls back to configured app url when request origin is absent', () => {
+    const prevAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+    const prevVercelUrl = process.env.VERCEL_URL;
+
+    process.env.NEXT_PUBLIC_APP_URL = 'https://staging.example.com/';
+    delete process.env.VERCEL_URL;
+
+    try {
+      assert.equal(resolveAppOrigin(), 'https://staging.example.com');
+      assert.equal(buildPlaceCardTemplate(), 'https://staging.example.com/placecards/PLACE_ID');
+    } finally {
+      if (prevAppUrl === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
+      else process.env.NEXT_PUBLIC_APP_URL = prevAppUrl;
+
+      if (prevVercelUrl === undefined) delete process.env.VERCEL_URL;
+      else process.env.VERCEL_URL = prevVercelUrl;
+    }
+  });
+
+  test('buildSystemPrompt injects the active app origin into place link instructions', () => {
+    const context: ChatContext = {
+      userCode: 'john2824',
+      userCity: 'Toronto',
+      preferences: null,
+      manifest: null,
+      recentDiscoveries: [],
+    };
+
+    const prompt = buildSystemPrompt(context, { appOrigin: 'http://localhost:3002' });
+
+    assert.match(prompt, /http:\/\/localhost:3002\/placecards\/PLACE_ID/);
+    assert.doesNotMatch(prompt, /compass-ai-agent\.vercel\.app/);
+  });
+
+  test('buildPlaceCardPath keeps placecard links app-local by default', () => {
+    assert.equal(buildPlaceCardPath('ChIJabc'), '/placecards/ChIJabc');
+  });
+});


### PR DESCRIPTION
Fixes #290

## Summary
- centralize Compass placecard URL building
- use request origin for chat-generated Compass links
- remove hard-coded Vercel placecard links from chat prompt/tool output
- add targeted regression coverage for origin-aware place links

## Testing
- NODE_PATH=/Users/john/.openclaw/workspace/compass-v2/node_modules npx --prefix /Users/john/.openclaw/workspace/compass-v2 tsx --test tests/chat-origin-links.test.ts tests/home-context-switch.test.ts