### PR TITLE
fix(chat): resolve existing trips from natural phrasing

### DIFF
--- a/app/_lib/chat/context-resolution.ts
+++ b/app/_lib/chat/context-resolution.ts
@@ -1,0 +1,292 @@
+import type { Context, UserManifest } from '../types';
+
+type RichContext = Context & Record<string, unknown>;
+
+export interface KnownContextDiscovery {
+  contextKey: string;
+  name: string;
+  type?: string;
+  city?: string;
+  address?: string;
+  discoveredAt?: string;
+}
+
+export interface ResolvedContextMatch {
+  context: Context;
+  score: number;
+  matchedAliases: string[];
+  matchedTokens: string[];
+}
+
+const STOP_WORDS = new Set([
+  'a', 'an', 'and', 'are', 'around', 'at', 'for', 'from', 'i', 'im', 'in', 'into', 'is', 'it', 'lets', 'me', 'my',
+  'of', 'on', 'our', 'please', 'review', 'show', 'switch', 'that', 'the', 'this', 'to', 'us', 'we', 'what', 'with',
+  'your', 'about', 'actually', 'check', 'focus', 'look', 'plan', 'planning', 'saved', 'trip', 'outing', 'radar',
+]);
+
+function normalizeText(value: string | undefined | null): string {
+  return (value || '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokenize(value: string | undefined | null): string[] {
+  return normalizeText(value)
+    .split(' ')
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 2 && !STOP_WORDS.has(token));
+}
+
+function pushUnique(target: string[], value: string | undefined | null): void {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (!trimmed) return;
+  if (!target.some((entry) => normalizeText(entry) === normalizeText(trimmed))) {
+    target.push(trimmed);
+  }
+}
+
+function getTypeWord(context: Context): string {
+  return context.type === 'outing' ? 'outing' : context.type === 'radar' ? 'radar' : 'trip';
+}
+
+function getLabelKeywords(context: Context): string[] {
+  return tokenize(context.label).filter((token) => !['solo', 'weekend', 'long'].includes(token));
+}
+
+function getDiscoveryNames(context: Context, discoveries: KnownContextDiscovery[] = [], limit = 2): string[] {
+  return discoveries
+    .filter((discovery) => discovery.contextKey === context.key)
+    .sort((a, b) => new Date(b.discoveredAt || 0).getTime() - new Date(a.discoveredAt || 0).getTime())
+    .slice(0, limit)
+    .map((discovery) => discovery.name)
+    .filter(Boolean);
+}
+
+function getAccommodationName(context: Context): string {
+  const raw = context as RichContext;
+  const accommodation = raw.accommodation;
+  if (!accommodation || typeof accommodation !== 'object') return '';
+  return typeof (accommodation as { name?: unknown }).name === 'string'
+    ? ((accommodation as { name: string }).name || '').trim()
+    : '';
+}
+
+function getPeopleNames(context: Context): string[] {
+  const raw = context as RichContext;
+  const people = Array.isArray(raw.people) ? raw.people : [];
+  return people
+    .map((person) => (person && typeof person === 'object' && typeof (person as { name?: unknown }).name === 'string')
+      ? ((person as { name: string }).name || '').trim()
+      : '')
+    .filter(Boolean)
+    .slice(0, 2);
+}
+
+export function buildContextAliases(
+  context: Context,
+  discoveries: KnownContextDiscovery[] = [],
+  maxAliases = 6,
+): string[] {
+  const aliases: string[] = [];
+  const typeWord = getTypeWord(context);
+  const label = context.label?.trim() || '';
+  const city = context.city?.trim() || '';
+  const labelKeywords = getLabelKeywords(context);
+  const labelTail = labelKeywords[labelKeywords.length - 1] || '';
+
+  pushUnique(aliases, label);
+  if (label && !normalizeText(label).includes(typeWord)) {
+    pushUnique(aliases, `${label} ${typeWord}`);
+  }
+
+  if (city) {
+    pushUnique(aliases, city);
+  }
+
+  if (labelTail && city && !normalizeText(city).includes(labelTail)) {
+    pushUnique(aliases, `${city} ${labelTail} ${typeWord}`);
+  }
+
+  if (city) {
+    pushUnique(aliases, `${city} ${typeWord}`);
+  }
+
+  if (labelTail) {
+    pushUnique(aliases, `${labelTail} ${typeWord}`);
+  }
+
+  const accommodationName = getAccommodationName(context);
+  pushUnique(aliases, accommodationName);
+
+  for (const name of getPeopleNames(context)) {
+    pushUnique(aliases, `${name} ${typeWord}`);
+  }
+
+  for (const discoveryName of getDiscoveryNames(context, discoveries)) {
+    pushUnique(aliases, `${discoveryName} ${typeWord}`);
+  }
+
+  return aliases.slice(0, maxAliases);
+}
+
+function addWeightedTokens(target: Map<string, number>, value: string | undefined | null, weight: number): void {
+  for (const token of tokenize(value)) {
+    const current = target.get(token) || 0;
+    if (weight > current) target.set(token, weight);
+  }
+}
+
+function getWeightedContextTokens(context: Context, discoveries: KnownContextDiscovery[] = []): Map<string, number> {
+  const raw = context as RichContext;
+  const weighted = new Map<string, number>();
+
+  addWeightedTokens(weighted, context.label, 8);
+  addWeightedTokens(weighted, context.city, 7);
+  addWeightedTokens(weighted, context.dates, 3);
+
+  for (const focus of context.focus || []) addWeightedTokens(weighted, focus, 4);
+  for (const alias of buildContextAliases(context, discoveries, 8)) addWeightedTokens(weighted, alias, 7);
+
+  addWeightedTokens(weighted, typeof raw.purpose === 'string' ? raw.purpose : '', 5);
+  addWeightedTokens(weighted, typeof raw.notes === 'string' ? raw.notes : '', 2);
+  addWeightedTokens(weighted, getAccommodationName(context), 6);
+
+  const accommodation = raw.accommodation;
+  if (accommodation && typeof accommodation === 'object') {
+    addWeightedTokens(weighted, typeof (accommodation as { address?: unknown }).address === 'string'
+      ? (accommodation as { address: string }).address
+      : '', 4);
+  }
+
+  const base = raw.base;
+  if (base && typeof base === 'object') {
+    addWeightedTokens(weighted, typeof (base as { address?: unknown }).address === 'string' ? (base as { address: string }).address : '', 4);
+    addWeightedTokens(weighted, typeof (base as { host?: unknown }).host === 'string' ? (base as { host: string }).host : '', 4);
+    addWeightedTokens(weighted, typeof (base as { zone?: unknown }).zone === 'string' ? (base as { zone: string }).zone : '', 3);
+  }
+
+  const anchor = raw.anchor;
+  if (anchor && typeof anchor === 'object') {
+    addWeightedTokens(weighted, typeof (anchor as { label?: unknown }).label === 'string' ? (anchor as { label: string }).label : '', 4);
+  }
+
+  const listFields = ['priorities', 'mustDo'] as const;
+  for (const field of listFields) {
+    const values = Array.isArray(raw[field]) ? raw[field] : [];
+    for (const value of values) {
+      if (typeof value === 'string') addWeightedTokens(weighted, value, 3);
+    }
+  }
+
+  const people = Array.isArray(raw.people) ? raw.people : [];
+  for (const person of people) {
+    if (!person || typeof person !== 'object') continue;
+    addWeightedTokens(weighted, typeof (person as { name?: unknown }).name === 'string' ? (person as { name: string }).name : '', 5);
+    addWeightedTokens(weighted, typeof (person as { relation?: unknown }).relation === 'string' ? (person as { relation: string }).relation : '', 2);
+    addWeightedTokens(weighted, typeof (person as { base?: unknown }).base === 'string' ? (person as { base: string }).base : '', 3);
+    addWeightedTokens(weighted, typeof (person as { note?: unknown }).note === 'string' ? (person as { note: string }).note : '', 2);
+  }
+
+  for (const discovery of discoveries) {
+    if (discovery.contextKey !== context.key) continue;
+    addWeightedTokens(weighted, discovery.name, 5);
+    addWeightedTokens(weighted, discovery.city, 3);
+    addWeightedTokens(weighted, discovery.address, 3);
+  }
+
+  return weighted;
+}
+
+function getKeyVariants(rawValue: string): string[] {
+  const normalized = normalizeText(rawValue);
+  if (!normalized) return [];
+  const variants = [normalized];
+  const rawSlug = rawValue.includes(':') ? rawValue.split(':').slice(1).join(':') : rawValue;
+  const slugNorm = normalizeText(rawSlug.replace(/-\d{4}$/, ''));
+  if (slugNorm && !variants.includes(slugNorm)) variants.push(slugNorm);
+  return variants;
+}
+
+function scoreAlias(messageNorm: string, messageTokens: string[], alias: string): number {
+  const aliasNorm = normalizeText(alias);
+  if (!aliasNorm) return 0;
+  const aliasTokenCount = tokenize(alias).length;
+  if (messageNorm === aliasNorm) return 24 + aliasTokenCount;
+  if (messageNorm.includes(aliasNorm)) return 18 + aliasTokenCount;
+  if (messageTokens.length >= 2 && aliasNorm.includes(messageNorm)) return 14 + messageTokens.length;
+  return 0;
+}
+
+export function resolveContextReference(
+  rawValue: string | undefined | null,
+  manifest: UserManifest | null | undefined,
+  discoveries: KnownContextDiscovery[] = [],
+): ResolvedContextMatch | null {
+  if (!rawValue || !manifest?.contexts?.length) return null;
+
+  const messageNorm = normalizeText(rawValue);
+  const messageTokens = tokenize(rawValue);
+  const keyVariants = getKeyVariants(rawValue);
+  if (!messageNorm) return null;
+
+  let best: ResolvedContextMatch | null = null;
+  let secondBestScore = 0;
+
+  for (const context of manifest.contexts) {
+    const aliases = buildContextAliases(context, discoveries, 8);
+    const matchedAliases = aliases
+      .map((alias) => ({ alias, score: scoreAlias(messageNorm, messageTokens, alias) }))
+      .filter((entry) => entry.score > 0)
+      .sort((a, b) => b.score - a.score);
+
+    let score = matchedAliases.reduce((sum, entry) => sum + entry.score, 0);
+
+    const keyNorm = normalizeText(context.key);
+    const keyBaseNorm = normalizeText(context.key.split(':').slice(1).join(':').replace(/-\d{4}$/, ''));
+    if (keyVariants.includes(keyNorm)) score += 30;
+    else if (keyBaseNorm && keyVariants.includes(keyBaseNorm)) score += 22;
+
+    const tokenWeights = getWeightedContextTokens(context, discoveries);
+    const matchedTokens = [...new Set(messageTokens.filter((token) => tokenWeights.has(token)))];
+    score += matchedTokens.reduce((sum, token) => sum + (tokenWeights.get(token) || 0), 0);
+    if (matchedTokens.length >= 2) score += matchedTokens.length * 2;
+
+    const candidate: ResolvedContextMatch = {
+      context,
+      score,
+      matchedAliases: matchedAliases.map((entry) => entry.alias).slice(0, 3),
+      matchedTokens: matchedTokens.slice(0, 6),
+    };
+
+    if (!best || candidate.score > best.score) {
+      secondBestScore = best?.score || secondBestScore;
+      best = candidate;
+    } else if (candidate.score > secondBestScore) {
+      secondBestScore = candidate.score;
+    }
+  }
+
+  if (!best) return null;
+
+  const hasStrongAlias = best.matchedAliases.length > 0;
+  const hasStrongTokenOverlap = best.matchedTokens.length >= 2;
+  const margin = best.score - secondBestScore;
+  if (!hasStrongAlias && !hasStrongTokenOverlap) return null;
+  if (best.score < 14) return null;
+  if (margin < 4 && best.score < 24) return null;
+
+  return best;
+}
+
+export function resolveContextKey(
+  rawContextKey: string | undefined | null,
+  manifest: UserManifest | null | undefined,
+  discoveries: KnownContextDiscovery[] = [],
+): string | null {
+  const resolved = resolveContextReference(rawContextKey, manifest, discoveries);
+  return resolved?.context.key || null;
+}

--- a/app/_lib/chat/system-prompt.ts
+++ b/app/_lib/chat/system-prompt.ts
@@ -4,6 +4,7 @@
  */
 
 import { buildPlaceCardTemplate } from '../app-url';
+import { buildContextAliases, type KnownContextDiscovery, type ResolvedContextMatch } from './context-resolution';
 import type { UserPreferences, UserManifest, Context } from '../types';
 
 export const SYSTEM_PROMPT = `You are the Compass Concierge — a warm, knowledgeable travel companion with real research abilities.
@@ -59,7 +60,7 @@ CONTEXT SWITCHING — keep the homepage in sync with the conversation:
   - Returning to a trip you were discussing earlier in the chat, e.g. Ontario → NYC → Ontario. Every hop between existing contexts needs its own set_active_context call.
 - After create_context for a brand-new trip, you do NOT need to call set_active_context — the app auto-switches on create_context.
 - If the user asks about a context that does not exist yet, call create_context instead (do NOT call set_active_context with a made-up key).
-- Use the exact key from KNOWN CONTEXTS (e.g. \`trip:nyc-solo-trip\`), not a free-form label.
+- Match against the context facts and alias cues in KNOWN CONTEXTS, then use the exact saved key (e.g. \`trip:nyc-solo-trip\`) in the tool call, not a free-form label.
 
 CONTEXTUAL EDITING — for corrections, additions, and removals:
 When the user is scoped to a specific context (see ACTIVE CHAT TARGET below), they may ask you to:
@@ -121,15 +122,6 @@ export interface ChatTargetInfo {
   cardPlaceId?: string;
 }
 
-export interface KnownContextDiscovery {
-  contextKey: string;
-  name: string;
-  type: string;
-  city: string;
-  address?: string;
-  discoveredAt?: string;
-}
-
 export interface ChatContext {
   userCode: string;
   userCity: string;
@@ -141,6 +133,8 @@ export interface ChatContext {
   activeContextKey?: string;
   /** Card-level targeting — a specific place the user is chatting about */
   chatTarget?: ChatTargetInfo;
+  /** High-confidence structured resolution for the latest user message */
+  resolvedContextReference?: ResolvedContextMatch;
 }
 
 type RichContext = Context & Record<string, unknown>;
@@ -297,6 +291,7 @@ function formatContextSummary(
   const priorities = getStringList(richContext.priorities);
   const mustDo = getStringList(richContext.mustDo);
   const places = getContextDiscoveries(context, discoveries, detailLevel === 'full' ? 3 : 2);
+  const aliases = buildContextAliases(context, discoveries, detailLevel === 'full' ? 5 : 3);
 
   const extras = [
     accommodation ? `Accommodation: ${accommodation}` : '',
@@ -308,6 +303,7 @@ function formatContextSummary(
     priorities.length > 0 ? `Priorities: ${priorities.join(', ')}` : '',
     mustDo.length > 0 ? `Must do: ${mustDo.join(', ')}` : '',
     places.length > 0 ? `Known places: ${places.join('; ')}` : '',
+    aliases.length > 0 ? `Alias cues: ${aliases.join('; ')}` : '',
   ].filter(Boolean);
 
   const maxExtras = detailLevel === 'full' ? 6 : 2;
@@ -392,6 +388,14 @@ Be curious and warm. Get to know them naturally.`;
     }
   } else {
     prompt += `\n\n## CONTEXTS\nNo saved trips, outings, or radars yet. If the user mentions an upcoming trip or outing, help them set it up.`;
+  }
+
+  if (context.resolvedContextReference) {
+    const resolved = context.resolvedContextReference;
+    const matchedFacts = [...resolved.matchedAliases, ...resolved.matchedTokens]
+      .filter(Boolean)
+      .slice(0, 5);
+    prompt += `\n\n## STRUCTURED CONTEXT MATCH\nThe latest user message most likely refers to **${resolved.context.emoji || '📍'} ${resolved.context.label}** (key: \`${resolved.context.key}\`).${matchedFacts.length > 0 ? ` Matching cues: ${matchedFacts.join(', ')}.` : ''}\n\nUnless the user is clearly creating a different brand-new context, treat this as a reference to the existing saved context. If it differs from ACTIVE CHAT TARGET, call set_active_context with \`${resolved.context.key}\` before other tools.`;
   }
 
   // Add recent discoveries

--- a/app/_lib/chat/tools/set-active-context.ts
+++ b/app/_lib/chat/tools/set-active-context.ts
@@ -10,7 +10,8 @@
  * "let's review the NYC trip" while the homepage is showing Boston.
  */
 
-import { getUserManifest } from '../../user-data';
+import { getUserDiscoveries, getUserManifest } from '../../user-data';
+import { resolveContextReference, type KnownContextDiscovery } from '../context-resolution';
 
 export interface SetActiveContextInput {
   contextKey: string;
@@ -26,12 +27,28 @@ export async function setActiveContext(
   }
 
   try {
-    const manifest = await getUserManifest(userId);
-    const ctx = manifest?.contexts?.find(c => c.key === key);
+    const [manifest, discoveries] = await Promise.all([
+      getUserManifest(userId),
+      getUserDiscoveries(userId),
+    ]);
+
+    const knownDiscoveries: KnownContextDiscovery[] = (discoveries?.discoveries || [])
+      .filter((discovery) => Boolean(discovery.contextKey))
+      .map((discovery) => ({
+        contextKey: discovery.contextKey,
+        name: discovery.name,
+        type: discovery.type,
+        city: discovery.city,
+        address: discovery.address,
+        discoveredAt: discovery.discoveredAt,
+      }));
+
+    const resolved = resolveContextReference(key, manifest, knownDiscoveries);
+    const ctx = resolved?.context || manifest?.contexts?.find(c => c.key === key);
     if (!ctx) {
       return `Context not found for key: ${key}`;
     }
-    return `🎯 Focused on ${ctx.emoji || '📌'} ${ctx.label} (${key})`;
+    return `🎯 Focused on ${ctx.emoji || '📌'} ${ctx.label} (${ctx.key})`;
   } catch (e) {
     console.error('[set_active_context] Failed:', e);
     return `Failed to set active context: ${e instanceof Error ? e.message : String(e)}`;

--- a/app/_lib/chat/tools/update-trip.ts
+++ b/app/_lib/chat/tools/update-trip.ts
@@ -3,7 +3,8 @@
  * Called by Concierge when the user shares trip details, dates, accommodation, etc.
  */
 
-import { getUserManifest, setUserData } from '../../user-data';
+import { getUserDiscoveries, getUserManifest, setUserData } from '../../user-data';
+import { resolveContextReference, type KnownContextDiscovery } from '../context-resolution';
 import type { Context } from '../../types';
 
 export interface UpdateTripInput {
@@ -20,12 +21,29 @@ export interface UpdateTripInput {
 
 export async function updateTrip(userId: string, input: UpdateTripInput): Promise<string> {
   try {
-    const manifest = await getUserManifest(userId);
+    const [manifest, discoveries] = await Promise.all([
+      getUserManifest(userId),
+      getUserDiscoveries(userId),
+    ]);
     if (!manifest) {
       return `❌ No manifest found for user. Can't update trip.`;
     }
 
-    const idx = manifest.contexts.findIndex(c => c.key === input.contextKey);
+    const knownDiscoveries: KnownContextDiscovery[] = (discoveries?.discoveries || [])
+      .filter((discovery) => Boolean(discovery.contextKey))
+      .map((discovery) => ({
+        contextKey: discovery.contextKey,
+        name: discovery.name,
+        type: discovery.type,
+        city: discovery.city,
+        address: discovery.address,
+        discoveredAt: discovery.discoveredAt,
+      }));
+
+    const resolved = resolveContextReference(input.contextKey, manifest, knownDiscoveries);
+    const resolvedContextKey = resolved?.context.key || input.contextKey;
+
+    const idx = manifest.contexts.findIndex(c => c.key === resolvedContextKey);
     if (idx === -1) {
       return `❌ Context not found: "${input.contextKey}". Available contexts: ${manifest.contexts.map(c => c.key).join(', ')}`;
     }
@@ -53,7 +71,7 @@ export async function updateTrip(userId: string, input: UpdateTripInput): Promis
     if (input.focus) changes.push(`focus → ${input.focus.join(', ')}`);
     if (input.accommodationName) changes.push(`accommodation → ${input.accommodationName}`);
 
-    console.log(`[update_trip] ✅ Updated context "${input.contextKey}" for user ${userId}: ${changes.join('; ')}`);
+    console.log(`[update_trip] ✅ Updated context "${resolvedContextKey}" for user ${userId}: ${changes.join('; ')}`);
     return `✅ Updated ${updated.emoji} ${updated.label}: ${changes.join(', ')}`;
   } catch (e) {
     console.error('[update_trip] Failed:', e);

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -3,11 +3,12 @@ import { getCurrentUser } from '../../_lib/user';
 import { getUserProfile, getUserPreferences, getUserManifest, getUserDiscoveries } from '../../_lib/user-data';
 import { persistChatData, getChatHistory } from '../../_lib/chat/persistence';
 import { buildSystemPrompt, type ChatContext } from '../../_lib/chat/system-prompt';
+import { resolveContextKey, resolveContextReference, type KnownContextDiscovery } from '../../_lib/chat/context-resolution';
 import { TOOLS } from '../../_lib/chat/tools';
 import { runToolCall, type ToolName } from '../../_lib/chat/tools/runner';
 import { computeContextKey } from '../../_lib/chat/tools/create-context';
 import { checkRateLimit, rateLimitHeaders } from '../../_lib/chat/rate-limiter';
-import type { ChatMessage, Discovery } from '../../_lib/types';
+import type { ChatMessage, Discovery, UserManifest } from '../../_lib/types';
 
 // Vercel serverless config — tool loops need time
 export const maxDuration = 60;
@@ -50,11 +51,14 @@ function mapToolName(name: string): string {
  *
  * - For create_context, derive the key from type+label using the same
  *   slugify rule as the tool implementation.
- * - For every other tool, prefer the explicit contextKey in the input.
+ * - For every other tool, canonically resolve the provided context reference
+ *   to a saved context key when possible, then fall back to the raw input.
  */
 function resolveTargetContextKey(
   toolName: string,
   input: Record<string, unknown>,
+  manifest: UserManifest | null,
+  knownDiscoveries: KnownContextDiscovery[] = [],
 ): string | undefined {
   if (toolName === 'create_context') {
     const type = typeof input?.type === 'string' ? input.type : undefined;
@@ -69,7 +73,8 @@ function resolveTargetContextKey(
     return undefined;
   }
   const ck = input?.contextKey;
-  return typeof ck === 'string' && ck.length > 0 ? ck : undefined;
+  if (typeof ck !== 'string' || ck.length === 0) return undefined;
+  return resolveContextKey(ck, manifest, knownDiscoveries) || ck;
 }
 
 /**
@@ -204,6 +209,8 @@ async function executeToolLoop(
           const toolContextKey = resolveTargetContextKey(
             toolBlock.name as string,
             (toolBlock.input as Record<string, unknown>) || {},
+            manifest,
+            knownDiscoveries,
           );
           controller.enqueue(encoder.encode(
             `data: ${JSON.stringify({ toolResult: frontendToolName, messageId, ...(toolContextKey ? { contextKey: toolContextKey } : {}) })}\n\n`
@@ -290,7 +297,7 @@ export async function POST(request: NextRequest) {
       .slice(0, 5)
       .map((d: Discovery) => ({ name: d.name, type: d.type, city: d.city }));
 
-    const knownDiscoveries = allDiscoveries
+    const knownDiscoveries: KnownContextDiscovery[] = allDiscoveries
       .filter((d: Discovery) => Boolean(d.contextKey))
       .map((d: Discovery) => ({
         contextKey: d.contextKey,
@@ -304,6 +311,8 @@ export async function POST(request: NextRequest) {
     const history: ChatMessage[] = clientHistory || (await getChatHistory(user.id));
 
     // Build chat context for system prompt
+    const resolvedContextReference = resolveContextReference(message, manifest, knownDiscoveries);
+
     const chatContext: ChatContext = {
       userCode: user.code,
       userCity: profile?.city || user.city || '',
@@ -318,6 +327,7 @@ export async function POST(request: NextRequest) {
         cardType: typeof chatTarget.cardType === 'string' ? chatTarget.cardType : undefined,
         cardPlaceId: typeof chatTarget.cardPlaceId === 'string' ? chatTarget.cardPlaceId : undefined,
       } : undefined,
+      resolvedContextReference,
     };
 
     const appOrigin = request.nextUrl.origin;

--- a/tests/context-resolution.test.ts
+++ b/tests/context-resolution.test.ts
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildContextAliases, resolveContextReference, type KnownContextDiscovery } from '../app/_lib/chat/context-resolution';
+import type { UserManifest } from '../app/_lib/types';
+
+const manifest: UserManifest = {
+  updatedAt: '2026-04-10T00:00:00.000Z',
+  contexts: [
+    {
+      key: 'trip:cottage-july-2026',
+      label: 'Ontario Cottage',
+      emoji: '🏊',
+      type: 'trip',
+      city: 'Lake Huron',
+      dates: 'July 2026 (3+ weeks)',
+      focus: ['waterfront', 'swimming'],
+      active: true,
+    },
+    {
+      key: 'trip:nyc-solo-trip',
+      label: 'NYC Solo Trip',
+      emoji: '🗽',
+      type: 'trip',
+      city: 'New York',
+      dates: '2026-04-27 to 2026-04-30',
+      focus: ['galleries', 'jazz'],
+      active: true,
+      accommodation: {
+        name: "Arnold's",
+        address: '126 Leonard St',
+      },
+    } as UserManifest['contexts'][number],
+  ],
+};
+
+const discoveries: KnownContextDiscovery[] = [
+  {
+    contextKey: 'trip:cottage-july-2026',
+    name: 'The Lookout',
+    type: 'accommodation',
+    city: 'Port Albert',
+    address: 'Port Albert',
+    discoveredAt: '2026-03-15T00:00:00.000Z',
+  },
+];
+
+test('buildContextAliases derives semantic cues from label, city, and saved places', () => {
+  const aliases = buildContextAliases(manifest.contexts[0]!, discoveries, 8);
+  assert.deepEqual(
+    aliases.slice(0, 6),
+    ['Ontario Cottage', 'Ontario Cottage trip', 'Lake Huron', 'Lake Huron cottage trip', 'Lake Huron trip', 'cottage trip'],
+  );
+  assert.match(aliases.join(' | '), /The Lookout trip/);
+});
+
+test('resolveContextReference matches natural regional phrasing', () => {
+  const resolved = resolveContextReference('What about the Lake Huron cottage trip?', manifest, discoveries);
+  assert.equal(resolved?.context.key, 'trip:cottage-july-2026');
+  assert.ok((resolved?.matchedAliases || []).includes('Lake Huron cottage trip'));
+});
+
+test('resolveContextReference matches saved-place phrasing', () => {
+  const resolved = resolveContextReference('Switch to The Lookout trip', manifest, discoveries);
+  assert.equal(resolved?.context.key, 'trip:cottage-july-2026');
+});
+
+test('resolveContextReference stays conservative on vague references', () => {
+  const resolved = resolveContextReference('What about the trip?', manifest, discoveries);
+  assert.equal(resolved, null);
+});

--- a/tests/home-context-switch.test.ts
+++ b/tests/home-context-switch.test.ts
@@ -10,8 +10,8 @@
  *
  * Covered behaviours:
  * 1. Route-level resolution of a tool call's target contextKey
- *    (create_context derives the key from label; everything else reads the
- *    explicit contextKey from the tool input).
+ *    (create_context derives the key from label; existing-context tools
+ *    canonically resolve natural phrasing to the saved key when possible).
  * 2. HomeClient-style reducer for chat-driven switches:
  *    - If the target key is in the current contexts → apply immediately
  *    - If the target key is NOT yet in contexts → stash as pending
@@ -22,7 +22,9 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 
+import { resolveContextKey, type KnownContextDiscovery } from '../app/_lib/chat/context-resolution';
 import { computeContextKey } from '../app/_lib/chat/tools/create-context';
+import type { UserManifest } from '../app/_lib/types';
 
 // ---------------------------------------------------------------------------
 // Pure function mirroring app/api/chat/route.ts resolveTargetContextKey.
@@ -31,6 +33,8 @@ import { computeContextKey } from '../app/_lib/chat/tools/create-context';
 function resolveTargetContextKey(
   toolName: string,
   input: Record<string, unknown>,
+  manifest: UserManifest | null = null,
+  knownDiscoveries: KnownContextDiscovery[] = [],
 ): string | undefined {
   if (toolName === 'create_context') {
     const type = typeof input?.type === 'string' ? input.type : undefined;
@@ -41,7 +45,8 @@ function resolveTargetContextKey(
     return undefined;
   }
   const ck = input?.contextKey;
-  return typeof ck === 'string' && ck.length > 0 ? ck : undefined;
+  if (typeof ck !== 'string' || ck.length === 0) return undefined;
+  return resolveContextKey(ck, manifest, knownDiscoveries) || ck;
 }
 
 // ---------------------------------------------------------------------------
@@ -132,6 +137,43 @@ function forwardToolResultContextKey(
 
 // ---------------------------------------------------------------------------
 describe('route.resolveTargetContextKey', () => {
+  const manifest: UserManifest = {
+    updatedAt: '2026-04-10T00:00:00.000Z',
+    contexts: [
+      {
+        key: 'trip:cottage-july-2026',
+        label: 'Ontario Cottage',
+        emoji: '🏊',
+        type: 'trip',
+        city: 'Lake Huron',
+        dates: 'July 2026 (3+ weeks)',
+        focus: ['waterfront', 'swimming'],
+        active: true,
+      },
+      {
+        key: 'trip:nyc-solo-trip',
+        label: 'NYC Solo Trip',
+        emoji: '🗽',
+        type: 'trip',
+        city: 'New York',
+        dates: '2026-04-27 to 2026-04-30',
+        focus: ['galleries', 'jazz'],
+        active: true,
+      },
+    ],
+  };
+
+  const knownDiscoveries: KnownContextDiscovery[] = [
+    {
+      contextKey: 'trip:cottage-july-2026',
+      name: 'The Lookout',
+      type: 'accommodation',
+      city: 'Port Albert',
+      address: 'Port Albert',
+      discoveredAt: '2026-03-15T00:00:00.000Z',
+    },
+  ];
+
   test('create_context derives key from type + label (matches tool slug)', () => {
     const key = resolveTargetContextKey('create_context', { type: 'trip', label: 'Barcelona November 2026' });
     assert.equal(key, 'trip:barcelona-november-2026');
@@ -148,23 +190,33 @@ describe('route.resolveTargetContextKey', () => {
   });
 
   test('add_to_compass reads contextKey from input', () => {
-    const key = resolveTargetContextKey('add_to_compass', { contextKey: 'trip:boston-aug-2026', name: 'x' });
+    const key = resolveTargetContextKey('add_to_compass', { contextKey: 'trip:boston-aug-2026', name: 'x' }, manifest, knownDiscoveries);
     assert.equal(key, 'trip:boston-aug-2026');
   });
 
   test('update_trip reads contextKey from input', () => {
-    const key = resolveTargetContextKey('update_trip', { contextKey: 'trip:nyc-solo-trip', dates: 'April 27-30, 2026' });
+    const key = resolveTargetContextKey('update_trip', { contextKey: 'trip:nyc-solo-trip', dates: 'April 27-30, 2026' }, manifest, knownDiscoveries);
     assert.equal(key, 'trip:nyc-solo-trip');
   });
 
   test('set_active_context reads contextKey from input', () => {
-    const key = resolveTargetContextKey('set_active_context', { contextKey: 'trip:paris-2027' });
+    const key = resolveTargetContextKey('set_active_context', { contextKey: 'trip:paris-2027' }, manifest, knownDiscoveries);
     assert.equal(key, 'trip:paris-2027');
   });
 
+  test('canonicalizes semantic trip phrasing to the saved key', () => {
+    const key = resolveTargetContextKey('set_active_context', { contextKey: 'Lake Huron cottage trip' }, manifest, knownDiscoveries);
+    assert.equal(key, 'trip:cottage-july-2026');
+  });
+
+  test('canonicalizes saved-place phrasing to the saved key', () => {
+    const key = resolveTargetContextKey('set_active_context', { contextKey: 'The Lookout trip' }, manifest, knownDiscoveries);
+    assert.equal(key, 'trip:cottage-july-2026');
+  });
+
   test('edit_discovery / remove_discovery also surface contextKey', () => {
-    assert.equal(resolveTargetContextKey('edit_discovery', { contextKey: 'outing:sat-dinner', name: 'x', updates: {} }), 'outing:sat-dinner');
-    assert.equal(resolveTargetContextKey('remove_discovery', { contextKey: 'radar:downtown', name: 'x' }), 'radar:downtown');
+    assert.equal(resolveTargetContextKey('edit_discovery', { contextKey: 'outing:sat-dinner', name: 'x', updates: {} }, manifest, knownDiscoveries), 'outing:sat-dinner');
+    assert.equal(resolveTargetContextKey('remove_discovery', { contextKey: 'radar:downtown', name: 'x' }, manifest, knownDiscoveries), 'radar:downtown');
   });
 
   test('returns undefined when no contextKey is present', () => {

--- a/tests/system-prompt-context.test.ts
+++ b/tests/system-prompt-context.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
+import { resolveContextReference } from '../app/_lib/chat/context-resolution';
 import { buildSystemPrompt, type ChatContext } from '../app/_lib/chat/system-prompt';
 
 test('buildSystemPrompt includes rich facts for known trip contexts', () => {
@@ -53,8 +54,57 @@ test('buildSystemPrompt includes rich facts for known trip contexts', () => {
   assert.match(prompt, /Ontario Cottage/);
   assert.match(prompt, /Location: Lake Huron/);
   assert.match(prompt, /Known places: The Lookout \(accommodation, Port Albert\)/);
+  assert.match(prompt, /Alias cues: Ontario Cottage; Ontario Cottage trip; Lake Huron; Lake Huron cottage trip/);
   assert.match(prompt, /Boston Long Weekend/);
   assert.match(prompt, /archived/);
+});
+
+
+test('buildSystemPrompt surfaces structured semantic context matches', () => {
+  const context: ChatContext = {
+    userCode: 'john',
+    userCity: 'Toronto',
+    preferences: null,
+    manifest: {
+      updatedAt: '2026-04-10T00:00:00.000Z',
+      contexts: [
+        {
+          key: 'trip:cottage-july-2026',
+          label: 'Ontario Cottage',
+          emoji: '🏊',
+          type: 'trip',
+          city: 'Lake Huron',
+          dates: 'July 2026 (3+ weeks)',
+          focus: ['waterfront', 'swimming'],
+          active: true,
+        },
+      ],
+    },
+    recentDiscoveries: [],
+    knownDiscoveries: [
+      {
+        contextKey: 'trip:cottage-july-2026',
+        name: 'The Lookout',
+        type: 'accommodation',
+        city: 'Port Albert',
+        address: 'Port Albert',
+        discoveredAt: '2026-03-15T00:00:00.000Z',
+      },
+    ],
+  };
+
+  context.resolvedContextReference = resolveContextReference(
+    'What about the Lake Huron cottage trip?',
+    context.manifest,
+    context.knownDiscoveries,
+  ) || undefined;
+
+  const prompt = buildSystemPrompt(context);
+
+  assert.match(prompt, /## STRUCTURED CONTEXT MATCH/);
+  assert.match(prompt, /Ontario Cottage/);
+  assert.match(prompt, /trip:cottage-july-2026/);
+  assert.match(prompt, /Lake Huron cottage trip/);
 });
 
 test('buildSystemPrompt expands active chat target with trip details', () => {


### PR DESCRIPTION
Fixes #296

## Summary
- add structured semantic existing-context resolution
- canonicalize chat context-switch keys before emitting homepage switch events
- make set_active_context and update_trip resilient to natural phrasing
- add targeted regression tests for semantic trip matching

## Testing
- NODE_PATH=/Users/john/.openclaw/workspace/compass-v2/node_modules /Users/john/.openclaw/workspace/compass-v2/node_modules/.bin/tsx --test tests/context-resolution.test.ts tests/system-prompt-context.test.ts tests/home-context-switch.test.ts