### PR TITLE
fix: restore generic homepage chat prompt

### DIFF
--- a/app/_components/ChatWidget.tsx
+++ b/app/_components/ChatWidget.tsx
@@ -591,7 +591,7 @@ export default function ChatWidget() {
             className={`${styles.chatInputField}${showScopeChip ? ` ${styles.chatInputFieldScoped}` : ''}`}
             placeholder={isPlaceScoped && chatTarget?.card
               ? `Ask about ${chatTarget.card.name}…`
-              : scopedLabel
+              : chatTarget && scopedLabel
                 ? `Add to ${scopedLabel}…`
                 : 'Ask me anything…'
             }

--- a/tests/chat.spec.ts
+++ b/tests/chat.spec.ts
@@ -9,6 +9,7 @@ test('chat widget has correct light background', async ({ page }) => {
 
   // Assert it exists and is visible
   await expect(chatInput).toBeVisible();
+  await expect(chatInput).toHaveAttribute('placeholder', /Ask me anything/i);
 
   // Check its computed background-color is a warm/light color (not dark)
   // rgb values where all channels > 200 means light color


### PR DESCRIPTION
## Summary
- keep the homepage chat input on a stable generic prompt during normal browsing
- preserve targeted placeholder copy only for explicit scoped/place-targeted chat flows
- assert the homepage chat prompt in the Playwright chat spec

## Verification
- manual Playwright check on `http://localhost:3002/` as signed-in `john` confirmed the chat input is visible and shows `Ask me anything…`
- `npx playwright test tests/chat.spec.ts`

Closes #306
