### PR TITLE
fix: improve monitoring observation pipeline throughput and reliability

### DIFF
--- a/app/_components/AccommodationReviewLayout.tsx
+++ b/app/_components/AccommodationReviewLayout.tsx
@@ -6,7 +6,7 @@ import type { Discovery } from '../_lib/types';
 import type { Context } from '../_lib/types';
 import { getTriageState } from '../_lib/triage';
 import TriageButtons from './TriageButtons';
-import { resolveImageUrlClient } from '../_lib/image-url';
+import { getDiscoveryPrimaryImageUrl } from '../_lib/image-url';
 import { getPlatformInfo } from '../_lib/platform';
 
 type Tab = 'unreviewed' | 'saved' | 'dismissed';
@@ -88,7 +88,7 @@ function AccommodationCard({
   const placeId = discovery.place_id ?? discovery.id;
 
   // Resolve hero image
-  const hero = resolveImageUrlClient(discovery.heroImage) || null;
+  const hero = getDiscoveryPrimaryImageUrl(discovery);
 
   // Extract cottage-specific fields (all from _cottage since migration update)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -144,12 +144,10 @@ function AccommodationCard({
   const enrichedVibeTags = vibeTags && vibeTags.length > 0 ? vibeTags : [];
   const topVibeTags = enrichedVibeTags.slice(0, 4);
 
-  // Shortened swimVerdict for potential tag (not currently used as a tag)
-  const shortSwimVerdict = swimVerdict && swimVerdict.length > 40 ? swimVerdict.slice(0, 37) + '...' : swimVerdict;
-
   // Location: city · water body
-  const city = (discovery as any).city as string | undefined;
-  const waterBody = (discovery as any).water_body as string | undefined;
+  const discoveryRecord = discovery as unknown as Record<string, unknown>;
+  const city = discoveryRecord.city as string | undefined;
+  const waterBody = discoveryRecord.water_body as string | undefined;
   const locationStr = [city, waterBody].filter(Boolean).join(' · ');
 
   return (
@@ -311,8 +309,8 @@ export default function AccommodationReviewLayout({
       const scoreB = preferenceScore(b);
       if (scoreB !== scoreA) return scoreB - scoreA;
       // Tiebreak: cards with hero image first
-      const hasHeroA = !!resolveImageUrlClient(a.heroImage);
-      const hasHeroB = !!resolveImageUrlClient(b.heroImage);
+      const hasHeroA = !!getDiscoveryPrimaryImageUrl(a);
+      const hasHeroB = !!getDiscoveryPrimaryImageUrl(b);
       if (hasHeroA !== hasHeroB) return hasHeroA ? -1 : 1;
       return 0;
     });

--- a/app/_components/ChatWidget.tsx
+++ b/app/_components/ChatWidget.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import type { ChatMessage } from '../_lib/types';
 import type { ChatTarget } from '../_lib/chat-target';
 import { chatTargetPill, CHAT_TARGET_EVENT, CHAT_TARGET_CLEAR_EVENT } from '../_lib/chat-target';
+import { diffTripEmergenceAttributes, type TripEmergenceSnapshot } from '../_lib/trip-emergence';
 import styles from './ChatWidget.module.css';
 
 /**
@@ -67,7 +68,7 @@ export default function ChatWidget() {
   const createContextUsed = useRef(false);
   const updateTripUsed = useRef<string | null>(null);
   const preContextKeys = useRef<Set<string>>(new Set());
-  const preContextSnapshots = useRef<Record<string, { dates?: string; city?: string; focus?: string[] }>>({});
+  const preContextSnapshots = useRef<Record<string, TripEmergenceSnapshot>>({});
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -296,11 +297,21 @@ export default function ChatWidget() {
       .then(r => r.ok ? r.json() : null)
       .then(data => {
         if (data?.contexts) {
-          const ctxs = data.contexts as Array<{ key: string; dates?: string; city?: string; focus?: string[] }>;
+          const ctxs = data.contexts as TripEmergenceSnapshot[];
           preContextKeys.current = new Set(ctxs.map(c => c.key));
-          const snapshots: Record<string, { dates?: string; city?: string; focus?: string[] }> = {};
+          const snapshots: Record<string, TripEmergenceSnapshot> = {};
           for (const c of ctxs) {
-            snapshots[c.key] = { dates: c.dates, city: c.city, focus: c.focus };
+            snapshots[c.key] = {
+              key: c.key,
+              label: c.label,
+              type: c.type,
+              emoji: c.emoji,
+              dates: c.dates,
+              city: c.city,
+              focus: c.focus,
+              purpose: c.purpose,
+              people: c.people,
+            };
           }
           preContextSnapshots.current = snapshots;
         }
@@ -375,7 +386,7 @@ export default function ChatWidget() {
               const res = await fetch('/api/contexts');
               if (res.ok) {
                 const data = await res.json();
-                const allCtxs = data.contexts as Array<{ key: string; label: string; type: string; emoji: string; dates?: string; city?: string; focus?: string[] }>;
+                const allCtxs = data.contexts as TripEmergenceSnapshot[];
 
                 const newCtxs = allCtxs.filter(c => !preContextKeys.current.has(c.key));
                 for (const ctx of newCtxs) {
@@ -392,17 +403,7 @@ export default function ChatWidget() {
                   for (const ctx of allCtxs) {
                     const prev = preContextSnapshots.current[ctx.key];
                     if (!prev) continue;
-                    const changedAttrs: Array<{ field: string; value: string }> = [];
-                    if (ctx.dates && ctx.dates !== prev.dates) {
-                      changedAttrs.push({ field: 'dates', value: ctx.dates });
-                    }
-                    if (ctx.city && ctx.city !== prev.city) {
-                      changedAttrs.push({ field: 'city', value: ctx.city });
-                    }
-                    const newFocus = (ctx.focus ?? []).filter(f => !(prev.focus ?? []).includes(f));
-                    if (newFocus.length > 0) {
-                      changedAttrs.push({ field: 'focus', value: newFocus.join(', ') });
-                    }
+                    const changedAttrs = diffTripEmergenceAttributes(prev, ctx);
                     if (changedAttrs.length > 0) {
                       window.dispatchEvent(new CustomEvent('compass-trip-attributes', {
                         detail: { key: ctx.key, attributes: changedAttrs },

--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -546,11 +546,22 @@ export default function HomeClient({
               )}
               {landingAttrs.length > 0 && (
                 <div className="section-attr-pills">
-                  {landingAttrs.map(attr => (
-                    <span key={attr.field} className="section-attr-pill">
-                      {attr.field === 'dates' ? '📅' : attr.field === 'city' ? '📍' : '🏷'} {attr.value}
-                    </span>
-                  ))}
+                  {landingAttrs.map(attr => {
+                    const icon = attr.field === 'dates'
+                      ? '📅'
+                      : attr.field === 'city'
+                        ? '📍'
+                        : attr.field === 'purpose'
+                          ? '🎯'
+                          : attr.field === 'people'
+                            ? '👥'
+                            : '🏷';
+                    return (
+                      <span key={`${attr.field}:${attr.value}`} className="section-attr-pill">
+                        {icon} {attr.value}
+                      </span>
+                    );
+                  })}
                 </div>
               )}
             </div>

--- a/app/_components/PlaceCard.tsx
+++ b/app/_components/PlaceCard.tsx
@@ -6,8 +6,8 @@ import type { Discovery } from '../_lib/types';
 import { dispatchChatTarget } from '../_lib/chat-target';
 import TypeBadge from './TypeBadge';
 import TriageButtons from './TriageButtons';
-import { resolveImageUrlClient } from '../_lib/image-url';
-import { getMonitoringExplanation, getMonitorStatusLabel } from '../_lib/discovery-monitoring';
+import { getDiscoveryPrimaryImageUrl } from '../_lib/image-url';
+import { getMonitorStatusLabel } from '../_lib/discovery-monitoring';
 
 interface PlaceCardProps {
   discovery: Discovery;
@@ -24,9 +24,7 @@ export default function PlaceCard({ discovery, contextKey, contextLabel, context
   const rating = discovery.rating != null ? Number(discovery.rating) : null;
   const safeRating = rating != null && !isNaN(rating) ? rating : null;
 
-  // Resolve image URL — prioritize new images array, then legacy heroImage
-  const rawImage = discovery.images?.[0]?.url || discovery.heroImage;
-  const imageUrl = resolveImageUrlClient(rawImage);
+  const imageUrl = getDiscoveryPrimaryImageUrl(discovery);
 
   // Fix #211: onError recovery - if image fails to load, trigger fetch from API
   const [fetchedImageUrl, setFetchedImageUrl] = useState<string | null>(null);
@@ -75,7 +73,6 @@ export default function PlaceCard({ discovery, contextKey, contextLabel, context
   const mapsUrl = place_id
     ? `https://www.google.com/maps/place/?q=place_id:${place_id}`
     : null;
-  const monitorExplanation = getMonitoringExplanation(discovery);
 
   // Track whether this card is the active chat target (for halo effect)
   const [isChatTarget, setIsChatTarget] = useState(false);

--- a/app/_components/PlaceCardDetail.tsx
+++ b/app/_components/PlaceCardDetail.tsx
@@ -239,14 +239,30 @@ interface PlaceCardDetailProps {
   discovery?: Partial<Discovery>;
 }
 
+function dedupeResolvedPlaceCardImages(images: Array<{ path: string; category: string }>): Array<{ path: string; category: string }> {
+  const deduped: Array<{ path: string; category: string }> = [];
+  const seen = new Set<string>();
+
+  for (const image of images) {
+    const resolvedPath = resolveImageUrlClient(image.path) || image.path;
+    if (!resolvedPath || seen.has(resolvedPath)) continue;
+    seen.add(resolvedPath);
+    deduped.push({
+      path: resolvedPath,
+      category: image.category,
+    });
+  }
+
+  return deduped;
+}
+
 export default function PlaceCardDetail({ card, userId, contextKey, discovery }: PlaceCardDetailProps) {
   const typeMeta = getTypeMeta(card.type);
   const data = card.data ?? { description: '', highlights: [], images: [] };
 
-  // Hero image — prefer interior_vibe category, then first available
-  const allImages = (data.images ?? []) as Array<{ path: string; category: string }>;
+  const allImages = dedupeResolvedPlaceCardImages((data.images ?? []) as Array<{ path: string; category: string }>);
   const heroImg = allImages.find(i => i.category === 'interior_vibe') || allImages[0];
-  const heroImage = heroImg ? resolveImageUrlClient(heroImg.path) : null;
+  const heroImage = heroImg?.path ?? null;
   const gradient = TYPE_GRADIENTS[card.type] || DEFAULT_GRADIENT;
   const isDark = DARK_TYPES.has(card.type);
   const isDevelopment = card.type === 'development';
@@ -307,10 +323,11 @@ export default function PlaceCardDetail({ card, userId, contextKey, discovery }:
     ? `https://earth.google.com/web/search/${encodeURIComponent([card.name, city || address?.split(',').slice(-2, -1)[0]?.trim()].filter(Boolean).join(' '))}`
     : null;
 
-  // Photo gallery — exclude hero, categorize
-  const foodPhotos = allImages.filter(i => ['food', 'drinks'].includes(i.category) && i !== heroImg);
-  const interiorPhotos = allImages.filter(i => ['interior_vibe', 'interior_detail'].includes(i.category) && i !== heroImg);
-  const otherPhotos = allImages.filter(i => !['food', 'drinks', 'interior_vibe', 'interior_detail'].includes(i.category) && i !== heroImg);
+  const gallerySeed = allImages.filter(i => i !== heroImg);
+  const galleryImages = gallerySeed.length >= 3 ? gallerySeed : allImages.slice(0, Math.max(3, allImages.length));
+  const foodPhotos = galleryImages.filter(i => ['food', 'drinks'].includes(i.category));
+  const interiorPhotos = galleryImages.filter(i => ['interior_vibe', 'interior_detail'].includes(i.category));
+  const otherPhotos = galleryImages.filter(i => !['food', 'drinks', 'interior_vibe', 'interior_detail'].includes(i.category));
 
   return (
     <div className={`place-detail-v2 ${isDark ? 'place-detail-dark' : ''}`}>
@@ -518,7 +535,7 @@ export default function PlaceCardDetail({ card, userId, contextKey, discovery }:
         )}
 
         {/* Interior gallery — below fold, for applicable types */}
-        {hasInteriorGallery && (interiorPhotos.length > 0 || otherPhotos.length > 0) && (
+        {hasInteriorGallery && galleryImages.length > 0 && (interiorPhotos.length > 0 || otherPhotos.length > 0) && (
           <div className="place-detail-v2-interior-gallery">
             <PhotoGallery images={[...interiorPhotos, ...otherPhotos]} />
           </div>

--- a/app/_components/ReviewContextClient.tsx
+++ b/app/_components/ReviewContextClient.tsx
@@ -9,6 +9,7 @@ import TypeBadge from './TypeBadge';
 import TriageButtons from './TriageButtons';
 import ReviewMarkersMap from './ReviewMarkersMap';
 import AccommodationReviewLayout from './AccommodationReviewLayout';
+import { getDiscoveryPrimaryImageUrl } from '../_lib/image-url';
 
 type Tab = 'unreviewed' | 'saved' | 'dismissed';
 
@@ -245,12 +246,7 @@ export default function ReviewContextClient({
                 {group.items.map(d => {
                   const placeId = d.place_id ?? d.id;
                   const entry = getTriageEntry(userId, context.key, placeId);
-                  const heroImage = (d as unknown as Record<string,string>).heroImage;
-                  const resolvedHero = heroImage
-                    ? (heroImage.startsWith('http') ? heroImage
-                      : heroImage.startsWith('/cottages/') || heroImage.startsWith('/developments/') ? heroImage
-                      : `${process.env.NEXT_PUBLIC_BLOB_BASE_URL || ''}${heroImage}`)
-                    : null;
+                  const resolvedHero = getDiscoveryPrimaryImageUrl(d);
                   // Distance badge for anchor contexts
                   const distanceM = (d as unknown as { distanceM?: number }).distanceM;
                   const walkable = context.anchor && distanceM !== undefined

--- a/app/_lib/card-adapter.ts
+++ b/app/_lib/card-adapter.ts
@@ -4,6 +4,7 @@
    ============================================================ */
 
 import type { PlaceCard, DiscoveryType } from './types';
+import { mergePlaceCardImages } from './image-url';
 
 // V1 card.json structure
 interface V1Card {
@@ -60,9 +61,18 @@ function normalizeType(raw?: string): DiscoveryType {
  * Optionally pass manifest data to include image URLs.
  */
 export function adaptCard(raw: Record<string, unknown>, manifest?: Record<string, unknown>): PlaceCard {
+  const manifestImages = manifest?.images as Array<{ path?: string; category?: string }> | undefined;
+
   // Already V2 format?
   if (raw.data && typeof raw.data === 'object' && raw.type) {
-    return raw as unknown as PlaceCard;
+    const v2 = raw as unknown as PlaceCard;
+    return {
+      ...v2,
+      data: {
+        ...v2.data,
+        images: mergePlaceCardImages(v2.data.images, manifestImages),
+      },
+    };
   }
 
   // V1 format
@@ -165,17 +175,7 @@ export function adaptCard(raw: Record<string, unknown>, manifest?: Record<string
     }
   }
 
-  // Merge images from manifest if available
-  if (manifest) {
-    const manifestImages = manifest.images as Array<{ path?: string; category?: string }> | undefined;
-    if (manifestImages && manifestImages.length > 0 && images.length === 0) {
-      for (const img of manifestImages) {
-        if (img.path) {
-          images.push({ path: img.path, category: img.category ?? 'general' });
-        }
-      }
-    }
-  }
+  const mergedImages = mergePlaceCardImages(images, manifestImages);
 
   return {
     place_id: v1.place_id ?? identity.place_id ?? '',
@@ -185,7 +185,7 @@ export function adaptCard(raw: Record<string, unknown>, manifest?: Record<string
       description,
       highlights,
       hours,
-      images,
+      images: mergedImages,
       ...(menu ? { menu } : {}),
       ...(rating !== undefined ? { rating } : {}),
       ...(reviewCount !== undefined ? { reviewCount } : {}),

--- a/app/_lib/discovery-monitoring.ts
+++ b/app/_lib/discovery-monitoring.ts
@@ -11,6 +11,7 @@ import type {
 } from './types';
 import { getDiscoveryHistoryKey, listRecentDiscoveryHistory } from './discovery-history';
 import { loadCheckinStore, getLatestCheckinAt } from './monitor-checkins';
+import { loadMonitorInventory } from './monitor-inventory';
 
 const BLOB_PREFIX = 'users';
 const MONITOR_HISTORY_LIMIT = 60;
@@ -411,11 +412,32 @@ export async function annotateDiscoveriesForMonitoring(params: {
   contexts: Context[];
 }): Promise<Discovery[]> {
   const { userId, discoveries, contexts } = params;
-  const [triageStore, historyEvents, checkinStore] = await Promise.all([
+  const [triageStore, historyEvents, checkinStore, monitorInventory] = await Promise.all([
     loadServerTriageStore(userId),
     listRecentDiscoveryHistory(userId, MONITOR_HISTORY_LIMIT),
     loadCheckinStore(userId),
+    loadMonitorInventory(userId),
   ]);
+
+  // Build a lookup from discovery key to inventory entry for timing overlay
+  const inventoryByKey = new Map<string, { lastObservedAt?: string; nextCheckAt?: string }>();
+  for (const entry of monitorInventory.entries) {
+    const key = getDiscoveryHistoryKey({
+      id: entry.discoveryId,
+      place_id: entry.place_id,
+      name: entry.name,
+      city: entry.city,
+      type: entry.type as Discovery['type'],
+      contextKey: entry.contextKey,
+      source: 'inventory',
+      discoveredAt: entry.firstPromotedAt,
+      placeIdStatus: entry.place_id ? 'verified' : 'pending',
+    });
+    inventoryByKey.set(key, {
+      lastObservedAt: entry.lastObservedAt,
+      nextCheckAt: entry.nextCheckAt,
+    });
+  }
 
   const observations = summarizeObservations(discoveries, historyEvents);
   const activeTripContextKeys = new Set(
@@ -465,9 +487,26 @@ export async function annotateDiscoveriesForMonitoring(params: {
     });
     const monitorSources = getMonitorSources(discovery, monitorStatus);
     const checkinAt = getLatestCheckinAt(checkinStore, getDiscoveryHistoryKey(discovery));
-    // Checkin timestamp wins over discovery history (most recent manual review resets the clock)
-    const monitorLastObservedAt = latestIso(checkinAt, observation.lastObservedAt) ?? discovery.discoveredAt;
-    const monitorNextCheckAt = monitorStatus === 'none' ? undefined : getNextCheckAt(monitorLastObservedAt, monitorCadence);
+
+    // Look up matching inventory entry for timing overlay
+    const discoveryKey = getDiscoveryHistoryKey(discovery);
+    const inventoryTiming = inventoryByKey.get(discoveryKey);
+
+    // Overlay inventory timing when available (actual observation cadence from durable inventory)
+    // Priority: inventory > checkin > discovery history > discoveredAt
+    let monitorLastObservedAt: string | undefined;
+    let monitorNextCheckAt: string | undefined;
+
+    if (inventoryTiming) {
+      // Use real observation timing from inventory
+      monitorLastObservedAt = inventoryTiming.lastObservedAt ?? latestIso(checkinAt, observation.lastObservedAt) ?? discovery.discoveredAt;
+      monitorNextCheckAt = inventoryTiming.nextCheckAt ?? (monitorStatus === 'none' ? undefined : getNextCheckAt(monitorLastObservedAt, monitorCadence));
+    } else {
+      // Fall back to discovery-history based timing
+      monitorLastObservedAt = latestIso(checkinAt, observation.lastObservedAt) ?? discovery.discoveredAt;
+      monitorNextCheckAt = monitorStatus === 'none' ? undefined : getNextCheckAt(monitorLastObservedAt, monitorCadence);
+    }
+
     const monitorDueNow = Boolean(monitorNextCheckAt && new Date(monitorNextCheckAt).getTime() <= Date.now());
 
     const explanationParts: string[] = [];

--- a/app/_lib/image-url.ts
+++ b/app/_lib/image-url.ts
@@ -1,3 +1,5 @@
+import type { Discovery, PlaceCardImage } from './types';
+
 /* ============================================================
    Compass v2 — Unified Image URL Resolution
    SINGLE source of truth for ALL image paths.
@@ -40,3 +42,59 @@ export function resolveImageUrlClient(path: string | undefined | null): string |
   if (path.startsWith('/') && base) return `${base}${path}`;
   return path;
 }
+
+function pushUniqueImage(
+  target: string[],
+  seen: Set<string>,
+  rawPath: string | undefined | null,
+) {
+  const resolved = resolveImageUrl(rawPath);
+  if (!resolved || seen.has(resolved)) return;
+  seen.add(resolved);
+  target.push(resolved);
+}
+
+export function getDiscoveryImageUrls(
+  discovery: Pick<Discovery, 'heroImage' | 'images'> | null | undefined,
+): string[] {
+  const urls: string[] = [];
+  const seen = new Set<string>();
+
+  pushUniqueImage(urls, seen, discovery?.heroImage);
+  for (const image of discovery?.images ?? []) {
+    pushUniqueImage(urls, seen, image?.url);
+  }
+
+  return urls;
+}
+
+export function getDiscoveryPrimaryImageUrl(
+  discovery: Pick<Discovery, 'heroImage' | 'images'> | null | undefined,
+): string | null {
+  return getDiscoveryImageUrls(discovery)[0] ?? null;
+}
+
+export function mergePlaceCardImages(
+  images: Array<{ path?: string | null; category?: string | null }> | undefined,
+  manifestImages: Array<{ path?: string | null; category?: string | null }> | undefined,
+): PlaceCardImage[] {
+  const merged: PlaceCardImage[] = [];
+  const seen = new Set<string>();
+
+  const push = (image: { path?: string | null; category?: string | null } | undefined | null) => {
+    if (!image?.path) return;
+    const resolved = resolveImageUrl(image.path) || image.path;
+    if (seen.has(resolved)) return;
+    seen.add(resolved);
+    merged.push({
+      path: image.path,
+      category: image.category || 'general',
+    });
+  };
+
+  for (const image of images ?? []) push(image);
+  for (const image of manifestImages ?? []) push(image);
+
+  return merged;
+}
+

--- a/app/_lib/observation-runner.test.ts
+++ b/app/_lib/observation-runner.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for observation-runner helpers
+ *
+ * Run: npx tsx app/_lib/observation-runner.test.ts
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { selectWebEnrichmentCandidates, baseIntervalMs, computeNextCheckAt } from './observation-runner';
+import type { MonitorEntry, MonitorObservation, ObservedState } from './monitor-inventory';
+
+function makeObservedState(overrides: Partial<ObservedState> = {}): ObservedState {
+  return {
+    observedAt: new Date().toISOString(),
+    source: 'google-places',
+    rating: 4.5,
+    reviewCount: 100,
+    ...overrides,
+  };
+}
+
+function makeObservation(overrides: Partial<MonitorObservation> = {}): MonitorObservation {
+  return {
+    observedAt: new Date().toISOString(),
+    source: 'google-places',
+    changes: [],
+    state: makeObservedState(),
+    significanceLevel: 'routine',
+    significanceScore: 10,
+    significanceSummary: 'Routine check',
+    ...overrides,
+  };
+}
+
+function makeEntry(overrides: Partial<MonitorEntry> = {}): MonitorEntry {
+  return {
+    id: `entry-${Math.random()}`,
+    discoveryId: `disc-${Math.random()}`,
+    name: 'Test Place',
+    city: 'Test City',
+    contextKey: 'test-context',
+    type: 'restaurant',
+    monitorStatus: 'candidate',
+    monitorType: 'hospitality',
+    monitorReasons: [],
+    monitorDimensions: [],
+    firstPromotedAt: new Date().toISOString(),
+    lastUpdatedAt: new Date().toISOString(),
+    observations: [],
+    detectedChangeKinds: [],
+    ...overrides,
+  };
+}
+
+describe('selectWebEnrichmentCandidates', () => {
+  it('returns empty for empty input', () => {
+    const result = selectWebEnrichmentCandidates([], 3);
+    assert.deepStrictEqual(result, []);
+  });
+
+  it('filters entries without place_id', () => {
+    const entries = [
+      makeEntry({ id: '1', place_id: 'place1' }),
+      makeEntry({ id: '2', place_id: undefined }),
+      makeEntry({ id: '3', place_id: 'place3' }),
+    ];
+    const result = selectWebEnrichmentCandidates(entries, 3);
+    assert.ok(result.includes('1'));
+    assert.ok(result.includes('3'));
+    assert.ok(!result.includes('2'));
+  });
+
+  it('prioritizes priority status entries', () => {
+    const entries = [
+      makeEntry({ id: 'candidate', monitorStatus: 'candidate', place_id: 'place-candidate' }),
+      makeEntry({ id: 'priority', monitorStatus: 'priority', place_id: 'place-priority' }),
+      makeEntry({ id: 'active', monitorStatus: 'active', place_id: 'place-active' }),
+    ];
+    const result = selectWebEnrichmentCandidates(entries, 2);
+    assert.strictEqual(result[0], 'priority');
+  });
+
+  it('sorts by significance score within same status', () => {
+    const entries = [
+      makeEntry({ id: 'low', monitorStatus: 'active', place_id: 'place-low', observations: [makeObservation({ significanceScore: 10 })] }),
+      makeEntry({ id: 'high', monitorStatus: 'active', place_id: 'place-high', observations: [makeObservation({ significanceScore: 90 })] }),
+    ];
+    const result = selectWebEnrichmentCandidates(entries, 2);
+    assert.strictEqual(result[0], 'high');
+  });
+
+  it('respects the limit', () => {
+    const entries = [
+      makeEntry({ id: '1', place_id: 'p1', monitorStatus: 'priority' }),
+      makeEntry({ id: '2', place_id: 'p2', monitorStatus: 'active' }),
+      makeEntry({ id: '3', place_id: 'p3', monitorStatus: 'candidate' }),
+      makeEntry({ id: '4', place_id: 'p4', monitorStatus: 'candidate' }),
+    ];
+    const result = selectWebEnrichmentCandidates(entries, 2);
+    assert.strictEqual(result.length, 2);
+  });
+});
+
+describe('baseIntervalMs', () => {
+  it('returns 7 days for hospitality', () => {
+    assert.strictEqual(baseIntervalMs('hospitality'), 7 * 24 * 60 * 60 * 1000);
+  });
+
+  it('returns 14 days for stay', () => {
+    assert.strictEqual(baseIntervalMs('stay'), 14 * 24 * 60 * 60 * 1000);
+  });
+
+  it('returns 14 days for development', () => {
+    assert.strictEqual(baseIntervalMs('development'), 14 * 24 * 60 * 60 * 1000);
+  });
+
+  it('returns 14 days for culture', () => {
+    assert.strictEqual(baseIntervalMs('culture'), 14 * 24 * 60 * 60 * 1000);
+  });
+
+  it('returns 14 days for general (default)', () => {
+    assert.strictEqual(baseIntervalMs('general'), 14 * 24 * 60 * 60 * 1000);
+    assert.strictEqual(baseIntervalMs('unknown'), 14 * 24 * 60 * 60 * 1000);
+  });
+});
+
+describe('computeNextCheckAt', () => {
+  it('uses 2 days for critical significance', () => {
+    const entry = makeEntry({
+      monitorType: 'hospitality',
+      observations: [makeObservation({ significanceLevel: 'critical' })],
+    });
+    const observedAt = new Date().toISOString();
+    const result = computeNextCheckAt(entry, observedAt);
+    const expectedMs = new Date(observedAt).getTime() + 2 * 24 * 60 * 60 * 1000;
+    assert.ok(Math.abs(new Date(result).getTime() - expectedMs) < 1000);
+  });
+
+  it('uses 5 days for notable significance', () => {
+    const entry = makeEntry({
+      monitorType: 'hospitality',
+      observations: [makeObservation({ significanceLevel: 'notable' })],
+    });
+    const observedAt = new Date().toISOString();
+    const result = computeNextCheckAt(entry, observedAt);
+    const expectedMs = new Date(observedAt).getTime() + 5 * 24 * 60 * 60 * 1000;
+    assert.ok(Math.abs(new Date(result).getTime() - expectedMs) < 1000);
+  });
+
+  it('halves interval for priority status', () => {
+    const entry = makeEntry({
+      monitorType: 'hospitality',
+      monitorStatus: 'priority',
+      observations: [makeObservation({ significanceLevel: 'routine' })],
+    });
+    const observedAt = new Date().toISOString();
+    const result = computeNextCheckAt(entry, observedAt);
+    // hospitality base is 7 days, halved = 3.5 days
+    const expectedMs = new Date(observedAt).getTime() + Math.floor(7 * 24 * 60 * 60 * 1000 * 0.5);
+    assert.ok(Math.abs(new Date(result).getTime() - expectedMs) < 1000);
+  });
+
+  it('uses base interval for routine significance', () => {
+    const entry = makeEntry({
+      monitorType: 'stay', // 14 days
+      monitorStatus: 'active',
+      observations: [makeObservation({ significanceLevel: 'routine' })],
+    });
+    const observedAt = new Date().toISOString();
+    const result = computeNextCheckAt(entry, observedAt);
+    const expectedMs = new Date(observedAt).getTime() + 14 * 24 * 60 * 60 * 1000;
+    assert.ok(Math.abs(new Date(result).getTime() - expectedMs) < 1000);
+  });
+});

--- a/app/_lib/observation-runner.ts
+++ b/app/_lib/observation-runner.ts
@@ -1,0 +1,356 @@
+/**
+ * Observation Runner Shared Helpers
+ *
+ * Bounded concurrency, fetch timeouts, and web enrichment gating
+ * for the monitoring observation pipeline.
+ */
+
+import { recordObservation, type MonitorEntry, type ObservedState } from './monitor-inventory';
+import { runWebEnrichment } from './web-search-enrichment';
+
+// ---- Constants ----
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Maximum concurrent Places API calls */
+export const MAX_CONCURRENT_PLACES = 3;
+
+/** Timeout for Places API fetch (ms) */
+export const PLACES_FETCH_TIMEOUT_MS = 8000;
+
+/** Maximum web enrichments per observation run (gated to preserve quota) */
+export const MAX_WEB_ENRICHMENTS_PER_RUN = 2;
+
+// ---- Types ----
+
+export interface PlaceData {
+  rating?: number;
+  userRatingCount?: number;
+  businessStatus?: string;
+  priceLevel?: string;
+  editorialSummary?: { text?: string };
+}
+
+export interface ObservationResult {
+  entryId: string;
+  name: string;
+  status: 'observed' | 'skipped-no-place-id' | 'skipped-fetch-failed' | 'skipped-timeout';
+  changes?: string[];
+  significanceLevel?: string;
+  significanceScore?: number;
+  significanceSummary?: string;
+  nextCheckAt?: string;
+  webChanges?: string[];
+}
+
+export interface RunSummary {
+  observed: number;
+  skipped: number;
+  withChanges: number;
+  withWebSignals: number;
+  results: ObservationResult[];
+}
+
+// ---- Helper: Fetch with timeout ----
+
+const PLACES_SERVER_KEY = process.env.GOOGLE_PLACES_SERVER_KEY;
+
+export async function fetchPlaceDetailsWithTimeout(placeId: string): Promise<PlaceData | null> {
+  if (!PLACES_SERVER_KEY) return null;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), PLACES_FETCH_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(
+      `https://places.googleapis.com/v1/places/${placeId}`,
+      {
+        headers: {
+          'X-Goog-Api-Key': PLACES_SERVER_KEY,
+          'X-Goog-FieldMask': 'id,displayName,rating,userRatingCount,businessStatus,priceLevel,editorialSummary',
+        },
+        signal: controller.signal,
+      },
+    );
+    clearTimeout(timeoutId);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (err) {
+    clearTimeout(timeoutId);
+    // Treat abort (timeout) as null
+    if (err instanceof Error && err.name === 'AbortError') {
+      console.log(`[observation-runner] Places fetch timeout for ${placeId}`);
+      return null;
+    }
+    console.error(`[observation-runner] Places fetch error for ${placeId}:`, err);
+    return null;
+  }
+}
+
+// ---- Helper: Map price level ----
+
+export function priceLevelToNumber(level?: string): number | undefined {
+  if (!level) return undefined;
+  const map: Record<string, number> = {
+    PRICE_LEVEL_FREE: 0,
+    PRICE_LEVEL_INEXPENSIVE: 1,
+    PRICE_LEVEL_MODERATE: 2,
+    PRICE_LEVEL_EXPENSIVE: 3,
+    PRICE_LEVEL_VERY_EXPENSIVE: 4,
+  };
+  return map[level];
+}
+
+// ---- Helper: Map operational status ----
+
+export function mapBusinessStatus(status?: string): string | undefined {
+  if (!status) return undefined;
+  const map: Record<string, string> = {
+    OPERATIONAL: 'OPERATIONAL',
+    CLOSED_TEMPORARILY: 'CLOSED_TEMPORARILY',
+    CLOSED_PERMANENTLY: 'CLOSED_PERMANENTLY',
+  };
+  return map[status] ?? status;
+}
+
+// ---- Helper: Build observed state ----
+
+export function buildObservedState(data: PlaceData): ObservedState {
+  const now = new Date().toISOString();
+  return {
+    observedAt: now,
+    source: 'google-places',
+    rating: data.rating,
+    reviewCount: data.userRatingCount,
+    description: data.editorialSummary?.text,
+    operationalStatus: mapBusinessStatus(data.businessStatus),
+    priceLevel: priceLevelToNumber(data.priceLevel),
+  };
+}
+
+// ---- Helper: Compute next check time ----
+
+/**
+ * Base check interval by monitorType.
+ */
+export function baseIntervalMs(monitorType: string): number {
+  const cadenceMap: Record<string, number> = {
+    hospitality: 7 * DAY_MS,   // weekly — restaurants/bars change frequently
+    stay: 14 * DAY_MS,        // bi-weekly — hotels/rentals
+    development: 14 * DAY_MS, // bi-weekly — construction timelines
+    culture: 14 * DAY_MS,     // bi-weekly — museums/galleries
+    general: 14 * DAY_MS,     // bi-weekly — default
+  };
+  return cadenceMap[monitorType] ?? cadenceMap.general ?? 14 * DAY_MS;
+}
+
+/**
+ * Compute next check time for a monitor entry.
+ *
+ * Adaptive scheduling:
+ *  - critical significance → re-check in 2 days
+ *  - notable significance  → re-check in 5 days
+ *  - priority status       → halve the base cadence
+ *  - routine / noise       → use full base cadence
+ */
+export function computeNextCheckAt(entry: MonitorEntry, observedAt: string): string {
+  const base = baseIntervalMs(entry.monitorType);
+  const latestObs = entry.observations?.[0];
+  const latestLevel = latestObs?.significanceLevel;
+
+  let intervalMs: number;
+  if (latestLevel === 'critical') {
+    intervalMs = 2 * DAY_MS;
+  } else if (latestLevel === 'notable') {
+    intervalMs = 5 * DAY_MS;
+  } else {
+    intervalMs = entry.monitorStatus === 'priority' ? Math.floor(base * 0.5) : base;
+  }
+
+  const baseMs = new Date(observedAt).getTime();
+  return new Date(baseMs + intervalMs).toISOString();
+}
+
+// ---- Helper: Run bounded concurrent observation ----
+
+/**
+ * Run observations for a batch of entries with bounded concurrency.
+ * Gates web enrichment to a small capped subset of high-priority entries.
+ */
+export async function runObservations(params: {
+  userId: string;
+  entries: MonitorEntry[];
+  maxConcurrent?: number;
+  maxWebEnrichments?: number;
+  dryRun?: boolean;
+}): Promise<RunSummary> {
+  const { userId, entries, maxConcurrent = MAX_CONCURRENT_PLACES, maxWebEnrichments = MAX_WEB_ENRICHMENTS_PER_RUN, dryRun = false } = params;
+
+  const results: ObservationResult[] = entries
+    .filter(entry => !entry.place_id)
+    .map(entry => ({
+      entryId: entry.id,
+      name: entry.name,
+      status: 'skipped-no-place-id' as const,
+    }));
+  let observed = 0;
+  let skipped = 0;
+  let withChanges = 0;
+  let withWebSignals = 0;
+
+  const validEntries = entries.filter(e => e.place_id);
+  if (validEntries.length === 0) {
+    return { observed: 0, skipped: results.length, withChanges: 0, withWebSignals: 0, results };
+  }
+
+  const webEnrichmentCandidates = new Set(
+    selectWebEnrichmentCandidates(validEntries, maxWebEnrichments),
+  );
+
+  let webEnrichmentCount = 0;
+
+  // Process with bounded concurrency
+  const queue = [...validEntries];
+  const running: Promise<void>[] = [];
+
+  const processEntry = async (entry: MonitorEntry): Promise<void> => {
+    // Places fetch with timeout
+    const placeData = await fetchPlaceDetailsWithTimeout(entry.place_id!);
+    if (!placeData) {
+      results.push({
+        entryId: entry.id,
+        name: entry.name,
+        status: 'skipped-fetch-failed',
+      });
+      return;
+    }
+
+    const observedState = buildObservedState(placeData);
+    const now = observedState.observedAt;
+
+    if (dryRun) {
+      results.push({
+        entryId: entry.id,
+        name: entry.name,
+        status: 'observed',
+        nextCheckAt: computeNextCheckAt(entry, now),
+      });
+      return;
+    }
+
+    // Record the observation
+    const nextCheck = computeNextCheckAt(entry, now);
+    const updated = await recordObservation({
+      userId,
+      entryId: entry.id,
+      observation: {
+        observedAt: now,
+        source: 'google-places',
+        state: observedState,
+      },
+      nextCheckAt: nextCheck,
+    });
+
+    const latestObs = updated?.observations?.[0];
+    const result: ObservationResult = {
+      entryId: entry.id,
+      name: entry.name,
+      status: 'observed',
+      changes: latestObs?.changes ?? [],
+      significanceLevel: latestObs?.significanceLevel,
+      significanceScore: latestObs?.significanceScore,
+      significanceSummary: latestObs?.significanceSummary,
+      nextCheckAt: updated?.nextCheckAt,
+    };
+
+    // Web enrichment (gated to top candidates)
+    if (webEnrichmentCandidates.has(entry.id) && webEnrichmentCount < maxWebEnrichments) {
+      webEnrichmentCount++;
+      const webEnrichment = await runWebEnrichment({
+        name: entry.name,
+        city: entry.city,
+        monitorType: entry.monitorType,
+      });
+      if (webEnrichment && webEnrichment.changes.length > 0) {
+        const webObsAt = new Date().toISOString();
+        await recordObservation({
+          userId,
+          entryId: entry.id,
+          observation: {
+            observedAt: webObsAt,
+            source: 'web-search',
+            changes: webEnrichment.changes,
+            changeSummary: `Web signals: ${webEnrichment.changes.join(', ')}`,
+            state: {
+              observedAt: webObsAt,
+              source: 'web-search',
+              notes: webEnrichment.notes,
+            },
+          },
+        });
+        result.webChanges = webEnrichment.changes.map(String);
+      }
+    }
+
+    results.push(result);
+  };
+
+  // Run with bounded concurrency
+  for (const entry of queue) {
+    // Wait if we've hit the concurrency limit
+    if (running.length >= maxConcurrent) {
+      await Promise.race(running);
+    }
+
+    const promise = processEntry(entry).then(() => {
+      running.splice(running.findIndex(p => p === promise), 1);
+    });
+    running.push(promise);
+  }
+
+  // Wait for remaining
+  await Promise.all(running);
+
+  // Compute summary from results
+  for (const r of results) {
+    if (r.status === 'observed') {
+      observed++;
+      if (r.changes && r.changes.length > 0) withChanges++;
+      if (r.webChanges && r.webChanges.length > 0) withWebSignals++;
+    } else {
+      skipped++;
+    }
+  }
+
+  return { observed, skipped, withChanges, withWebSignals, results };
+}
+
+// ---- Helper: Select web enrichment candidates ----
+
+/**
+ * Select entries that should receive web enrichment.
+ * Prioritizes: priority status, then highest significance score, then recent changes.
+ */
+export function selectWebEnrichmentCandidates(entries: MonitorEntry[], limit: number): string[] {
+  return entries
+    .filter(e => e.place_id)
+    .sort((a, b) => {
+      // Priority status first
+      const statusRank: Record<string, number> = { priority: 0, active: 1, candidate: 2 };
+      const aRank = statusRank[a.monitorStatus] ?? 3;
+      const bRank = statusRank[b.monitorStatus] ?? 3;
+      if (aRank !== bRank) return aRank - bRank;
+
+      // Then significance score (higher first)
+      const aScore = a.observations?.[0]?.significanceScore ?? 0;
+      const bScore = b.observations?.[0]?.significanceScore ?? 0;
+      if (bScore !== aScore) return bScore - aScore;
+
+      // Then recent changes (more = higher priority)
+      const aChanges = a.observations?.[0]?.changes?.length ?? 0;
+      const bChanges = b.observations?.[0]?.changes?.length ?? 0;
+      return bChanges - aChanges;
+    })
+    .slice(0, limit)
+    .map(e => e.id);
+}

--- a/app/_lib/trip-emergence.ts
+++ b/app/_lib/trip-emergence.ts
@@ -1,0 +1,64 @@
+export interface TripEmergenceSnapshot {
+  key: string;
+  label?: string;
+  type?: string;
+  emoji?: string;
+  dates?: string;
+  city?: string;
+  focus?: string[];
+  purpose?: string;
+  people?: Array<{ name: string; relation?: string }>;
+}
+
+export interface TripAttributeChip {
+  field: 'dates' | 'city' | 'focus' | 'purpose' | 'people';
+  value: string;
+}
+
+function normalizePeople(people: TripEmergenceSnapshot['people']): string[] {
+  if (!Array.isArray(people)) return [];
+  return people
+    .map(person => {
+      if (!person || typeof person.name !== 'string') return null;
+      const name = person.name.trim();
+      const relation = typeof person.relation === 'string' ? person.relation.trim() : '';
+      if (!name) return null;
+      return relation ? `${name} (${relation})` : name;
+    })
+    .filter((value): value is string => Boolean(value));
+}
+
+export function diffTripEmergenceAttributes(
+  previous: TripEmergenceSnapshot | undefined,
+  next: TripEmergenceSnapshot,
+): TripAttributeChip[] {
+  if (!previous) return [];
+
+  const changedAttrs: TripAttributeChip[] = [];
+
+  if (next.dates && next.dates !== previous.dates) {
+    changedAttrs.push({ field: 'dates', value: next.dates });
+  }
+
+  if (next.city && next.city !== previous.city) {
+    changedAttrs.push({ field: 'city', value: next.city });
+  }
+
+  const newFocus = (next.focus ?? []).filter(f => !(previous.focus ?? []).includes(f));
+  if (newFocus.length > 0) {
+    changedAttrs.push({ field: 'focus', value: newFocus.join(', ') });
+  }
+
+  if (next.purpose && next.purpose !== previous.purpose) {
+    changedAttrs.push({ field: 'purpose', value: next.purpose });
+  }
+
+  const previousPeople = normalizePeople(previous.people);
+  const nextPeople = normalizePeople(next.people);
+  const newPeople = nextPeople.filter(person => !previousPeople.includes(person));
+  if (newPeople.length > 0) {
+    changedAttrs.push({ field: 'people', value: newPeople.join(', ') });
+  }
+
+  return changedAttrs;
+}

--- a/app/_lib/web-search-enrichment.ts
+++ b/app/_lib/web-search-enrichment.ts
@@ -14,6 +14,8 @@
 
 import type { MonitorChangeKind } from './monitor-inventory';
 
+const WEB_ENRICHMENT_FETCH_TIMEOUT_MS = 5000;
+
 // ---- Types ----
 
 export interface WebEnrichmentResult {
@@ -181,6 +183,9 @@ export async function runWebEnrichment(params: {
   const query = buildSearchQuery({ name, city, monitorType });
 
   let results: BraveWebResult[] = [];
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), WEB_ENRICHMENT_FETCH_TIMEOUT_MS);
+
   try {
     const url = `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}&count=5&freshness=pm`;
     const res = await fetch(url, {
@@ -188,6 +193,7 @@ export async function runWebEnrichment(params: {
         'X-Subscription-Token': apiKey,
         'Accept': 'application/json',
       },
+      signal: controller.signal,
     });
     if (!res.ok) {
       console.error(`[web-enrichment] Brave search error ${res.status} for "${name}"`);
@@ -196,8 +202,14 @@ export async function runWebEnrichment(params: {
     const data = await res.json();
     results = (data.web?.results ?? []).slice(0, 5) as BraveWebResult[];
   } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      console.error(`[web-enrichment] Search timeout for "${name}"`);
+      return null;
+    }
     console.error(`[web-enrichment] Search failed for "${name}":`, err);
     return null;
+  } finally {
+    clearTimeout(timeoutId);
   }
 
   if (results.length === 0) return null;

--- a/app/api/internal/cron-observations/route.ts
+++ b/app/api/internal/cron-observations/route.ts
@@ -8,22 +8,21 @@
  * Gracefully skips users with no due entries.
  *
  * Schedule: twice daily (see vercel.json)
- * Budget: 30s per user batch, 5 entries per user per run to stay within limits.
+ * Budget: 60s per user batch, 15 entries per user per run for better backlog drain.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getAllUsers } from '../../../_lib/user';
-import { loadMonitorInventory, getDueEntries, recordObservation } from '../../../_lib/monitor-inventory';
-import { runWebEnrichment } from '../../../_lib/web-search-enrichment';
+import { loadMonitorInventory, getDueEntries } from '../../../_lib/monitor-inventory';
+import { runObservations, MAX_CONCURRENT_PLACES, MAX_WEB_ENRICHMENTS_PER_RUN } from '../../../_lib/observation-runner';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
 const CRON_SECRET = process.env.CRON_SECRET;
-const PLACES_SERVER_KEY = process.env.GOOGLE_PLACES_SERVER_KEY;
 
-// Entries per user per cron run (conservative quota management)
-const ENTRIES_PER_USER = 5;
+// Entries per user per cron run (increased from 5 for better backlog drain)
+const ENTRIES_PER_USER = 15;
 
 // ---- Auth ----
 
@@ -33,74 +32,6 @@ function isAuthorized(request: NextRequest): boolean {
   if (!CRON_SECRET) return false;
   const auth = request.headers.get('authorization');
   return auth === `Bearer ${CRON_SECRET}`;
-}
-
-// ---- Places fetch (inline — same logic as run-observations) ----
-
-interface PlaceData {
-  rating?: number;
-  userRatingCount?: number;
-  businessStatus?: string;
-  priceLevel?: string;
-  editorialSummary?: { text?: string };
-}
-
-async function fetchPlaceDetails(placeId: string): Promise<PlaceData | null> {
-  if (!PLACES_SERVER_KEY) return null;
-  try {
-    const res = await fetch(
-      `https://places.googleapis.com/v1/places/${placeId}`,
-      {
-        headers: {
-          'X-Goog-Api-Key': PLACES_SERVER_KEY,
-          'X-Goog-FieldMask': 'id,displayName,rating,userRatingCount,businessStatus,priceLevel,editorialSummary',
-        },
-      },
-    );
-    if (!res.ok) return null;
-    return res.json();
-  } catch {
-    return null;
-  }
-}
-
-function priceLevelToNumber(level?: string): number | undefined {
-  if (!level) return undefined;
-  const map: Record<string, number> = {
-    PRICE_LEVEL_FREE: 0,
-    PRICE_LEVEL_INEXPENSIVE: 1,
-    PRICE_LEVEL_MODERATE: 2,
-    PRICE_LEVEL_EXPENSIVE: 3,
-    PRICE_LEVEL_VERY_EXPENSIVE: 4,
-  };
-  return map[level];
-}
-
-// ---- Cadence (mirrors run-observations) ----
-
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-import type { MonitorEntry } from '../../../_lib/monitor-inventory';
-
-function computeNextCheckAt(entry: MonitorEntry, observedAt: string): string {
-  const cadenceMap: Record<string, number> = {
-    hospitality: 7 * DAY_MS,
-    stay: 14 * DAY_MS,
-    development: 14 * DAY_MS,
-    culture: 14 * DAY_MS,
-    general: 14 * DAY_MS,
-  };
-  const base = cadenceMap[entry.monitorType] ?? 14 * DAY_MS;
-  const latestLevel = entry.observations?.[0]?.significanceLevel;
-  let intervalMs: number;
-  if (latestLevel === 'critical') {
-    intervalMs = 2 * DAY_MS;
-  } else if (latestLevel === 'notable') {
-    intervalMs = 5 * DAY_MS;
-  } else {
-    intervalMs = entry.monitorStatus === 'priority' ? Math.floor(base * 0.5) : base;
-  }
-  return new Date(new Date(observedAt).getTime() + intervalMs).toISOString();
 }
 
 // ---- Per-user observation run ----
@@ -138,75 +69,24 @@ async function runForUser(userId: string): Promise<UserRunSummary> {
 
     const batch = due.slice(0, ENTRIES_PER_USER);
 
-    for (const entry of batch) {
-      if (!entry.place_id) {
-        summary.skipped++;
-        continue;
-      }
+    if (batch.length === 0) return summary;
 
-      const placeData = await fetchPlaceDetails(entry.place_id);
-      if (!placeData) {
-        summary.skipped++;
-        continue;
-      }
+    // Run observations with bounded concurrency and web enrichment gating
+    const result = await runObservations({
+      userId,
+      entries: batch,
+      maxConcurrent: MAX_CONCURRENT_PLACES,
+      maxWebEnrichments: MAX_WEB_ENRICHMENTS_PER_RUN,
+    });
 
-      const now = new Date().toISOString();
-      const observedState = {
-        observedAt: now,
-        source: 'google-places' as const,
-        rating: placeData.rating,
-        reviewCount: placeData.userRatingCount,
-        description: placeData.editorialSummary?.text,
-        operationalStatus: placeData.businessStatus,
-        priceLevel: priceLevelToNumber(placeData.priceLevel),
-      };
+    summary.observed = result.observed;
+    summary.skipped = result.skipped;
+    summary.withChanges = result.withChanges;
 
-      const nextCheckAt = computeNextCheckAt(entry, now);
-
-      const updated = await recordObservation({
-        userId,
-        entryId: entry.id,
-        observation: {
-          observedAt: now,
-          source: 'google-places',
-          state: observedState,
-        },
-        nextCheckAt,
-      });
-
-      summary.observed++;
-
-      const latestObs = updated?.observations?.[0];
-      if (latestObs?.changes && latestObs.changes.length > 0) {
-        summary.withChanges++;
-        if (latestObs.significanceLevel === 'critical') {
-          summary.criticalChanges++;
-        }
-      }
-
-      // Web enrichment for notable context
-      const webEnrichment = await runWebEnrichment({
-        name: entry.name,
-        city: entry.city,
-        monitorType: entry.monitorType,
-      });
-      if (webEnrichment && webEnrichment.changes.length > 0) {
-        const webAt = new Date().toISOString();
-        await recordObservation({
-          userId,
-          entryId: entry.id,
-          observation: {
-            observedAt: webAt,
-            source: 'web-search',
-            changes: webEnrichment.changes,
-            changeSummary: `Web signals: ${webEnrichment.changes.join(', ')}`,
-            state: {
-              observedAt: webAt,
-              source: 'web-search',
-              notes: webEnrichment.notes,
-            },
-          },
-        });
+    // Count critical changes
+    for (const r of result.results) {
+      if (r.significanceLevel === 'critical') {
+        summary.criticalChanges++;
       }
     }
   } catch (err) {

--- a/app/api/internal/run-observations/route.ts
+++ b/app/api/internal/run-observations/route.ts
@@ -15,13 +15,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import {
   loadMonitorInventory,
   getDueEntries,
-  recordObservation,
 } from '../../../_lib/monitor-inventory';
-import type {
-  MonitorEntry,
-  ObservedState,
-} from '../../../_lib/monitor-inventory';
-import { runWebEnrichment } from '../../../_lib/web-search-enrichment';
+import {
+  runObservations,
+  MAX_CONCURRENT_PLACES,
+  MAX_WEB_ENRICHMENTS_PER_RUN,
+} from '../../../_lib/observation-runner';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 30;
@@ -29,143 +28,6 @@ export const maxDuration = 30;
 const PLACES_SERVER_KEY = process.env.GOOGLE_PLACES_SERVER_KEY;
 
 const DEFAULT_LIMIT = 10;
-
-// Fields to request from Places API (New)
-const PLACE_FIELDS = [
-  'places.id',
-  'places.displayName',
-  'places.rating',
-  'places.userRatingCount',
-  'places.businessStatus',
-  'places.currentOpeningHours',
-  'places.priceLevel',
-  'places.editorialSummary',
-  'places.websiteUri',
-].join(',');
-
-// ---- Google Places fetch ----
-
-interface PlaceData {
-  rating?: number;
-  userRatingCount?: number;
-  businessStatus?: string;
-  priceLevel?: string;
-  editorialSummary?: { text?: string };
-}
-
-async function fetchPlaceDetails(placeId: string): Promise<PlaceData | null> {
-  if (!PLACES_SERVER_KEY) return null;
-
-  try {
-    const url = `https://places.googleapis.com/v1/places/${placeId}`;
-    const res = await fetch(url, {
-      method: 'GET',
-      headers: {
-        'X-Goog-Api-Key': PLACES_SERVER_KEY,
-        'X-Goog-FieldMask': 'id,displayName,rating,userRatingCount,businessStatus,priceLevel,editorialSummary',
-      },
-    });
-    if (!res.ok) {
-      console.error(`Places API error for ${placeId}: ${res.status}`);
-      return null;
-    }
-    return await res.json();
-  } catch (err) {
-    console.error(`Places API fetch failed for ${placeId}:`, err);
-    return null;
-  }
-}
-
-// ---- Map price level strings to numeric ----
-
-function priceLevelToNumber(level?: string): number | undefined {
-  if (!level) return undefined;
-  const map: Record<string, number> = {
-    PRICE_LEVEL_FREE: 0,
-    PRICE_LEVEL_INEXPENSIVE: 1,
-    PRICE_LEVEL_MODERATE: 2,
-    PRICE_LEVEL_EXPENSIVE: 3,
-    PRICE_LEVEL_VERY_EXPENSIVE: 4,
-  };
-  return map[level];
-}
-
-// ---- Map operational status ----
-
-function mapBusinessStatus(status?: string): string | undefined {
-  if (!status) return undefined;
-  const map: Record<string, string> = {
-    OPERATIONAL: 'OPERATIONAL',
-    CLOSED_TEMPORARILY: 'CLOSED_TEMPORARILY',
-    CLOSED_PERMANENTLY: 'CLOSED_PERMANENTLY',
-  };
-  return map[status] ?? status;
-}
-
-// ---- Build observed state from Places data ----
-
-function buildObservedState(data: PlaceData): ObservedState {
-  const now = new Date().toISOString();
-  return {
-    observedAt: now,
-    source: 'google-places',
-    rating: data.rating,
-    reviewCount: data.userRatingCount,
-    description: data.editorialSummary?.text,
-    operationalStatus: mapBusinessStatus(data.businessStatus),
-    priceLevel: priceLevelToNumber(data.priceLevel),
-  };
-}
-
-// ---- Cadence computation ----
-
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-/**
- * Base check interval by monitorType.
- * Keys match Discovery['monitorType']: hospitality | stay | development | culture | general
- */
-function baseIntervalMs(monitorType: string): number {
-  const cadenceMap: Record<string, number> = {
-    'hospitality':  7 * DAY_MS,   // weekly — restaurants/bars change frequently
-    'stay':        14 * DAY_MS,   // bi-weekly — hotels/rentals
-    'development': 14 * DAY_MS,   // bi-weekly — construction timelines
-    'culture':     14 * DAY_MS,   // bi-weekly — museums/galleries
-    'general':     14 * DAY_MS,   // bi-weekly — default
-  };
-  return cadenceMap[monitorType] ?? cadenceMap.general ?? 14 * DAY_MS;
-}
-
-/**
- * Compute next check time for a monitor entry.
- *
- * Adaptive scheduling:
- *  - critical significance → re-check in 2 days (something may still be changing)
- *  - notable significance  → re-check in 5 days
- *  - priority status       → halve the base cadence
- *  - routine / noise       → use full base cadence
- *
- * This keeps critical/notable entries in tight review without burning quota
- * on quiet entries.
- */
-function computeNextCheckAt(entry: MonitorEntry, observedAt: string): string {
-  const base = baseIntervalMs(entry.monitorType);
-  const latestObs = entry.observations?.[0];
-  const latestLevel = latestObs?.significanceLevel;
-
-  let intervalMs: number;
-  if (latestLevel === 'critical') {
-    intervalMs = 2 * DAY_MS;    // re-check soon — situation may still be developing
-  } else if (latestLevel === 'notable') {
-    intervalMs = 5 * DAY_MS;    // elevated cadence while something meaningful is happening
-  } else {
-    // priority status halves the regular cadence; otherwise use base
-    intervalMs = entry.monitorStatus === 'priority' ? Math.floor(base * 0.5) : base;
-  }
-
-  const baseMs = new Date(observedAt).getTime();
-  return new Date(baseMs + intervalMs).toISOString();
-}
 
 // ---- GET: status check (how many due?) ----
 
@@ -186,18 +48,6 @@ export async function GET(request: NextRequest) {
 }
 
 // ---- POST: run observations ----
-
-interface RunResult {
-  entryId: string;
-  name: string;
-  status: 'observed' | 'skipped-no-place-id' | 'skipped-fetch-failed';
-  changes?: string[];
-  significanceLevel?: string;
-  significanceScore?: number;
-  significanceSummary?: string;
-  nextCheckAt?: string;
-  webChanges?: string[];
-}
 
 export async function POST(request: NextRequest) {
   let body: { userId?: string; limit?: number; dryRun?: boolean };
@@ -235,113 +85,26 @@ export async function POST(request: NextRequest) {
     });
   }
 
-  const results: RunResult[] = [];
-
-  for (const entry of batch) {
-    // Need a place_id to fetch from Google Places
-    if (!entry.place_id) {
-      results.push({
-        entryId: entry.id,
-        name: entry.name,
-        status: 'skipped-no-place-id',
-      });
-      continue;
-    }
-
-    const placeData = await fetchPlaceDetails(entry.place_id);
-    if (!placeData) {
-      results.push({
-        entryId: entry.id,
-        name: entry.name,
-        status: 'skipped-fetch-failed',
-      });
-      continue;
-    }
-
-    const observedState = buildObservedState(placeData);
-    const now = observedState.observedAt;
-
-    if (dryRun) {
-      results.push({
-        entryId: entry.id,
-        name: entry.name,
-        status: 'observed',
-        nextCheckAt: computeNextCheckAt(entry, now),
-      });
-      continue;
-    }
-
-    // Record the observation (change detection happens inside recordObservation)
-    const nextCheck = computeNextCheckAt(entry, now);
-    const updated = await recordObservation({
-      userId,
-      entryId: entry.id,
-      observation: {
-        observedAt: now,
-        source: 'google-places',
-        state: observedState,
-      },
-      nextCheckAt: nextCheck,
-    });
-
-    const latestObs = updated?.observations?.[0];
-    const result: RunResult = {
-      entryId: entry.id,
-      name: entry.name,
-      status: 'observed',
-      changes: latestObs?.changes ?? [],
-      significanceLevel: latestObs?.significanceLevel,
-      significanceScore: latestObs?.significanceScore,
-      significanceSummary: latestObs?.significanceSummary,
-      nextCheckAt: updated?.nextCheckAt,
-    };
-
-    // Web enrichment: run type-specific search for signals Places API can't detect
-    // (awards, buzz, closures in press, construction milestones, program changes)
-    const webEnrichment = await runWebEnrichment({
-      name: entry.name,
-      city: entry.city,
-      monitorType: entry.monitorType,
-    });
-    if (webEnrichment && webEnrichment.changes.length > 0) {
-      const webObsAt = new Date().toISOString();
-      await recordObservation({
-        userId,
-        entryId: entry.id,
-        observation: {
-          observedAt: webObsAt,
-          source: 'web-search',
-          changes: webEnrichment.changes,
-          changeSummary: `Web signals: ${webEnrichment.changes.join(', ')}`,
-          state: {
-            observedAt: webObsAt,
-            source: 'web-search',
-            notes: webEnrichment.notes,
-          },
-        },
-        // Don't override nextCheckAt — the Places observation already set it
-      });
-      result.webChanges = webEnrichment.changes.map(String);
-    }
-
-    results.push(result);
-  }
-
-  const observed = results.filter(r => r.status === 'observed');
-  const withChanges = observed.filter(r => r.changes && r.changes.length > 0);
-  const withWebSignals = observed.filter(r => r.webChanges && r.webChanges.length > 0);
+  // Run observations with bounded concurrency and web enrichment gating
+  const summary = await runObservations({
+    userId,
+    entries: batch,
+    maxConcurrent: MAX_CONCURRENT_PLACES,
+    maxWebEnrichments: MAX_WEB_ENRICHMENTS_PER_RUN,
+    dryRun,
+  });
 
   return NextResponse.json({
-    message: `Observed ${observed.length}/${batch.length} entries${dryRun ? ' (dry run)' : ''}`,
+    message: `Observed ${summary.observed}/${batch.length} entries${dryRun ? ' (dry run)' : ''}`,
     totalEntries: inventory.entries.length,
     dueCount: due.length,
     batchSize: batch.length,
-    results,
+    results: summary.results,
     summary: {
-      observed: observed.length,
-      skipped: results.length - observed.length,
-      withChanges: withChanges.length,
-      withWebSignals: withWebSignals.length,
+      observed: summary.observed,
+      skipped: summary.skipped,
+      withChanges: summary.withChanges,
+      withWebSignals: summary.withWebSignals,
     },
   });
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,8 +3,7 @@ import { getCurrentUser } from './_lib/user';
 import { getEffectiveDerivedUserDiscoveries, getEffectiveUserManifest } from './_lib/effective-user-data';
 import type { Context, Discovery } from './_lib/types';
 import { isContextActive } from './_lib/context-lifecycle';
-import { resolveImageUrl } from './_lib/image-url';
-import { getManifestHeroImage } from './_lib/image-url.server';
+import { getHeroImage } from './_lib/image-url.server';
 import { isTypeCompatible } from './_lib/context-compat';
 import { scoreDiscovery } from './_lib/discovery-score';
 import { rankDiscoveriesForHomepage } from './_lib/discovery-preferences';
@@ -26,6 +25,13 @@ function sortContexts(contexts: Context[]): Context[] {
     if (a.type === 'outing' && b.type === 'radar') return -1;
     if (b.type === 'outing' && a.type === 'radar') return 1;
     return 0;
+  });
+}
+
+function enrichDiscoveriesWithImageMinimums(discoveries: Discovery[]): Discovery[] {
+  return discoveries.map((discovery) => {
+    const heroImage = getHeroImage(discovery.place_id, discovery.heroImage);
+    return heroImage ? { ...discovery, heroImage } : discovery;
   });
 }
 
@@ -73,26 +79,7 @@ export default async function HomePage() {
   });
   const discoveries_final = fullyBuilt;
 
-  // Enrich discoveries with resolved image URLs
-  // Priority: heroImage field (already resolved) > manifest fallback > Blob place-cards/
-  const BLOB_BASE_URL = process.env.NEXT_PUBLIC_BLOB_BASE_URL || '';
-  const enrichedDiscoveries = discoveries_final.map(d => {
-    // 1. Use heroImage if present
-    let heroImage: string | null = resolveImageUrl(d.heroImage);
-    // 2. Fall back to manifest (local fs)
-    if (!heroImage && d.place_id) {
-      heroImage = getManifestHeroImage(d.place_id);
-    }
-    // 3. Fall back to Blob place-cards/{id}/card.json heroImage via URL pattern
-    //    (card stubs may have heroImage set from the migration; use URL directly)
-    if (!heroImage && d.place_id && BLOB_BASE_URL) {
-      // Point at the Blob-hosted card; PlaceCardStore will resolve at render time.
-      // For now, mark with a synthetic Blob photo URL to signal availability.
-      // Actual resolution happens client-side for cards with real photos in Blob.
-      heroImage = null; // leave null — handled below by photo-first sort
-    }
-    return heroImage ? { ...d, heroImage } : d;
-  });
+  const enrichedDiscoveries = enrichDiscoveriesWithImageMinimums(discoveries_final);
 
   // Group discoveries by context — fuzzy match on slug to handle key variants
   // Fix #108: deduplicate by place_id within each context bucket

--- a/app/review/[contextKey]/page.tsx
+++ b/app/review/[contextKey]/page.tsx
@@ -1,12 +1,21 @@
 import Link from 'next/link';
 import { getCurrentUser } from '../../_lib/user';
 import { getEffectiveDerivedUserDiscoveries, getEffectiveUserManifest } from '../../_lib/effective-user-data';
+import { getHeroImage } from '../../_lib/image-url.server';
+import type { Discovery } from '../../_lib/types';
 import ReviewContextClient from '../../_components/ReviewContextClient';
 
 export const dynamic = 'force-dynamic';
 
 interface Props {
   params: Promise<{ contextKey: string }>;
+}
+
+function enrichDiscoveriesWithImageMinimums(discoveries: Discovery[]): Discovery[] {
+  return discoveries.map((discovery) => {
+    const heroImage = getHeroImage(discovery.place_id, discovery.heroImage);
+    return heroImage ? { ...discovery, heroImage } : discovery;
+  });
 }
 
 export default async function ReviewContextPage({ params }: Props) {
@@ -28,16 +37,18 @@ export default async function ReviewContextPage({ params }: Props) {
   ]);
 
   const context = manifest?.contexts.find(c => c.key === contextKey);
-  const discoveries = (discoveriesData?.discoveries ?? []).filter(d => {
-    if (d.contextKey !== contextKey) return false;
-    // Only show fully-built discoveries (must have name + address or description or rating)
-    if (!d.name || d.name === 'Unknown Place') return false;
-    const rec = d as unknown as Record<string, unknown>;
-    const hasAddress = !!(rec.address as string);
-    const hasDescription = !!(rec.description || rec.summary);
-    const hasRating = d.rating != null && d.rating > 0;
-    return hasAddress || hasDescription || hasRating;
-  });
+  const discoveries = enrichDiscoveriesWithImageMinimums(
+    (discoveriesData?.discoveries ?? []).filter(d => {
+      if (d.contextKey !== contextKey) return false;
+      // Only show fully-built discoveries (must have name + address or description or rating)
+      if (!d.name || d.name === 'Unknown Place') return false;
+      const rec = d as unknown as Record<string, unknown>;
+      const hasAddress = !!(rec.address as string);
+      const hasDescription = !!(rec.description || rec.summary);
+      const hasRating = d.rating != null && d.rating > 0;
+      return hasAddress || hasDescription || hasRating;
+    })
+  );
 
   if (!context) {
     return (

--- a/data/local-discoveries.json
+++ b/data/local-discoveries.json
@@ -3955,7 +3955,25 @@
         "tips": [
           "Official site: ajuntament.barcelona.cat/lavirreina",
           "Typical hours from Google Places: Tue–Sun 11am–8pm, closed Monday"
-        ]
+        ],
+        "streetRank": 1,
+        "streetScore": 88,
+        "confidence": "high",
+        "rarity": "notable",
+        "streetFit": "strong",
+        "provenanceGrade": "A",
+        "provenance": {
+          "leadSource": "goplaces-verified",
+          "supportingSources": [
+            "goplaces-verified"
+          ],
+          "verifiedBy": [
+            "google-places"
+          ],
+          "lastVerifiedAt": "2026-04-04T23:29:00.000Z",
+          "sourceType": "live-verification"
+        },
+        "whyThisPlaceMatters": "Street-defining palace turned image centre, directly on Las Ramblas."
       }
     },
     {
@@ -3979,7 +3997,25 @@
         "tips": [
           "Official site: amatller.org",
           "Google Places hours currently show daily 10am–7pm"
-        ]
+        ],
+        "streetRank": 1,
+        "streetScore": 88,
+        "confidence": "high",
+        "rarity": "notable",
+        "streetFit": "strong",
+        "provenanceGrade": "A",
+        "provenance": {
+          "leadSource": "goplaces-verified",
+          "supportingSources": [
+            "goplaces-verified"
+          ],
+          "verifiedBy": [
+            "google-places"
+          ],
+          "lastVerifiedAt": "2026-04-04T23:29:00.000Z",
+          "sourceType": "live-verification"
+        },
+        "whyThisPlaceMatters": "One of the key façades that makes the street itself worth reading block by block."
       }
     },
     {
@@ -4001,7 +4037,25 @@
         "whyInteresting": "Historic-hotel scale at a major Commonwealth node, helping the boulevard read as lived city rather than pure scenery.",
         "tips": [
           "Official site: hotelcommonwealth.com"
-        ]
+        ],
+        "streetRank": 1,
+        "streetScore": 88,
+        "confidence": "high",
+        "rarity": "notable",
+        "streetFit": "strong",
+        "provenanceGrade": "A",
+        "provenance": {
+          "leadSource": "goplaces-verified",
+          "supportingSources": [
+            "goplaces-verified"
+          ],
+          "verifiedBy": [
+            "google-places"
+          ],
+          "lastVerifiedAt": "2026-04-04T23:29:00.000Z",
+          "sourceType": "live-verification"
+        },
+        "whyThisPlaceMatters": "Historic-hotel scale at a major Commonwealth node, helping the boulevard read as lived city rather than pure scenery."
       }
     },
     {
@@ -4024,7 +4078,25 @@
         "whyInteresting": "A functioning cultural institution that keeps Unter den Linden from being just a postcard axis.",
         "tips": [
           "Official site: staatsoper-berlin.de"
-        ]
+        ],
+        "streetRank": 1,
+        "streetScore": 88,
+        "confidence": "high",
+        "rarity": "notable",
+        "streetFit": "strong",
+        "provenanceGrade": "A",
+        "provenance": {
+          "leadSource": "goplaces-verified",
+          "supportingSources": [
+            "goplaces-verified"
+          ],
+          "verifiedBy": [
+            "google-places"
+          ],
+          "lastVerifiedAt": "2026-04-04T23:29:00.000Z",
+          "sourceType": "live-verification"
+        },
+        "whyThisPlaceMatters": "A functioning cultural institution that keeps Unter den Linden from being just a postcard axis."
       }
     },
     {
@@ -4048,7 +4120,25 @@
         "tips": [
           "Official site: publicisdrugstore.com",
           "Google Places currently shows late-night hours, often until 2am"
-        ]
+        ],
+        "streetRank": 1,
+        "streetScore": 88,
+        "confidence": "high",
+        "rarity": "notable",
+        "streetFit": "strong",
+        "provenanceGrade": "A",
+        "provenance": {
+          "leadSource": "goplaces-verified",
+          "supportingSources": [
+            "goplaces-verified"
+          ],
+          "verifiedBy": [
+            "google-places"
+          ],
+          "lastVerifiedAt": "2026-04-04T23:29:00.000Z",
+          "sourceType": "live-verification"
+        },
+        "whyThisPlaceMatters": "Shows the Champs at its most urban: a flagship that works like infrastructure, not just luxury frontage."
       }
     },
     {
@@ -4071,7 +4161,25 @@
         "tips": [
           "Official site: bmvbooks.com",
           "Google Places currently shows late closing Thu–Sat"
-        ]
+        ],
+        "streetRank": 1,
+        "streetScore": 88,
+        "confidence": "high",
+        "rarity": "notable",
+        "streetFit": "strong",
+        "provenanceGrade": "A",
+        "provenance": {
+          "leadSource": "goplaces-verified",
+          "supportingSources": [
+            "goplaces-verified"
+          ],
+          "verifiedBy": [
+            "google-places"
+          ],
+          "lastVerifiedAt": "2026-04-04T23:29:00.000Z",
+          "sourceType": "live-verification"
+        },
+        "whyThisPlaceMatters": "One of the clearest present-day examples of the Annex strip still working as a true great street edge."
       }
     },
     {
@@ -4093,7 +4201,25 @@
         "tips": [
           "Official site: lesdeuxgarcons.fr",
           "Use it as a street-reading stop rather than only a meal stop — the terrace is the point."
-        ]
+        ],
+        "streetRank": 1,
+        "streetScore": 88,
+        "confidence": "high",
+        "rarity": "notable",
+        "streetFit": "strong",
+        "provenanceGrade": "A",
+        "provenance": {
+          "leadSource": "official-web-verified",
+          "supportingSources": [
+            "official-web-verified"
+          ],
+          "verifiedBy": [
+            "official-website"
+          ],
+          "lastVerifiedAt": "2026-04-06T00:31:00.000Z",
+          "sourceType": "live-verification"
+        },
+        "whyThisPlaceMatters": "Historic brasserie frontage that lets you read the avenue as social theater, not just postcard architecture."
       }
     },
     {
@@ -4115,7 +4241,25 @@
         "tips": [
           "Official site: illum.dk",
           "Current official programming includes Friday rooftop DJs (17:00–21:00)."
-        ]
+        ],
+        "streetRank": 1,
+        "streetScore": 88,
+        "confidence": "high",
+        "rarity": "notable",
+        "streetFit": "strong",
+        "provenanceGrade": "A",
+        "provenance": {
+          "leadSource": "official-web-verified",
+          "supportingSources": [
+            "official-web-verified"
+          ],
+          "verifiedBy": [
+            "official-website"
+          ],
+          "lastVerifiedAt": "2026-04-06T00:31:00.000Z",
+          "sourceType": "live-verification"
+        },
+        "whyThisPlaceMatters": "A classic Strøget street machine: major frontage on the pedestrian spine, with rooftop and underground programs extending the street upward and downward."
       }
     },
     {
@@ -4137,7 +4281,25 @@
         "tips": [
           "Official site: saltonline.org/en",
           "Check the live program before a walk; exhibitions and talks are actively changing."
-        ]
+        ],
+        "streetRank": 1,
+        "streetScore": 88,
+        "confidence": "high",
+        "rarity": "notable",
+        "streetFit": "strong",
+        "provenanceGrade": "A",
+        "provenance": {
+          "leadSource": "official-web-verified",
+          "supportingSources": [
+            "official-web-verified"
+          ],
+          "verifiedBy": [
+            "official-website"
+          ],
+          "lastVerifiedAt": "2026-04-06T00:31:00.000Z",
+          "sourceType": "live-verification"
+        },
+        "whyThisPlaceMatters": "A real civic interior on the avenue — the kind of place that proves İstiklal is a cultural corridor, not just a shopping street."
       }
     },
     {
@@ -4159,7 +4321,25 @@
         "tips": [
           "Official site: rome.intercontinental.com",
           "Useful as an evening-read stop even if John is not staying there."
-        ]
+        ],
+        "streetRank": 1,
+        "streetScore": 88,
+        "confidence": "high",
+        "rarity": "notable",
+        "streetFit": "strong",
+        "provenanceGrade": "A",
+        "provenance": {
+          "leadSource": "official-web-verified",
+          "supportingSources": [
+            "official-web-verified"
+          ],
+          "verifiedBy": [
+            "official-website"
+          ],
+          "lastVerifiedAt": "2026-04-06T00:31:00.000Z",
+          "sourceType": "live-verification"
+        },
+        "whyThisPlaceMatters": "A current luxury anchor on the boulevard that helps Via Veneto still read as a grand hotel street."
       }
     },
     {
@@ -4181,7 +4361,25 @@
         "tips": [
           "Official source: chicago.gov Chicago Cultural Center page",
           "Open daily 10am–5pm per the City page; exhibitions close 15 minutes before building close."
-        ]
+        ],
+        "streetRank": 1,
+        "streetScore": 88,
+        "confidence": "high",
+        "rarity": "notable",
+        "streetFit": "strong",
+        "provenanceGrade": "A",
+        "provenance": {
+          "leadSource": "official-web-verified",
+          "supportingSources": [
+            "official-web-verified"
+          ],
+          "verifiedBy": [
+            "official-website"
+          ],
+          "lastVerifiedAt": "2026-04-06T00:31:00.000Z",
+          "sourceType": "live-verification"
+        },
+        "whyThisPlaceMatters": "One of the best civic interiors off Michigan Avenue, turning the grand street into a cultural sequence rather than a shopping strip."
       }
     },
     {
@@ -4203,7 +4401,25 @@
         "tips": [
           "Official site: fundaciontelefonica.com/espacio-fundacion-telefonica/",
           "Official hours listed: Tue–Fri 10:00–20:00; Sat/Sun/holidays 11:00–20:00."
-        ]
+        ],
+        "streetRank": 1,
+        "streetScore": 88,
+        "confidence": "high",
+        "rarity": "notable",
+        "streetFit": "strong",
+        "provenanceGrade": "A",
+        "provenance": {
+          "leadSource": "official-web-verified",
+          "supportingSources": [
+            "official-web-verified"
+          ],
+          "verifiedBy": [
+            "official-website"
+          ],
+          "lastVerifiedAt": "2026-04-06T00:31:00.000Z",
+          "sourceType": "live-verification"
+        },
+        "whyThisPlaceMatters": "A serious public program plugged into the Gran Vía edge condition, where commercial spectacle meets ideas and exhibitions."
       }
     }
   ]

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -1,39 +1,55 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Locator, type Page } from '@playwright/test';
 
-test('all visible images load correctly', async ({ page }) => {
-  // Auth pre-seeded by global-setup.ts
+const OWNER_AUTH_CODE = 'john2824';
+const IMAGE_RICH_CONTEXT_KEY = 'trip:cottage-july-2026';
+const IMAGE_RICH_PLACE_ID = 'ChIJCxjDu8c1K4gR33Dh5X2QMlc';
+
+async function loginAsOwner(page: Page) {
+  await page.goto(`/u/${OWNER_AUTH_CODE}`, { waitUntil: 'networkidle' });
+}
+
+async function expectPreviewBackgrounds(locator: Locator, minimumCards: number) {
+  const count = await locator.count();
+  expect(count).toBeGreaterThanOrEqual(minimumCards);
+
+  for (let i = 0; i < Math.min(count, minimumCards); i++) {
+    const backgroundImage = await locator.nth(i).evaluate((el) => getComputedStyle(el).backgroundImage);
+    expect(backgroundImage).not.toBe('none');
+  }
+}
+
+async function expectLoadedGalleryImages(locator: Locator, minimumImages: number) {
+  const count = await locator.count();
+  expect(count).toBeGreaterThanOrEqual(minimumImages);
+
+  for (let i = 0; i < minimumImages; i++) {
+    const naturalWidth = await locator.nth(i).evaluate((el) => (el as HTMLImageElement).naturalWidth);
+    expect(naturalWidth).toBeGreaterThan(0);
+  }
+}
+
+test('homepage place cards show preview images for the Ontario Cottage context', async ({ page }) => {
+  await loginAsOwner(page);
+  await page.evaluate((contextKey) => {
+    window.localStorage.setItem('compass-active-context', contextKey);
+  }, IMAGE_RICH_CONTEXT_KEY);
   await page.goto('/', { waitUntil: 'networkidle' });
 
-  // Find all img elements with src attributes
-  const images = page.locator('img[src]');
-  const count = await images.count();
+  const previews = page.locator('.place-card-image');
+  await expectPreviewBackgrounds(previews, 3);
+});
 
-  expect(count).toBeGreaterThan(0);
+test('review cards show preview images for the Ontario Cottage context', async ({ page }) => {
+  await loginAsOwner(page);
+  await page.goto(`/review/${encodeURIComponent(IMAGE_RICH_CONTEXT_KEY)}`, { waitUntil: 'networkidle' });
 
-  const brokenImages: string[] = [];
+  const previews = page.locator('.accomm-card-hero');
+  await expectPreviewBackgrounds(previews, 4);
+});
 
-  for (let i = 0; i < count; i++) {
-    const img = images.nth(i);
-    const src = await img.getAttribute('src');
+test('image-rich place cards expose at least three gallery images when available', async ({ page }) => {
+  await page.goto(`/placecards/${IMAGE_RICH_PLACE_ID}`, { waitUntil: 'networkidle' });
 
-    // Check if image is visible
-    const isVisible = await img.isVisible();
-    if (!isVisible) continue;
-
-    // Wait for the image to potentially load
-    await img.waitFor({ state: 'attached', timeout: 5000 }).catch(() => {});
-
-    // Get naturalWidth to check if image loaded
-    const naturalWidth = await img.evaluate((el) => (el as HTMLImageElement).naturalWidth);
-
-    if (naturalWidth === 0) {
-      brokenImages.push(src || 'unknown');
-    }
-  }
-
-  if (brokenImages.length > 0) {
-    console.log('Broken images found:', brokenImages);
-  }
-
-  expect(brokenImages).toHaveLength(0);
+  const galleryImages = page.locator('.place-detail-v2 .photo-gallery-item img');
+  await expectLoadedGalleryImages(galleryImages, 3);
 });

--- a/tests/trip-emergence.test.ts
+++ b/tests/trip-emergence.test.ts
@@ -1,0 +1,70 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { diffTripEmergenceAttributes } from '../app/_lib/trip-emergence';
+
+describe('diffTripEmergenceAttributes', () => {
+  test('returns only newly attached focus items', () => {
+    const attrs = diffTripEmergenceAttributes(
+      {
+        key: 'trip:nyc',
+        focus: ['food'],
+      },
+      {
+        key: 'trip:nyc',
+        focus: ['food', 'jazz', 'architecture'],
+      },
+    );
+
+    assert.deepEqual(attrs, [
+      { field: 'focus', value: 'jazz, architecture' },
+    ]);
+  });
+
+  test('surfaces purpose and people changes for trip emergence chips', () => {
+    const attrs = diffTripEmergenceAttributes(
+      {
+        key: 'trip:paris',
+        purpose: 'Anniversary escape',
+        people: [{ name: 'John' }],
+      },
+      {
+        key: 'trip:paris',
+        purpose: 'Anniversary escape with gallery days',
+        people: [{ name: 'John' }, { name: 'Huzur', relation: 'wife' }],
+      },
+    );
+
+    assert.deepEqual(attrs, [
+      { field: 'purpose', value: 'Anniversary escape with gallery days' },
+      { field: 'people', value: 'Huzur (wife)' },
+    ]);
+  });
+
+  test('includes core trip changes in stable order', () => {
+    const attrs = diffTripEmergenceAttributes(
+      {
+        key: 'trip:tokyo',
+        dates: 'May 2027',
+        city: 'Tokyo',
+        focus: ['food'],
+      },
+      {
+        key: 'trip:tokyo',
+        dates: 'May 10 to May 18, 2027',
+        city: 'Kyoto',
+        focus: ['food', 'design'],
+        purpose: 'Spring architecture trip',
+        people: [{ name: 'John' }, { name: 'Dessa', relation: 'daughter' }],
+      },
+    );
+
+    assert.deepEqual(attrs, [
+      { field: 'dates', value: 'May 10 to May 18, 2027' },
+      { field: 'city', value: 'Kyoto' },
+      { field: 'focus', value: 'design' },
+      { field: 'purpose', value: 'Spring architecture trip' },
+      { field: 'people', value: 'John, Dessa (daughter)' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- extract a shared observation runner with bounded concurrency and hard upstream timeouts
- gate web enrichment to a small capped subset per run so Places observations drain backlog first
- increase cron observation throughput from 5 to 15 entries per user per run
- overlay durable monitor inventory timing into discovery monitoring annotations so due-now status reflects real observation cadence

## Testing
- npx tsx app/_lib/observation-runner.test.ts
- npx tsc --noEmit

Fixes #311.