### PR TITLE
fix: unify owner-local inventory across compass surfaces

### DIFF
--- a/app/_lib/chat/tools/add-to-compass.ts
+++ b/app/_lib/chat/tools/add-to-compass.ts
@@ -9,8 +9,9 @@
  */
 
 import { buildPlaceCardUrl } from '../../app-url';
-import { setUserData, getUserData, getUserManifest } from '../../user-data';
-import type { Discovery, DiscoveryType, PlaceImage, UserDiscoveries } from '../../types';
+import { getEffectiveUserManifest } from '../../effective-user-data';
+import { setUserData, getUserData } from '../../user-data';
+import type { Discovery, DiscoveryType, UserDiscoveries } from '../../types';
 import { resolveCity } from './resolve-city';
 
 const VALID_TYPES = new Set<DiscoveryType>([
@@ -142,7 +143,7 @@ export async function addToCompass(
     let resolvedContextKey = input.contextKey || '';
     if (resolvedContextKey) {
       try {
-        const manifest = await getUserManifest(userId);
+        const manifest = await getEffectiveUserManifest(userId);
         if (manifest?.contexts?.length) {
           const exact = manifest.contexts.find(c => c.key === resolvedContextKey);
           if (!exact) {

--- a/app/_lib/chat/tools/create-context.ts
+++ b/app/_lib/chat/tools/create-context.ts
@@ -3,7 +3,8 @@
  * Called by Concierge when user says "I'm planning a trip to Boston" or "add a NYC radar".
  */
 
-import { getUserManifest, setUserData } from '../../user-data';
+import { setUserData } from '../../user-data';
+import { getWritableUserManifest } from '../../effective-user-data';
 import type { Context, ContextType, UserManifest } from '../../types';
 
 export interface CreateContextInput {
@@ -68,11 +69,7 @@ export async function createContext(userId: string, input: CreateContextInput): 
       active: input.setActive !== false,
     };
 
-    let manifest = await getUserManifest(userId);
-    if (!manifest) {
-      // Create new manifest
-      manifest = { contexts: [], updatedAt: new Date().toISOString() } as UserManifest;
-    }
+    const manifest = (await getWritableUserManifest(userId)) as UserManifest;
 
     // Check if key already exists
     const existing = manifest.contexts.findIndex(c => c.key === key);

--- a/app/_lib/chat/tools/set-active-context.ts
+++ b/app/_lib/chat/tools/set-active-context.ts
@@ -10,7 +10,7 @@
  * "let's review the NYC trip" while the homepage is showing Boston.
  */
 
-import { getUserManifest } from '../../user-data';
+import { getEffectiveUserManifest } from '../../effective-user-data';
 
 export interface SetActiveContextInput {
   contextKey: string;
@@ -26,7 +26,7 @@ export async function setActiveContext(
   }
 
   try {
-    const manifest = await getUserManifest(userId);
+    const manifest = await getEffectiveUserManifest(userId);
     const ctx = manifest?.contexts?.find(c => c.key === key);
     if (!ctx) {
       return `Context not found for key: ${key}`;

--- a/app/_lib/chat/tools/update-trip.ts
+++ b/app/_lib/chat/tools/update-trip.ts
@@ -3,7 +3,8 @@
  * Called by Concierge when the user shares trip details, dates, accommodation, etc.
  */
 
-import { getUserManifest, setUserData } from '../../user-data';
+import { setUserData } from '../../user-data';
+import { getWritableUserManifest } from '../../effective-user-data';
 import type { Context } from '../../types';
 
 export interface UpdateTripInput {
@@ -20,10 +21,7 @@ export interface UpdateTripInput {
 
 export async function updateTrip(userId: string, input: UpdateTripInput): Promise<string> {
   try {
-    const manifest = await getUserManifest(userId);
-    if (!manifest) {
-      return `❌ No manifest found for user. Can't update trip.`;
-    }
+    const manifest = await getWritableUserManifest(userId);
 
     const idx = manifest.contexts.findIndex(c => c.key === input.contextKey);
     if (idx === -1) {

--- a/app/_lib/effective-user-data.ts
+++ b/app/_lib/effective-user-data.ts
@@ -1,0 +1,44 @@
+import { deriveDiscoveryInventory } from './discovery-history';
+import { mergeDiscoveryInventories, mergeManifestInventories, readOwnerLocalDiscoveries, readOwnerLocalManifest } from './owner-local-inventory';
+import type { UserDiscoveries, UserManifest } from './types';
+import { getUserById } from './user';
+import { getUserDiscoveries, getUserManifest } from './user-data';
+
+function shouldUseOwnerLocalInventory(userId: string): boolean {
+  return Boolean(getUserById(userId)?.isOwner);
+}
+
+export async function getEffectiveUserManifest(userId: string): Promise<UserManifest | null> {
+  const manifest = await getUserManifest(userId);
+  if (!shouldUseOwnerLocalInventory(userId)) return manifest;
+  return mergeManifestInventories(manifest, readOwnerLocalManifest());
+}
+
+export async function getWritableUserManifest(userId: string): Promise<UserManifest> {
+  return (await getEffectiveUserManifest(userId)) ?? {
+    contexts: [],
+    updatedAt: '',
+  };
+}
+
+export async function getEffectiveUserDiscoveries(userId: string): Promise<UserDiscoveries | null> {
+  const discoveries = await getUserDiscoveries(userId);
+  if (!shouldUseOwnerLocalInventory(userId)) return discoveries;
+  return mergeDiscoveryInventories(discoveries, readOwnerLocalDiscoveries());
+}
+
+export async function getEffectiveDerivedUserDiscoveries(userId: string, historyLimit = 50): Promise<UserDiscoveries | null> {
+  const current = await getEffectiveUserDiscoveries(userId);
+  const discoveries = await deriveDiscoveryInventory({
+    userId,
+    currentDiscoveries: current?.discoveries ?? [],
+    historyLimit,
+  });
+
+  if (!current && discoveries.length === 0) return null;
+
+  return {
+    discoveries,
+    updatedAt: current?.updatedAt ?? new Date().toISOString(),
+  };
+}

--- a/app/_lib/owner-local-inventory.ts
+++ b/app/_lib/owner-local-inventory.ts
@@ -1,0 +1,84 @@
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+import type { Discovery, UserDiscoveries, UserManifest } from './types';
+
+export function readOwnerLocalManifest(): UserManifest | null {
+  const manifestPath = path.join(process.cwd(), 'data', 'compass-manifest.json');
+  if (!existsSync(manifestPath)) return null;
+
+  try {
+    const raw = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      contexts?: UserManifest['contexts'];
+      updatedAt?: string;
+    };
+    return {
+      contexts: raw.contexts ?? [],
+      updatedAt: raw.updatedAt ?? '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function readOwnerLocalDiscoveries(): UserDiscoveries | null {
+  const discoveriesPath = path.join(process.cwd(), 'data', 'local-discoveries.json');
+  if (!existsSync(discoveriesPath)) return null;
+
+  try {
+    const raw = JSON.parse(readFileSync(discoveriesPath, 'utf8')) as Discovery[] | UserDiscoveries;
+    if (Array.isArray(raw)) {
+      return {
+        discoveries: raw,
+        updatedAt: '',
+      };
+    }
+    return {
+      discoveries: raw.discoveries ?? [],
+      updatedAt: raw.updatedAt ?? '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function mergeManifestInventories(
+  primary: UserManifest | null,
+  ownerLocal: UserManifest | null,
+): UserManifest | null {
+  if (!primary && !ownerLocal) return null;
+
+  const primaryContexts = (primary?.contexts ?? []).map((context) => ({ ...context }));
+  const ownerLocalContexts = ownerLocal?.contexts ?? [];
+  const primaryKeys = new Set(primaryContexts.map((context) => context.key));
+
+  return {
+    contexts: [
+      ...primaryContexts,
+      ...ownerLocalContexts
+        .filter((context) => !primaryKeys.has(context.key))
+        .map((context) => ({ ...context })),
+    ],
+    updatedAt: primary?.updatedAt || ownerLocal?.updatedAt || '',
+  };
+}
+
+export function mergeDiscoveryInventories(
+  primary: UserDiscoveries | null,
+  ownerLocal: UserDiscoveries | null,
+): UserDiscoveries | null {
+  if (!primary && !ownerLocal) return null;
+
+  const primaryDiscoveries = (primary?.discoveries ?? []).map((discovery) => ({ ...discovery }));
+  const ownerLocalDiscoveries = ownerLocal?.discoveries ?? [];
+  const primaryIds = new Set(primaryDiscoveries.map((discovery) => discovery.id));
+
+  return {
+    discoveries: [
+      ...primaryDiscoveries,
+      ...ownerLocalDiscoveries
+        .filter((discovery) => !primaryIds.has(discovery.id))
+        .map((discovery) => ({ ...discovery })),
+    ],
+    updatedAt: primary?.updatedAt || ownerLocal?.updatedAt || '',
+  };
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getCurrentUser } from '../../_lib/user';
-import { getUserProfile, getUserPreferences, getUserManifest, getUserDiscoveries } from '../../_lib/user-data';
+import { getUserProfile, getUserPreferences } from '../../_lib/user-data';
+import { getEffectiveDerivedUserDiscoveries, getEffectiveUserManifest } from '../../_lib/effective-user-data';
 import { persistChatData, getChatHistory } from '../../_lib/chat/persistence';
 import { buildSystemPrompt, type ChatContext } from '../../_lib/chat/system-prompt';
 import { TOOLS } from '../../_lib/chat/tools';
@@ -20,7 +21,6 @@ const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
 const MODEL = 'claude-sonnet-4-20250514';
 const MAX_TOOL_ROUNDS = 5;
 const MAX_TOOL_TIME_MS = 50_000; // Stop tool loops before Vercel kills us
-const PER_ROUND_BUDGET_MS = 12_000; // Warn threshold per round
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -279,8 +279,8 @@ export async function POST(request: NextRequest) {
     const [profile, preferences, manifest, discoveries] = await Promise.all([
       getUserProfile(user.id),
       getUserPreferences(user.id),
-      getUserManifest(user.id),
-      getUserDiscoveries(user.id),
+      getEffectiveUserManifest(user.id),
+      getEffectiveDerivedUserDiscoveries(user.id),
     ]);
 
     const allDiscoveries = discoveries?.discoveries || [];

--- a/app/api/contexts/route.ts
+++ b/app/api/contexts/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getCurrentUser } from '../../_lib/user';
-import { getUserManifest } from '../../_lib/user-data';
+import { getEffectiveUserManifest } from '../../_lib/effective-user-data';
 import { isContextActive } from '../../_lib/context-lifecycle';
 
 /**
@@ -16,7 +16,7 @@ export async function GET() {
     return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
   }
 
-  const manifest = await getUserManifest(user.id);
+  const manifest = await getEffectiveUserManifest(user.id);
   const contexts = (manifest?.contexts ?? []).filter(isContextActive);
 
   return NextResponse.json({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,7 @@
-import { readFileSync, existsSync } from 'fs';
-import path from 'path';
 import Link from 'next/link';
 import { getCurrentUser } from './_lib/user';
-import { getUserManifest, getDerivedUserDiscoveries } from './_lib/user-data';
-import type { Context, Discovery, UserManifest } from './_lib/types';
+import { getEffectiveDerivedUserDiscoveries, getEffectiveUserManifest } from './_lib/effective-user-data';
+import type { Context, Discovery } from './_lib/types';
 import { isContextActive } from './_lib/context-lifecycle';
 import { resolveImageUrl } from './_lib/image-url';
 import { getManifestHeroImage } from './_lib/image-url.server';
@@ -18,26 +16,6 @@ import { buildHomepageDigest } from './_lib/monitor-digest';
 import HomeClient from './_components/HomeClient';
 
 export const dynamic = 'force-dynamic';
-
-/** Load local manifest as fallback when Blob has none */
-function loadLocalManifest(): UserManifest | null {
-  const p = path.join(process.cwd(), 'data', 'compass-manifest.json');
-  if (!existsSync(p)) return null;
-  try {
-    const raw = JSON.parse(readFileSync(p, 'utf8'));
-    return { contexts: raw.contexts ?? [], updatedAt: raw.updatedAt ?? '' };
-  } catch { return null; }
-}
-
-/** Load local discoveries (cottages, developments) */
-function loadLocalDiscoveries(): Discovery[] {
-  const p = path.join(process.cwd(), 'data', 'local-discoveries.json');
-  if (!existsSync(p)) return [];
-  try {
-    const raw = JSON.parse(readFileSync(p, 'utf8'));
-    return (Array.isArray(raw) ? raw : (raw.discoveries ?? [])) as Discovery[];
-  } catch { return []; }
-}
 
 function sortContexts(contexts: Context[]): Context[] {
   return [...contexts].sort((a, b) => {
@@ -65,39 +43,21 @@ export default async function HomePage() {
     );
   }
 
-  // Load user data from Blob, with local manifest as fallback
-  const [blobManifest, discoveriesData] = await Promise.all([
-    getUserManifest(user.id),
-    getDerivedUserDiscoveries(user.id),
+  const [manifest, discoveriesData] = await Promise.all([
+    getEffectiveUserManifest(user.id),
+    getEffectiveDerivedUserDiscoveries(user.id),
   ]);
 
   // Non-owner with no manifest → onboarding
-  if (!user.isOwner && (!blobManifest || blobManifest.contexts.length === 0)) {
+  if (!user.isOwner && (!manifest || manifest.contexts.length === 0)) {
     const { redirect } = await import('next/navigation');
     redirect('/onboarding');
   }
 
-  // Merge contexts: Blob manifest + local manifest (owner only)
-  const blobContexts = blobManifest?.contexts ?? [];
-  const localContexts = user.isOwner ? (loadLocalManifest()?.contexts ?? []) : [];
-  const blobKeys = new Set(blobContexts.map(c => c.key));
-  const mergedContexts = [
-    ...blobContexts,
-    ...localContexts.filter(c => !blobKeys.has(c.key)),
-  ];
-
   const contexts = sortContexts(
-    mergedContexts.filter(c => isContextActive(c)),
+    (manifest?.contexts ?? []).filter(c => isContextActive(c)),
   );
-  // Merge Blob discoveries with local discoveries (cottages, developments)
-  const blobDiscoveries = discoveriesData?.discoveries ?? [];
-  // Local discoveries (cottages, developments) — owner only
-  const localDisc = user.isOwner ? loadLocalDiscoveries() : [];
-  const blobIds = new Set(blobDiscoveries.map(d => d.id));
-  const discoveries = [
-    ...blobDiscoveries,
-    ...localDisc.filter(d => !blobIds.has(d.id)),
-  ];
+  const discoveries = discoveriesData?.discoveries ?? [];
 
   // Filter out discoveries that are not fully built
   // A discovery must have at minimum: a name AND (address OR description OR rating)

--- a/app/review/[contextKey]/page.tsx
+++ b/app/review/[contextKey]/page.tsx
@@ -1,16 +1,7 @@
-import { readFileSync, existsSync } from 'fs';
-import path from 'path';
+import Link from 'next/link';
 import { getCurrentUser } from '../../_lib/user';
-import { getUserManifest, getDerivedUserDiscoveries } from '../../_lib/user-data';
+import { getEffectiveDerivedUserDiscoveries, getEffectiveUserManifest } from '../../_lib/effective-user-data';
 import ReviewContextClient from '../../_components/ReviewContextClient';
-
-function loadSharedManifest() {
-  try {
-    const p = path.join(process.cwd(), 'data', 'compass-manifest.json');
-    if (!existsSync(p)) return null;
-    return JSON.parse(readFileSync(p, 'utf8'));
-  } catch { return null; }
-}
 
 export const dynamic = 'force-dynamic';
 
@@ -26,20 +17,17 @@ export default async function ReviewContextPage({ params }: Props) {
   if (!user) {
     return (
       <main className="page">
-        <p className="text-muted"><a href="/u/join" style={{textDecoration: 'underline', color: 'inherit'}}>Sign in</a> to review.</p>
+        <p className="text-muted"><Link href="/u/join" style={{textDecoration: 'underline', color: 'inherit'}}>Sign in</Link> to review.</p>
       </main>
     );
   }
 
   const [manifest, discoveriesData] = await Promise.all([
-    getUserManifest(user.id),
-    getDerivedUserDiscoveries(user.id),
+    getEffectiveUserManifest(user.id),
+    getEffectiveDerivedUserDiscoveries(user.id),
   ]);
 
-  // Fall back to shared compass-manifest.json ONLY for the owner user
-  const sharedManifest = user?.isOwner ? loadSharedManifest() : null;
-  const context = manifest?.contexts.find(c => c.key === contextKey)
-    ?? sharedManifest?.contexts?.find((c: { key: string }) => c.key === contextKey);
+  const context = manifest?.contexts.find(c => c.key === contextKey);
   const discoveries = (discoveriesData?.discoveries ?? []).filter(d => {
     if (d.contextKey !== contextKey) return false;
     // Only show fully-built discoveries (must have name + address or description or rating)

--- a/app/review/page.tsx
+++ b/app/review/page.tsx
@@ -1,5 +1,6 @@
+import Link from 'next/link';
 import { getCurrentUser } from '../_lib/user';
-import { getUserManifest, getDerivedUserDiscoveries } from '../_lib/user-data';
+import { getEffectiveDerivedUserDiscoveries, getEffectiveUserManifest } from '../_lib/effective-user-data';
 import { getContextStatus } from '../_lib/context-lifecycle';
 import ReviewHubClient from '../_components/ReviewHubClient';
 
@@ -13,15 +14,15 @@ export default async function ReviewPage() {
       <main className="page">
         <div className="page-header">
           <h1>Review</h1>
-          <p className="text-muted"><a href="/u/join" style={{textDecoration: 'underline', color: 'inherit'}}>Sign in</a> to manage your discoveries.</p>
+          <p className="text-muted"><Link href="/u/join" style={{textDecoration: 'underline', color: 'inherit'}}>Sign in</Link> to manage your discoveries.</p>
         </div>
       </main>
     );
   }
 
   const [manifest, discoveriesData] = await Promise.all([
-    getUserManifest(user.id),
-    getDerivedUserDiscoveries(user.id),
+    getEffectiveUserManifest(user.id),
+    getEffectiveDerivedUserDiscoveries(user.id),
   ]);
 
   const allContexts = manifest?.contexts ?? [];

--- a/tests/owner-local-inventory.test.ts
+++ b/tests/owner-local-inventory.test.ts
@@ -1,0 +1,80 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { mergeDiscoveryInventories, mergeManifestInventories } from '../app/_lib/owner-local-inventory';
+import type { Context, Discovery, UserDiscoveries, UserManifest } from '../app/_lib/types';
+
+function manifest(contexts: Context[]): UserManifest {
+  return {
+    contexts,
+    updatedAt: '2026-04-10T12:00:00.000Z',
+  };
+}
+
+function discoveries(items: Discovery[]): UserDiscoveries {
+  return {
+    discoveries: items,
+    updatedAt: '2026-04-10T12:00:00.000Z',
+  };
+}
+
+describe('owner-local manifest inventory merge', () => {
+  test('includes owner-local contexts that are missing from the primary manifest', () => {
+    const merged = mergeManifestInventories(
+      manifest([{ key: 'trip:boston-2026', label: 'Boston', emoji: '🦞', type: 'trip', focus: [], active: true }]),
+      manifest([{ key: 'trip:nyc-solo-trip', label: 'NYC Solo Trip', emoji: '🗽', type: 'trip', focus: [], active: true }]),
+    );
+
+    assert.deepEqual(
+      merged?.contexts.map((context) => context.key),
+      ['trip:boston-2026', 'trip:nyc-solo-trip'],
+    );
+  });
+
+  test('keeps the primary version when blob and owner-local share the same key', () => {
+    const merged = mergeManifestInventories(
+      manifest([{ key: 'trip:nyc-solo-trip', label: 'NYC Solo Trip (blob)', emoji: '🗽', type: 'trip', focus: ['food'], active: true }]),
+      manifest([{ key: 'trip:nyc-solo-trip', label: 'NYC Solo Trip (local)', emoji: '🗽', type: 'trip', focus: ['art'], active: true }]),
+    );
+
+    assert.equal(merged?.contexts.length, 1);
+    assert.equal(merged?.contexts[0]?.label, 'NYC Solo Trip (blob)');
+    assert.deepEqual(merged?.contexts[0]?.focus, ['food']);
+  });
+
+  test('surfaces owner-local contexts for downstream key lookups', () => {
+    const merged = mergeManifestInventories(
+      null,
+      manifest([{ key: 'trip:nyc-solo-trip', label: 'NYC Solo Trip', emoji: '🗽', type: 'trip', focus: [], active: true }]),
+    );
+
+    assert.equal(
+      merged?.contexts.findIndex((context) => context.key === 'trip:nyc-solo-trip'),
+      0,
+    );
+  });
+});
+
+describe('owner-local discovery inventory merge', () => {
+  test('includes owner-local discoveries that are missing from the primary inventory', () => {
+    const merged = mergeDiscoveryInventories(
+      discoveries([{ id: 'blob-1', name: 'Blob Place', city: 'Boston', type: 'restaurant', contextKey: 'trip:boston-2026', source: 'chat:recommendation', discoveredAt: '2026-04-10T12:00:00.000Z', placeIdStatus: 'verified' }]),
+      discoveries([{ id: 'local-1', name: 'Local Place', city: 'New York', type: 'restaurant', contextKey: 'trip:nyc-solo-trip', source: 'local:test', discoveredAt: '2026-04-10T12:00:00.000Z', placeIdStatus: 'verified' }]),
+    );
+
+    assert.deepEqual(
+      merged?.discoveries.map((discovery) => discovery.id),
+      ['blob-1', 'local-1'],
+    );
+  });
+
+  test('dedupes owner-local discoveries when the primary inventory already has the same id', () => {
+    const merged = mergeDiscoveryInventories(
+      discoveries([{ id: 'shared-1', name: 'Blob Place', city: 'Boston', type: 'restaurant', contextKey: 'trip:boston-2026', source: 'chat:recommendation', discoveredAt: '2026-04-10T12:00:00.000Z', placeIdStatus: 'verified' }]),
+      discoveries([{ id: 'shared-1', name: 'Local Place', city: 'New York', type: 'restaurant', contextKey: 'trip:nyc-solo-trip', source: 'local:test', discoveredAt: '2026-04-10T12:00:00.000Z', placeIdStatus: 'verified' }]),
+    );
+
+    assert.equal(merged?.discoveries.length, 1);
+    assert.equal(merged?.discoveries[0]?.name, 'Blob Place');
+  });
+});


### PR DESCRIPTION
## Summary
- centralize effective owner-local manifest/discovery resolution for local dev
- use the shared resolver in homepage, review, chat, and /api/contexts
- make create_context, set_active_context, and update_trip resolve against the effective owner inventory
- add regression tests for owner-local inventory merging

## Testing
- node --import tsx --test tests/home-context-switch.test.ts tests/homepage-contexts.test.ts tests/owner-local-inventory.test.ts
- npx eslint app/page.tsx app/review/page.tsx 'app/review/[contextKey]/page.tsx' app/api/chat/route.ts app/api/contexts/route.ts app/_lib/effective-user-data.ts app/_lib/owner-local-inventory.ts app/_lib/chat/tools/create-context.ts app/_lib/chat/tools/set-active-context.ts app/_lib/chat/tools/update-trip.ts app/_lib/chat/tools/add-to-compass.ts tests/owner-local-inventory.test.ts
- npm run build