### PR TITLE
feat: add cadence hints to homepage monitoring rows

### DIFF
--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -172,14 +172,24 @@ const CHANGE_LABELS: Record<string, string> = {
   'general-update': 'Updated',
 };
 
-export function getHomepageMonitoringExplanation(item: Pick<MonitoringQueueItem, 'dueNow' | 'significanceLevel' | 'monitorExplanation'>): string | null {
+export function getHomepageMonitoringExplanation(item: Pick<MonitoringQueueItem, 'dueNow' | 'significanceLevel' | 'monitorExplanation' | 'monitorCadence'>): string | null {
   const explanation = item.monitorExplanation?.trim();
   if (!explanation) return null;
   const sig = item.significanceLevel ?? 'noise';
-  if (item.dueNow || sig === 'critical' || sig === 'notable') {
-    return explanation;
+  if (!item.dueNow && sig !== 'critical' && sig !== 'notable') {
+    return null;
   }
-  return null;
+
+  const cadence = item.monitorCadence?.trim();
+  if (!cadence) return explanation;
+  if (!item.dueNow) return explanation;
+
+  const compactCadence = cadence
+    .replace(/^Check\s+/i, '')
+    .replace(/\.$/, '')
+    .replace(/^while\s+/i, 'while ');
+
+  return `${explanation} · ${compactCadence}`;
 }
 
 function formatChangeKinds(changes: string[]): string {

--- a/tests/home-monitoring-explanation.test.ts
+++ b/tests/home-monitoring-explanation.test.ts
@@ -5,27 +5,47 @@ function getHomepageMonitoringExplanation(item: {
   dueNow?: boolean;
   significanceLevel?: string;
   monitorExplanation?: string;
+  monitorCadence?: string;
 }): string | null {
   const explanation = item.monitorExplanation?.trim();
   if (!explanation) return null;
   const sig = item.significanceLevel ?? 'noise';
-  if (item.dueNow || sig === 'critical' || sig === 'notable') {
-    return explanation;
+  if (!item.dueNow && sig !== 'critical' && sig !== 'notable') {
+    return null;
   }
-  return null;
+
+  const cadence = item.monitorCadence?.trim();
+  if (!cadence) return explanation;
+  if (!item.dueNow) return explanation;
+
+  const compactCadence = cadence
+    .replace(/^Check\s+/i, '')
+    .replace(/\.$/, '')
+    .replace(/^while\s+/i, 'while ');
+
+  return `${explanation} · ${compactCadence}`;
 }
 
 describe('getHomepageMonitoringExplanation', () => {
-  test('shows explanation for due items', () => {
+  test('shows explanation for due items and appends a compact cadence hint', () => {
     assert.equal(
-      getHomepageMonitoringExplanation({ dueNow: true, significanceLevel: 'routine', monitorExplanation: 'belongs to an active trip' }),
-      'belongs to an active trip',
+      getHomepageMonitoringExplanation({
+        dueNow: true,
+        significanceLevel: 'routine',
+        monitorExplanation: 'belongs to an active trip',
+        monitorCadence: 'Check weekly while the trip is live.',
+      }),
+      'belongs to an active trip · weekly while the trip is live',
     );
   });
 
-  test('shows explanation for notable or critical changes', () => {
+  test('shows explanation for notable or critical changes without extra cadence noise', () => {
     assert.equal(
-      getHomepageMonitoringExplanation({ significanceLevel: 'notable', monitorExplanation: 'saved already · check weekly' }),
+      getHomepageMonitoringExplanation({
+        significanceLevel: 'notable',
+        monitorExplanation: 'saved already · check weekly',
+        monitorCadence: 'Check every 2–3 weeks.',
+      }),
       'saved already · check weekly',
     );
     assert.equal(


### PR DESCRIPTION
## Summary
- append a compact cadence hint to homepage monitoring explanations only for due rows
- keep notable/critical change rows terse, without extra cadence copy
- extend targeted tests for the homepage explanation helper

## Verification
- `npx tsx --test tests/home-monitoring-explanation.test.ts`
- `npx eslint app/_components/HomeClient.tsx`

## Related
- #46
- follow-through after PR #315