### PR TITLE
fix: enforce homepage html budget

### DIFF
--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import type { ContextType, Discovery } from '../_lib/types';
+import type { HomepageDigestItem } from '../_lib/homepage-data';
 import { getContextCounts } from '../_lib/triage';
 import PlaceGrid from './PlaceGrid';
 import BriefingBanner from './BriefingBanner';
@@ -29,24 +30,6 @@ interface MonitoringQueueItem {
   observationCount?: number;
 }
 
-interface DigestItemProp {
-  entryId: string;
-  name: string;
-  city: string;
-  monitorType: string;
-  contextKey: string;
-  significanceLevel: string;
-  significanceSummary: string;
-  changes: string[];
-  stateContext?: {
-    rating?: number;
-    previousRating?: number;
-    operationalStatus?: string;
-    previousOperationalStatus?: string;
-  };
-  placeId?: string;
-}
-
 interface HomeContext {
   key: string;
   label: string;
@@ -63,11 +46,6 @@ interface HomeClientProps {
   userId: string;
   contexts: HomeContext[];
   initialContextKey?: string | null;
-  initialDiscoveries?: Discovery[];
-  initialMonitoringQueue?: MonitoringQueueItem[];
-  contextMeta?: Record<string, { travel?: unknown; accommodation?: unknown; bookingStatus?: string }>;
-  digestTeaser?: string | null;
-  digestItems?: DigestItemProp[];
 }
 
 const TYPE_EMOJI: Record<string, string> = {
@@ -259,11 +237,6 @@ export default function HomeClient({
   userId,
   contexts,
   initialContextKey = null,
-  initialDiscoveries = [],
-  initialMonitoringQueue = [],
-  contextMeta = {},
-  digestTeaser,
-  digestItems = [],
 }: HomeClientProps) {
   const router = useRouter();
   const [mounted, setMounted] = useState(false);
@@ -271,12 +244,11 @@ export default function HomeClient({
   const [emergingKeys, setEmergingKeys] = useState<Set<string>>(new Set());
   const [attachingAttrs, setAttachingAttrs] = useState<Record<string, Array<{ field: string; value: string }>>>({});
   const [, setTriageVersion] = useState(0);
-  const [discoveriesByContext, setDiscoveriesByContext] = useState<Record<string, Discovery[]>>(() => (
-    initialContextKey && initialDiscoveries.length > 0 ? { [initialContextKey]: initialDiscoveries } : {}
-  ));
-  const [monitoringQueueByContext, setMonitoringQueueByContext] = useState<Record<string, MonitoringQueueItem[]>>(() => (
-    initialContextKey && initialMonitoringQueue.length > 0 ? { [initialContextKey]: initialMonitoringQueue } : {}
-  ));
+  const [discoveriesByContext, setDiscoveriesByContext] = useState<Record<string, Discovery[]>>({});
+  const [monitoringQueueByContext, setMonitoringQueueByContext] = useState<Record<string, MonitoringQueueItem[]>>({});
+  const [contextMetaByKey, setContextMetaByKey] = useState<Record<string, { travel?: unknown; accommodation?: unknown; bookingStatus?: string }>>({});
+  const [digestTeaser, setDigestTeaser] = useState<string | null>(null);
+  const [digestItems, setDigestItems] = useState<HomepageDigestItem[]>([]);
   const [loadingDiscoveries, setLoadingDiscoveries] = useState<Set<string>>(new Set());
 
   // Active context key — persisted in localStorage
@@ -380,17 +352,30 @@ export default function HomeClient({
   const ensureContextData = useCallback((key: string) => {
     if (Object.prototype.hasOwnProperty.call(discoveriesByContext, key) || loadingDiscoveries.has(key)) return;
     setLoadingDiscoveries(prev => new Set(prev).add(key));
-    fetch(`/api/home/context?key=${encodeURIComponent(key)}`)
+    const endpoint = digestItems.length === 0 && Object.keys(contextMetaByKey).length === 0
+      ? `/api/home/bootstrap?key=${encodeURIComponent(key)}`
+      : `/api/home/context?key=${encodeURIComponent(key)}`;
+    fetch(endpoint)
       .then(async (res) => {
         if (!res.ok) throw new Error(`Failed to load context ${key}`);
         return res.json();
       })
       .then((data) => {
+        const resolvedKey = typeof data?.contextKey === 'string' ? data.contextKey : key;
         if (Array.isArray(data?.discoveries)) {
-          setDiscoveriesByContext(prev => ({ ...prev, [key]: data.discoveries }));
+          setDiscoveriesByContext(prev => ({ ...prev, [resolvedKey]: data.discoveries }));
         }
         if (Array.isArray(data?.monitoringQueue)) {
-          setMonitoringQueueByContext(prev => ({ ...prev, [key]: data.monitoringQueue }));
+          setMonitoringQueueByContext(prev => ({ ...prev, [resolvedKey]: data.monitoringQueue }));
+        }
+        if (data?.contextMeta) {
+          setContextMetaByKey(prev => ({ ...prev, [resolvedKey]: data.contextMeta }));
+        }
+        if (typeof data?.digestTeaser === 'string' || data?.digestTeaser === null) {
+          setDigestTeaser(data.digestTeaser ?? null);
+        }
+        if (Array.isArray(data?.digestItems)) {
+          setDigestItems(data.digestItems);
         }
       })
       .catch(console.error)
@@ -401,7 +386,7 @@ export default function HomeClient({
           return next;
         });
       });
-  }, [discoveriesByContext, loadingDiscoveries]);
+  }, [contextMetaByKey, digestItems.length, discoveriesByContext, loadingDiscoveries]);
 
   const handleContextSelect = useCallback((key: string) => {
     applyActiveKey(key);
@@ -642,9 +627,9 @@ export default function HomeClient({
               <TripPlanningWidget
                 userId={userId}
                 contextKey={ctx.key}
-                travel={contextMeta[ctx.key]?.travel as never}
-                accommodation={contextMeta[ctx.key]?.accommodation as never}
-                bookingStatus={contextMeta[ctx.key]?.bookingStatus}
+                travel={contextMetaByKey[ctx.key]?.travel as never}
+                accommodation={contextMetaByKey[ctx.key]?.accommodation as never}
+                bookingStatus={contextMetaByKey[ctx.key]?.bookingStatus}
                 savedCount={counts.saved}
                 purpose={raw.purpose as string | undefined}
                 people={raw.people as Array<{ name: string; relation?: string }> | undefined}

--- a/app/_components/HomeClient.tsx
+++ b/app/_components/HomeClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import type { Context, Discovery } from '../_lib/types';
+import type { ContextType, Discovery } from '../_lib/types';
 import { getContextCounts } from '../_lib/triage';
 import PlaceGrid from './PlaceGrid';
 import BriefingBanner from './BriefingBanner';
@@ -47,12 +47,25 @@ interface DigestItemProp {
   placeId?: string;
 }
 
+interface HomeContext {
+  key: string;
+  label: string;
+  emoji: string;
+  type: ContextType;
+  city?: string;
+  dates?: string;
+  focus: string[];
+  purpose?: string;
+  people?: Array<{ name: string; relation?: string }>;
+}
+
 interface HomeClientProps {
   userId: string;
-  contexts: Context[];
-  discoveryMap: Record<string, Discovery[]>;
+  contexts: HomeContext[];
+  initialContextKey?: string | null;
+  initialDiscoveries?: Discovery[];
+  initialMonitoringQueue?: MonitoringQueueItem[];
   contextMeta?: Record<string, { travel?: unknown; accommodation?: unknown; bookingStatus?: string }>;
-  monitoringQueue?: MonitoringQueueItem[];
   digestTeaser?: string | null;
   digestItems?: DigestItemProp[];
 }
@@ -135,7 +148,7 @@ function formatDateNatural(dates: string | undefined): string | null {
 /**
  * Build a short description from context focus areas.
  */
-function buildDescription(ctx: Context): string | null {
+function buildDescription(ctx: HomeContext): string | null {
   if (ctx.focus && ctx.focus.length > 0) {
     return ctx.focus.slice(0, 5).join(' · ');
   }
@@ -245,9 +258,10 @@ function MonitoringQueueTray({ items }: { items: MonitoringQueueItem[] }) {
 export default function HomeClient({
   userId,
   contexts,
-  discoveryMap,
+  initialContextKey = null,
+  initialDiscoveries = [],
+  initialMonitoringQueue = [],
   contextMeta = {},
-  monitoringQueue = [],
   digestTeaser,
   digestItems = [],
 }: HomeClientProps) {
@@ -257,6 +271,13 @@ export default function HomeClient({
   const [emergingKeys, setEmergingKeys] = useState<Set<string>>(new Set());
   const [attachingAttrs, setAttachingAttrs] = useState<Record<string, Array<{ field: string; value: string }>>>({});
   const [, setTriageVersion] = useState(0);
+  const [discoveriesByContext, setDiscoveriesByContext] = useState<Record<string, Discovery[]>>(() => (
+    initialContextKey && initialDiscoveries.length > 0 ? { [initialContextKey]: initialDiscoveries } : {}
+  ));
+  const [monitoringQueueByContext, setMonitoringQueueByContext] = useState<Record<string, MonitoringQueueItem[]>>(() => (
+    initialContextKey && initialMonitoringQueue.length > 0 ? { [initialContextKey]: initialMonitoringQueue } : {}
+  ));
+  const [loadingDiscoveries, setLoadingDiscoveries] = useState<Set<string>>(new Set());
 
   // Active context key — persisted in localStorage
   const [activeKey, setActiveKey] = useState<string | null>(null);
@@ -300,24 +321,28 @@ export default function HomeClient({
       const stored = localStorage.getItem('compass-active-context');
       if (stored) {
         setActiveKey(stored);
+      } else if (initialContextKey) {
+        setActiveKey(initialContextKey);
       } else if (contexts.length > 0) {
         setActiveKey(contexts[0]!.key);
       }
     } catch {
-      if (contexts.length > 0) setActiveKey(contexts[0]!.key);
+      if (initialContextKey) setActiveKey(initialContextKey);
+      else if (contexts.length > 0) setActiveKey(contexts[0]!.key);
     }
     // Intentionally runs only once; subsequent switches go through
     // applyActiveKey / chat switch / trip-created handlers.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [contexts, initialContextKey]);
 
   // Defensive fallback: if activeKey ever becomes null (e.g. first
   // mount raced with contexts arriving), seed it from the first context.
   useEffect(() => {
-    if (activeKey === null && contexts.length > 0) {
-      setActiveKey(contexts[0]!.key);
+    if (activeKey === null) {
+      if (initialContextKey) setActiveKey(initialContextKey);
+      else if (contexts.length > 0) setActiveKey(contexts[0]!.key);
     }
-  }, [activeKey, contexts]);
+  }, [activeKey, contexts, initialContextKey]);
 
   // When contexts update, apply any pending chat-driven target key that
   // is now available. This fixes the case where a chat switch arrives
@@ -352,10 +377,37 @@ export default function HomeClient({
     }));
   }, [contexts]);
 
+  const ensureContextData = useCallback((key: string) => {
+    if (Object.prototype.hasOwnProperty.call(discoveriesByContext, key) || loadingDiscoveries.has(key)) return;
+    setLoadingDiscoveries(prev => new Set(prev).add(key));
+    fetch(`/api/home/context?key=${encodeURIComponent(key)}`)
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`Failed to load context ${key}`);
+        return res.json();
+      })
+      .then((data) => {
+        if (Array.isArray(data?.discoveries)) {
+          setDiscoveriesByContext(prev => ({ ...prev, [key]: data.discoveries }));
+        }
+        if (Array.isArray(data?.monitoringQueue)) {
+          setMonitoringQueueByContext(prev => ({ ...prev, [key]: data.monitoringQueue }));
+        }
+      })
+      .catch(console.error)
+      .finally(() => {
+        setLoadingDiscoveries(prev => {
+          const next = new Set(prev);
+          next.delete(key);
+          return next;
+        });
+      });
+  }, [discoveriesByContext, loadingDiscoveries]);
+
   const handleContextSelect = useCallback((key: string) => {
     applyActiveKey(key);
     broadcastActiveContext(key);
-  }, [applyActiveKey, broadcastActiveContext]);
+    ensureContextData(key);
+  }, [applyActiveKey, broadcastActiveContext, ensureContextData]);
 
   // Listen for chat-driven context switches.
   // If the target key is already in `contexts`, apply it immediately.
@@ -370,6 +422,7 @@ export default function HomeClient({
         // Mirror manual context selection: broadcast immediately so
         // chat-scoped UI stays aligned on multi-hop conversational switches.
         broadcastActiveContext(detail.key);
+        ensureContextData(detail.key);
       } else {
         pendingContextKeyRef.current = detail.key;
         // Persist immediately so a subsequent mount/hydration cycle
@@ -379,7 +432,7 @@ export default function HomeClient({
     };
     window.addEventListener('compass-chat-context-switch', handler);
     return () => window.removeEventListener('compass-chat-context-switch', handler);
-  }, [contexts, applyActiveKey, broadcastActiveContext]);
+  }, [contexts, applyActiveKey, broadcastActiveContext, ensureContextData]);
 
   // Triage change listener
   useEffect(() => {
@@ -473,8 +526,9 @@ export default function HomeClient({
   useEffect(() => {
     if (activeKey) {
       broadcastActiveContext(activeKey);
+      ensureContextData(activeKey);
     }
-  }, [activeKey, broadcastActiveContext]);
+  }, [activeKey, broadcastActiveContext, ensureContextData]);
 
   if (contexts.length === 0) {
     return (
@@ -493,7 +547,11 @@ export default function HomeClient({
   }
 
   const ctx = contexts.find(c => c.key === activeKey) || contexts[0]!;
-  const discoveries = discoveryMap[ctx.key] ?? [];
+  // Combine SSR discoveries (active context) with lazy-loaded discoveries (other contexts)
+  const discoveries = discoveriesByContext[ctx.key] ?? [];
+  const contextMonitoringQueue = monitoringQueueByContext[ctx.key] ?? [];
+  const hasLoadedContextDiscoveries = Object.prototype.hasOwnProperty.call(discoveriesByContext, ctx.key);
+  const isLoadingContext = loadingDiscoveries.has(ctx.key) || !hasLoadedContextDiscoveries;
   const counts = mounted ? (contextCounts[ctx.key] ?? { saved: 0, dismissed: 0, resurfaced: 0 }) : { saved: 0, dismissed: 0, resurfaced: 0 };
   const naturalDate = formatDateNatural(ctx.dates);
   const description = buildDescription(ctx);
@@ -619,10 +677,14 @@ export default function HomeClient({
           </div>
         )}
 
-        <MonitoringQueueTray items={monitoringQueue.filter(i => i.contextKey === ctx.key)} />
+        <MonitoringQueueTray items={contextMonitoringQueue} />
 
         {/* Discoveries */}
-        {discoveries.length > 0 ? (
+        {isLoadingContext ? (
+          <div className="focused-empty-discoveries focused-empty-discoveries-compact">
+            <p className="focused-empty-title">Loading discoveries…</p>
+          </div>
+        ) : discoveries.length > 0 ? (
           <PlaceGrid
             discoveries={discoveries}
             contextKey={ctx.key}

--- a/app/_lib/homepage-data.ts
+++ b/app/_lib/homepage-data.ts
@@ -55,30 +55,36 @@ export interface HomepageContextData {
   }>;
 }
 
+export interface HomepageDigestItem {
+  entryId: string;
+  name: string;
+  city: string;
+  monitorType: string;
+  contextKey: string;
+  significanceLevel: string;
+  significanceSummary: string;
+  changes: string[];
+  stateContext?: {
+    rating?: number;
+    previousRating?: number;
+    operationalStatus?: string;
+    previousOperationalStatus?: string;
+  };
+  placeId?: string;
+}
+
 export interface HomepageData {
   contexts: HomepageContext[];
   initialContextKey: string | null;
-  initialDiscoveries: HomepageDiscovery[];
-  initialMonitoringQueue: HomepageContextData['monitoringQueue'];
-  contextMeta: Record<string, { travel?: unknown; accommodation?: unknown; bookingStatus?: string }>;
+}
+
+export interface HomepageBootstrapData {
+  contextKey: string | null;
+  discoveries: HomepageDiscovery[];
+  monitoringQueue: HomepageContextData['monitoringQueue'];
+  contextMeta?: { travel?: unknown; accommodation?: unknown; bookingStatus?: string };
   digestTeaser: string | null;
-  digestItems: Array<{
-    entryId: string;
-    name: string;
-    city: string;
-    monitorType: string;
-    contextKey: string;
-    significanceLevel: string;
-    significanceSummary: string;
-    changes: string[];
-    stateContext?: {
-      rating?: number;
-      previousRating?: number;
-      operationalStatus?: string;
-      previousOperationalStatus?: string;
-    };
-    placeId?: string;
-  }>;
+  digestItems: HomepageDigestItem[];
 }
 
 function sortContexts(contexts: Context[]): Context[] {
@@ -286,18 +292,25 @@ async function prepareHomepageState(userId: string) {
 }
 
 export async function getHomepageData(userId: string): Promise<HomepageData> {
-  const { homepageContexts, byContext, contextMeta, monitoringQueue, homepageDigest } = await prepareHomepageState(userId);
+  const { homepageContexts } = await prepareHomepageState(userId);
   const initialContextKey = homepageContexts[0]?.key ?? null;
-  // Keep all contexts for the switcher UI, but only SSR discoveries for the active context
-  // to keep HTML under 50KB - other contexts load lazily via /api/home/context
   return {
     contexts: homepageContexts,
     initialContextKey,
-    // Keep homepage SSR shell lean. Active-context discoveries/monitoring
-    // load immediately on the client after mount.
-    initialDiscoveries: [],
-    initialMonitoringQueue: [],
-    contextMeta,
+  };
+}
+
+export async function getHomepageBootstrapData(userId: string, contextKey?: string | null): Promise<HomepageBootstrapData> {
+  const { homepageContexts, byContext, contextMeta, monitoringQueue, homepageDigest } = await prepareHomepageState(userId);
+  const resolvedContextKey = contextKey && homepageContexts.some((item) => item.key === contextKey)
+    ? contextKey
+    : (homepageContexts[0]?.key ?? null);
+
+  return {
+    contextKey: resolvedContextKey,
+    discoveries: resolvedContextKey ? (byContext.get(resolvedContextKey) ?? []).map(toHomepageDiscovery) : [],
+    monitoringQueue: resolvedContextKey ? monitoringQueue.filter((item) => item.contextKey === resolvedContextKey) : [],
+    contextMeta: resolvedContextKey ? contextMeta[resolvedContextKey] : undefined,
     digestTeaser: homepageDigest.teaserText,
     digestItems: homepageDigest.items,
   };

--- a/app/_lib/homepage-data.ts
+++ b/app/_lib/homepage-data.ts
@@ -1,0 +1,315 @@
+import { getEffectiveDerivedUserDiscoveries, getEffectiveUserManifest } from './effective-user-data';
+import type { Context, Discovery } from './types';
+import { isContextActive } from './context-lifecycle';
+import { getHeroImage } from './image-url.server';
+import { isTypeCompatible } from './context-compat';
+import { scoreDiscovery } from './discovery-score';
+import { rankDiscoveriesForHomepage } from './discovery-preferences';
+import { annotateDiscoveriesForMonitoring } from './discovery-monitoring';
+import { bulkPromoteFromAnnotated, loadMonitorInventory } from './monitor-inventory';
+import type { MonitorChangeKind } from './monitor-inventory';
+import type { SignificanceLevel } from './observation-significance';
+import { buildHomepageDigest } from './monitor-digest';
+
+export type HomepageDiscovery = Pick<Discovery,
+  'id' |
+  'place_id' |
+  'name' |
+  'type' |
+  'rating' |
+  'heroImage' |
+  'images' |
+  'contextKey' |
+  'city' |
+  'rankingExplanation' |
+  'monitorStatus' |
+  'source' |
+  'discoveredAt' |
+  'placeIdStatus'
+>;
+
+export type HomepageContext = Pick<Context, 'key' | 'label' | 'emoji' | 'type' | 'city' | 'dates' | 'focus'> & {
+  purpose?: string;
+  people?: Array<{ name: string; relation?: string }>;
+};
+
+export interface HomepageContextData {
+  context: HomepageContext;
+  discoveries: HomepageDiscovery[];
+  monitoringQueue: Array<{
+    id: string;
+    name: string;
+    city: string;
+    type: string;
+    contextKey: string;
+    monitorStatus: string;
+    monitorType: string;
+    monitorCadence?: string;
+    monitorExplanation?: string;
+    dueNow: boolean;
+    placeId?: string;
+    detectedChanges?: MonitorChangeKind[];
+    significanceLevel?: SignificanceLevel;
+    significanceSummary?: string;
+    observationCount?: number;
+  }>;
+}
+
+export interface HomepageData {
+  contexts: HomepageContext[];
+  initialContextKey: string | null;
+  initialDiscoveries: HomepageDiscovery[];
+  initialMonitoringQueue: HomepageContextData['monitoringQueue'];
+  contextMeta: Record<string, { travel?: unknown; accommodation?: unknown; bookingStatus?: string }>;
+  digestTeaser: string | null;
+  digestItems: Array<{
+    entryId: string;
+    name: string;
+    city: string;
+    monitorType: string;
+    contextKey: string;
+    significanceLevel: string;
+    significanceSummary: string;
+    changes: string[];
+    stateContext?: {
+      rating?: number;
+      previousRating?: number;
+      operationalStatus?: string;
+      previousOperationalStatus?: string;
+    };
+    placeId?: string;
+  }>;
+}
+
+function sortContexts(contexts: Context[]): Context[] {
+  return [...contexts].sort((a, b) => {
+    if (a.type === 'trip' && b.type !== 'trip') return -1;
+    if (b.type === 'trip' && a.type !== 'trip') return 1;
+    if (a.type === 'outing' && b.type === 'radar') return -1;
+    if (b.type === 'outing' && a.type === 'radar') return 1;
+    return 0;
+  });
+}
+
+function enrichDiscoveriesWithImageMinimums(discoveries: Discovery[]): Discovery[] {
+  return discoveries.map((discovery) => {
+    const heroImage = getHeroImage(discovery.place_id, discovery.heroImage);
+    return heroImage ? { ...discovery, heroImage } : discovery;
+  });
+}
+
+function toHomepageDiscovery(discovery: Discovery): HomepageDiscovery {
+  return {
+    id: discovery.id,
+    place_id: discovery.place_id,
+    name: discovery.name,
+    type: discovery.type,
+    rating: discovery.rating,
+    heroImage: discovery.heroImage,
+    images: discovery.images,
+    contextKey: discovery.contextKey,
+    city: discovery.city,
+    rankingExplanation: discovery.rankingExplanation,
+    monitorStatus: discovery.monitorStatus,
+    source: discovery.source,
+    discoveredAt: discovery.discoveredAt,
+    placeIdStatus: discovery.placeIdStatus,
+  };
+}
+
+function toHomepageContext(context: Context): HomepageContext {
+  const raw = context as unknown as Record<string, unknown>;
+  return {
+    key: context.key,
+    label: context.label,
+    emoji: context.emoji,
+    type: context.type,
+    city: context.city,
+    dates: context.dates,
+    focus: context.focus,
+    purpose: raw.purpose as string | undefined,
+    people: raw.people as Array<{ name: string; relation?: string }> | undefined,
+  };
+}
+
+async function prepareHomepageState(userId: string) {
+  const [manifest, discoveriesData] = await Promise.all([
+    getEffectiveUserManifest(userId),
+    getEffectiveDerivedUserDiscoveries(userId),
+  ]);
+
+  const contexts = sortContexts((manifest?.contexts ?? []).filter((c) => isContextActive(c)));
+  const discoveries = discoveriesData?.discoveries ?? [];
+
+  const fullyBuilt = discoveries.filter((d) => {
+    if (!d.name || d.name === 'Unknown Place') return false;
+    if (d.source?.startsWith('chat:')) return true;
+    const rec = d as unknown as Record<string, unknown>;
+    const hasAddress = !!(rec.address as string);
+    const hasDescription = !!(rec.description || rec.summary);
+    const hasRating = d.rating != null && d.rating > 0;
+    return hasAddress || hasDescription || hasRating;
+  });
+
+  const enrichedDiscoveries = enrichDiscoveriesWithImageMinimums(fullyBuilt);
+  const byContext = new Map<string, Discovery[]>();
+
+  for (const ctx of contexts) {
+    const ctxSlug = ctx.key.split(':').slice(1).join(':');
+    const matched = enrichedDiscoveries.filter((d) => {
+      if (!isTypeCompatible(ctx.key, d.type)) return false;
+      if (d.contextKey === ctx.key) return true;
+      if (!d.contextKey || d.contextKey === '') return ctx.key === contexts[0]?.key;
+      const dSlug = d.contextKey.split(':').slice(1).join(':');
+      return dSlug === ctxSlug || dSlug.includes(ctxSlug) || ctxSlug.includes(dSlug);
+    });
+
+    const seenPlaceIds = new Set<string>();
+    const seenIds = new Set<string>();
+    const deduped = matched.filter((d) => {
+      if (d.place_id) {
+        if (seenPlaceIds.has(d.place_id)) return false;
+        seenPlaceIds.add(d.place_id);
+      }
+      if (seenIds.has(d.id)) return false;
+      seenIds.add(d.id);
+      return true;
+    });
+
+    byContext.set(ctx.key, deduped);
+  }
+
+  const globalSeenPlaceIds = new Set<string>();
+  for (const [ctxKey, items] of byContext) {
+    byContext.set(ctxKey, items.filter((d) => {
+      if (!d.place_id) return true;
+      if (globalSeenPlaceIds.has(d.place_id)) return false;
+      globalSeenPlaceIds.add(d.place_id);
+      return true;
+    }));
+  }
+
+  const rankedDiscoveries = await rankDiscoveriesForHomepage({
+    userId,
+    discoveries: Array.from(byContext.values()).flat(),
+    contexts,
+    baseScore: (discovery) => scoreDiscovery(discovery).total,
+  });
+
+  const monitoredDiscoveries = await annotateDiscoveriesForMonitoring({
+    userId,
+    discoveries: rankedDiscoveries,
+    contexts,
+  });
+
+  const rankedByKey = new Map(
+    monitoredDiscoveries.map((discovery) => [
+      discovery.place_id ? `${discovery.contextKey}::${discovery.place_id}` : `${discovery.contextKey}::${discovery.id}`,
+      discovery,
+    ]),
+  );
+
+  for (const [ctxKey, items] of byContext) {
+    const ranked = items
+      .map((discovery) => rankedByKey.get(discovery.place_id ? `${ctxKey}::${discovery.place_id}` : `${ctxKey}::${discovery.id}`) ?? discovery)
+      .sort((a, b) => (b.rankingScore ?? scoreDiscovery(b).total) - (a.rankingScore ?? scoreDiscovery(a).total));
+    byContext.set(ctxKey, ranked);
+  }
+
+  bulkPromoteFromAnnotated(userId, monitoredDiscoveries);
+
+  const inventory = await loadMonitorInventory(userId);
+  const inventoryById = new Map(inventory.entries.flatMap((e) => [[e.id, e], [e.discoveryId, e]]));
+
+  const visibleContexts = contexts.filter((c) => c.type === 'trip' || (byContext.get(c.key)?.length ?? 0) > 0);
+
+  const homepageContexts = visibleContexts.map(toHomepageContext);
+
+  const contextMeta = Object.fromEntries(
+    visibleContexts
+      .filter((c) => c.type === 'trip')
+      .map((c) => {
+        const raw = c as unknown as Record<string, unknown>;
+        return [c.key, {
+          travel: raw.travel,
+          accommodation: raw.accommodation,
+          bookingStatus: raw.bookingStatus as string | undefined,
+        }];
+      }),
+  );
+
+  const monitoringQueue = monitoredDiscoveries
+    .filter((d) => {
+      if (!d.monitorStatus || d.monitorStatus === 'none') return false;
+      if (d.monitorDueNow) return true;
+      const inv = inventoryById.get(d.place_id ?? d.id) ?? inventoryById.get(d.id);
+      const effectiveStatus = inv?.monitorStatus ?? d.monitorStatus;
+      return effectiveStatus === 'priority';
+    })
+    .sort((a, b) => {
+      if (a.monitorDueNow !== b.monitorDueNow) return a.monitorDueNow ? -1 : 1;
+      const rank: Record<string, number> = { priority: 0, active: 1, candidate: 2 };
+      const aInvForSort = inventoryById.get(a.place_id ?? a.id) ?? inventoryById.get(a.id);
+      const bInvForSort = inventoryById.get(b.place_id ?? b.id) ?? inventoryById.get(b.id);
+      const aStatus = aInvForSort?.monitorStatus ?? a.monitorStatus ?? 'candidate';
+      const bStatus = bInvForSort?.monitorStatus ?? b.monitorStatus ?? 'candidate';
+      const statusDiff = (rank[aStatus] ?? 9) - (rank[bStatus] ?? 9);
+      if (statusDiff !== 0) return statusDiff;
+      const sigRank: Record<string, number> = { critical: 3, notable: 2, routine: 1, noise: 0 };
+      return (sigRank[bInvForSort?.peakSignificanceLevel ?? 'noise'] ?? 0) - (sigRank[aInvForSort?.peakSignificanceLevel ?? 'noise'] ?? 0);
+    })
+    .slice(0, 8)
+    .map((d) => {
+      const inv = inventoryById.get(d.place_id ?? d.id) ?? inventoryById.get(d.id);
+      return {
+        id: d.id,
+        name: d.name,
+        city: d.city,
+        type: d.type,
+        contextKey: d.contextKey,
+        monitorStatus: inv?.monitorStatus ?? d.monitorStatus ?? 'candidate',
+        monitorType: d.monitorType ?? 'general',
+        monitorCadence: d.monitorCadence,
+        monitorExplanation: d.monitorExplanation,
+        dueNow: Boolean(d.monitorDueNow),
+        placeId: d.place_id,
+        detectedChanges: inv?.detectedChangeKinds,
+        significanceLevel: inv?.peakSignificanceLevel,
+        significanceSummary: inv?.latestSignificanceSummary,
+        observationCount: inv?.observations?.length ?? 0,
+      };
+    });
+
+  const homepageDigest = buildHomepageDigest(inventory);
+
+  return { visibleContexts, homepageContexts, byContext, contextMeta, monitoringQueue, homepageDigest };
+}
+
+export async function getHomepageData(userId: string): Promise<HomepageData> {
+  const { homepageContexts, byContext, contextMeta, monitoringQueue, homepageDigest } = await prepareHomepageState(userId);
+  const initialContextKey = homepageContexts[0]?.key ?? null;
+  // Keep all contexts for the switcher UI, but only SSR discoveries for the active context
+  // to keep HTML under 50KB - other contexts load lazily via /api/home/context
+  return {
+    contexts: homepageContexts,
+    initialContextKey,
+    // Keep homepage SSR shell lean. Active-context discoveries/monitoring
+    // load immediately on the client after mount.
+    initialDiscoveries: [],
+    initialMonitoringQueue: [],
+    contextMeta,
+    digestTeaser: homepageDigest.teaserText,
+    digestItems: homepageDigest.items,
+  };
+}
+
+export async function getHomepageContextData(userId: string, contextKey: string): Promise<HomepageContextData | null> {
+  const { homepageContexts, byContext, monitoringQueue } = await prepareHomepageState(userId);
+  const context = homepageContexts.find((item) => item.key === contextKey);
+  if (!context) return null;
+  return {
+    context,
+    discoveries: (byContext.get(context.key) ?? []).map(toHomepageDiscovery),
+    monitoringQueue: monitoringQueue.filter((item) => item.contextKey === context.key),
+  };
+}

--- a/app/api/home/bootstrap/route.ts
+++ b/app/api/home/bootstrap/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getHomepageBootstrapData } from '../../../_lib/homepage-data';
+import { getCurrentUser } from '../../../_lib/user';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const contextKey = request.nextUrl.searchParams.get('key');
+  const data = await getHomepageBootstrapData(user.id, contextKey);
+  return NextResponse.json(data);
+}

--- a/app/api/home/context/route.ts
+++ b/app/api/home/context/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getHomepageContextData } from '../../../_lib/homepage-data';
+import { getCurrentUser } from '../../../_lib/user';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const contextKey = request.nextUrl.searchParams.get('key');
+  if (!contextKey) {
+    return NextResponse.json({ error: 'Missing context key' }, { status: 400 });
+  }
+
+  const data = await getHomepageContextData(user.id, contextKey);
+  if (!data) {
+    return NextResponse.json({ error: 'Context not found' }, { status: 404 });
+  }
+
+  return NextResponse.json(data);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,26 @@
 import Link from 'next/link';
 import { getCurrentUser } from './_lib/user';
-import { getHomepageData } from './_lib/homepage-data';
+import { getHomepageData, type HomepageContext } from './_lib/homepage-data';
 import HomeClient from './_components/HomeClient';
 
 export const dynamic = 'force-dynamic';
+
+function sanitizeHomepageContexts(contexts: HomepageContext[]): HomepageContext[] {
+  return contexts.map((context) => ({
+    key: context.key,
+    label: context.label,
+    emoji: context.emoji,
+    type: context.type,
+    city: context.city,
+    dates: context.dates,
+    focus: [...context.focus],
+    purpose: context.purpose,
+    people: context.people?.map((person) => ({
+      name: person.name,
+      relation: person.relation,
+    })),
+  }));
+}
 
 export default async function HomePage() {
   const user = await getCurrentUser();
@@ -20,8 +37,9 @@ export default async function HomePage() {
   }
 
   const homepageData = await getHomepageData(user.id);
+  const contexts = sanitizeHomepageContexts(homepageData.contexts);
 
-  if (!user.isOwner && homepageData.contexts.length === 0) {
+  if (!user.isOwner && contexts.length === 0) {
     const { redirect } = await import('next/navigation');
     redirect('/onboarding');
   }
@@ -29,7 +47,7 @@ export default async function HomePage() {
   return (
     <HomeClient
       userId={user.id}
-      contexts={homepageData.contexts}
+      contexts={contexts}
       initialContextKey={homepageData.initialContextKey}
     />
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,11 +31,6 @@ export default async function HomePage() {
       userId={user.id}
       contexts={homepageData.contexts}
       initialContextKey={homepageData.initialContextKey}
-      initialDiscoveries={homepageData.initialDiscoveries}
-      initialMonitoringQueue={homepageData.initialMonitoringQueue}
-      contextMeta={homepageData.contextMeta}
-      digestTeaser={homepageData.digestTeaser}
-      digestItems={homepageData.digestItems}
     />
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,39 +1,9 @@
 import Link from 'next/link';
 import { getCurrentUser } from './_lib/user';
-import { getEffectiveDerivedUserDiscoveries, getEffectiveUserManifest } from './_lib/effective-user-data';
-import type { Context, Discovery } from './_lib/types';
-import { isContextActive } from './_lib/context-lifecycle';
-import { getHeroImage } from './_lib/image-url.server';
-import { isTypeCompatible } from './_lib/context-compat';
-import { scoreDiscovery } from './_lib/discovery-score';
-import { rankDiscoveriesForHomepage } from './_lib/discovery-preferences';
-import { annotateDiscoveriesForMonitoring } from './_lib/discovery-monitoring';
-import { bulkPromoteFromAnnotated, loadMonitorInventory } from './_lib/monitor-inventory';
-import type { MonitorChangeKind } from './_lib/monitor-inventory';
-import type { SignificanceLevel } from './_lib/observation-significance';
-import { buildHomepageDigest } from './_lib/monitor-digest';
+import { getHomepageData } from './_lib/homepage-data';
 import HomeClient from './_components/HomeClient';
 
 export const dynamic = 'force-dynamic';
-
-function sortContexts(contexts: Context[]): Context[] {
-  return [...contexts].sort((a, b) => {
-    // Trips with dates first (nearest date first)
-    if (a.type === 'trip' && b.type !== 'trip') return -1;
-    if (b.type === 'trip' && a.type !== 'trip') return 1;
-    // Outings next
-    if (a.type === 'outing' && b.type === 'radar') return -1;
-    if (b.type === 'outing' && a.type === 'radar') return 1;
-    return 0;
-  });
-}
-
-function enrichDiscoveriesWithImageMinimums(discoveries: Discovery[]): Discovery[] {
-  return discoveries.map((discovery) => {
-    const heroImage = getHeroImage(discovery.place_id, discovery.heroImage);
-    return heroImage ? { ...discovery, heroImage } : discovery;
-  });
-}
 
 export default async function HomePage() {
   const user = await getCurrentUser();
@@ -43,229 +13,29 @@ export default async function HomePage() {
       <main className="page">
         <div className="page-header">
           <h1>🧭 Compass</h1>
-          <p>Personal travel intelligence. <Link href="/u/join" style={{textDecoration: 'underline', color: 'inherit'}}>Sign in</Link> to get started.</p>
+          <p>Personal travel intelligence. <Link href="/u/join" style={{ textDecoration: 'underline', color: 'inherit' }}>Sign in</Link> to get started.</p>
         </div>
       </main>
     );
   }
 
-  const [manifest, discoveriesData] = await Promise.all([
-    getEffectiveUserManifest(user.id),
-    getEffectiveDerivedUserDiscoveries(user.id),
-  ]);
+  const homepageData = await getHomepageData(user.id);
 
-  // Non-owner with no manifest → onboarding
-  if (!user.isOwner && (!manifest || manifest.contexts.length === 0)) {
+  if (!user.isOwner && homepageData.contexts.length === 0) {
     const { redirect } = await import('next/navigation');
     redirect('/onboarding');
   }
 
-  const contexts = sortContexts(
-    (manifest?.contexts ?? []).filter(c => isContextActive(c)),
-  );
-  const discoveries = discoveriesData?.discoveries ?? [];
-
-  // Filter out discoveries that are not fully built
-  // A discovery must have at minimum: a name AND (address OR description OR rating)
-  const fullyBuilt = discoveries.filter(d => {
-    if (!d.name || d.name === 'Unknown Place') return false;
-    // Chat-sourced discoveries may not have address/rating yet — always show them
-    if (d.source?.startsWith('chat:')) return true;
-    const rec = d as unknown as Record<string, unknown>;
-    const hasAddress = !!(rec.address as string);
-    const hasDescription = !!(rec.description || rec.summary);
-    const hasRating = d.rating != null && d.rating > 0;
-    return hasAddress || hasDescription || hasRating;
-  });
-  const discoveries_final = fullyBuilt;
-
-  const enrichedDiscoveries = enrichDiscoveriesWithImageMinimums(discoveries_final);
-
-  // Group discoveries by context — fuzzy match on slug to handle key variants
-  // Fix #108: deduplicate by place_id within each context bucket
-  const byContext = new Map<string, Discovery[]>();
-  for (const ctx of contexts) {
-    const ctxSlug = ctx.key.split(':').slice(1).join(':');
-    const matched = enrichedDiscoveries.filter(d => {
-      // Type-context compatibility check (e.g. no galleries in dinner outings)
-      if (!isTypeCompatible(ctx.key, d.type)) return false;
-      // Exact match first
-      if (d.contextKey === ctx.key) return true;
-      // Empty contextKey defaults to first context (typically the active trip)
-      if (!d.contextKey || d.contextKey === '') {
-        return ctx.key === contexts[0]?.key;
-      }
-      // Fuzzy: slug contains or is contained by context slug
-      const dSlug = d.contextKey.split(':').slice(1).join(':');
-      return dSlug === ctxSlug || dSlug.includes(ctxSlug) || ctxSlug.includes(dSlug);
-    });
-
-    // Deduplicate by place_id (keep first occurrence), then by id
-    const seenPlaceIds = new Set<string>();
-    const seenIds = new Set<string>();
-    const deduped = matched.filter(d => {
-      if (d.place_id) {
-        if (seenPlaceIds.has(d.place_id)) return false;
-        seenPlaceIds.add(d.place_id);
-      }
-      if (seenIds.has(d.id)) return false;
-      seenIds.add(d.id);
-      return true;
-    });
-
-    // Show all places — photos are guaranteed by ingest pipeline (Fix #234)
-    const withPhoto = deduped;
-    byContext.set(ctx.key, withPhoto);
-  }
-
-  // Fix #108 (global): deduplicate place_ids across ALL context carousels
-  // A place appearing in NYC trip should not also appear in the Toronto radar carousel
-  const globalSeenPlaceIds = new Set<string>();
-  for (const [ctxKey, items] of byContext) {
-    const globalDeduped = items.filter(d => {
-      if (!d.place_id) return true; // no place_id → always show (won't match cross-context)
-      if (globalSeenPlaceIds.has(d.place_id)) return false;
-      globalSeenPlaceIds.add(d.place_id);
-      return true;
-    });
-    byContext.set(ctxKey, globalDeduped);
-  }
-
-  const rankedDiscoveries = await rankDiscoveriesForHomepage({
-    userId: user.id,
-    discoveries: Array.from(byContext.values()).flat(),
-    contexts,
-    baseScore: (discovery) => scoreDiscovery(discovery).total,
-  });
-
-  const monitoredDiscoveries = await annotateDiscoveriesForMonitoring({
-    userId: user.id,
-    discoveries: rankedDiscoveries,
-    contexts,
-  });
-
-  const rankedByKey = new Map(
-    monitoredDiscoveries.map((discovery) => [
-      discovery.place_id ? `${discovery.contextKey}::${discovery.place_id}` : `${discovery.contextKey}::${discovery.id}`,
-      discovery,
-    ]),
-  );
-
-  for (const [ctxKey, items] of byContext) {
-    const ranked = items
-      .map((discovery) => rankedByKey.get(discovery.place_id ? `${ctxKey}::${discovery.place_id}` : `${ctxKey}::${discovery.id}`) ?? discovery)
-      .sort((a, b) => (b.rankingScore ?? scoreDiscovery(b).total) - (a.rankingScore ?? scoreDiscovery(a).total));
-    byContext.set(ctxKey, ranked);
-  }
-
-  // Auto-promote active/priority monitored places into the durable inventory (fire-and-forget)
-  bulkPromoteFromAnnotated(user.id, monitoredDiscoveries);
-
-  // Load durable inventory for change signals
-  const inventory = await loadMonitorInventory(user.id);
-  const inventoryById = new Map(
-    inventory.entries.flatMap(e => [
-      [e.id, e],
-      [e.discoveryId, e],
-    ]),
-  );
-
-  // Hide contexts with no discoveries in their final ranked bucket (homepage only).
-  // Contexts remain accessible in /review and other pages — this suppression is
-  // limited to homepage rendering so the page never shows empty carousels.
-  // Trip contexts are always shown (they carry planning widgets even without discoveries).
-  const visibleContexts = contexts.filter(c =>
-    c.type === 'trip' || (byContext.get(c.key)?.length ?? 0) > 0
-  );
-
-  // Build contextMeta — structured trip data for widgets
-  const contextMeta = Object.fromEntries(
-    visibleContexts
-      .filter(c => c.type === 'trip')
-      .map(c => {
-        const raw = c as unknown as Record<string, unknown>;
-        return [c.key, {
-          travel: raw.travel,
-          accommodation: raw.accommodation,
-          bookingStatus: raw.bookingStatus as string | undefined,
-        }];
-      })
-  );
-
-  // Build monitoring queue: due-now places + priority monitored places (up to 8)
-  const monitoringQueue: Array<{
-    id: string;
-    name: string;
-    city: string;
-    type: string;
-    contextKey: string;
-    monitorStatus: string;
-    monitorType: string;
-    monitorCadence?: string;
-    monitorExplanation?: string;
-    dueNow: boolean;
-    placeId?: string;
-    detectedChanges?: MonitorChangeKind[];
-    significanceLevel?: SignificanceLevel;
-    significanceSummary?: string;
-    observationCount?: number;
-  }> = monitoredDiscoveries
-    .filter(d => {
-      if (!d.monitorStatus || d.monitorStatus === 'none') return false;
-      if (d.monitorDueNow) return true;
-      // Also include places whose durable inventory status escalated to priority
-      const inv = inventoryById.get(d.place_id ?? d.id) ?? inventoryById.get(d.id);
-      const effectiveStatus = inv?.monitorStatus ?? d.monitorStatus;
-      return effectiveStatus === 'priority';
-    })
-    .sort((a, b) => {
-      if (a.monitorDueNow !== b.monitorDueNow) return a.monitorDueNow ? -1 : 1;
-      const rank: Record<string, number> = { priority: 0, active: 1, candidate: 2 };
-      const aInvForSort = inventoryById.get(a.place_id ?? a.id) ?? inventoryById.get(a.id);
-      const bInvForSort = inventoryById.get(b.place_id ?? b.id) ?? inventoryById.get(b.id);
-      const aStatus = aInvForSort?.monitorStatus ?? a.monitorStatus ?? 'candidate';
-      const bStatus = bInvForSort?.monitorStatus ?? b.monitorStatus ?? 'candidate';
-      const statusDiff = (rank[aStatus] ?? 9) - (rank[bStatus] ?? 9);
-      if (statusDiff !== 0) return statusDiff;
-      // Within same status group: critical/notable significance first
-      const sigRank: Record<string, number> = { critical: 3, notable: 2, routine: 1, noise: 0 };
-      return (sigRank[bInvForSort?.peakSignificanceLevel ?? 'noise'] ?? 0) - (sigRank[aInvForSort?.peakSignificanceLevel ?? 'noise'] ?? 0);
-    })
-    .slice(0, 8)
-    .map(d => {
-      const inv = inventoryById.get(d.place_id ?? d.id) ?? inventoryById.get(d.id);
-      return {
-        id: d.id,
-        name: d.name,
-        city: d.city,
-        type: d.type,
-        contextKey: d.contextKey,
-        // Prefer durable inventory status (may have been escalated by significance)
-        monitorStatus: inv?.monitorStatus ?? d.monitorStatus ?? 'candidate',
-        monitorType: d.monitorType ?? 'general',
-        monitorCadence: d.monitorCadence,
-        monitorExplanation: d.monitorExplanation,
-        dueNow: Boolean(d.monitorDueNow),
-        placeId: d.place_id,
-        detectedChanges: inv?.detectedChangeKinds,
-        significanceLevel: inv?.peakSignificanceLevel,
-        significanceSummary: inv?.latestSignificanceSummary,
-        observationCount: inv?.observations?.length ?? 0,
-      };
-    });
-
-  // Build significance digest for recent changes banner
-  const homepageDigest = buildHomepageDigest(inventory);
-
   return (
     <HomeClient
       userId={user.id}
-      contexts={visibleContexts}
-      discoveryMap={Object.fromEntries(byContext)}
-      contextMeta={contextMeta}
-      monitoringQueue={monitoringQueue}
-      digestTeaser={homepageDigest.teaserText}
-      digestItems={homepageDigest.items}
+      contexts={homepageData.contexts}
+      initialContextKey={homepageData.initialContextKey}
+      initialDiscoveries={homepageData.initialDiscoveries}
+      initialMonitoringQueue={homepageData.initialMonitoringQueue}
+      contextMeta={homepageData.contextMeta}
+      digestTeaser={homepageData.digestTeaser}
+      digestItems={homepageData.digestItems}
     />
   );
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   reporter: [['html', { open: 'never' }]],
   outputDir: 'test-results',
   use: {
-    baseURL: 'http://localhost:3002',
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3002',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     // Reuse auth state seeded by global-setup (compass-user cookie)

--- a/scripts/check-homepage-size.ts
+++ b/scripts/check-homepage-size.ts
@@ -1,0 +1,59 @@
+/**
+ * Homepage HTML Budget Check
+ *
+ * Validates that signed-in homepage HTML stays under 50KB to maintain fast LCP.
+ * Run as: npx tsx scripts/check-homepage-size.ts
+ *
+ * Expects COMPASS_USER cookie for authenticated state:
+ *   curl -s http://localhost:3002/ -b "compass-user=john" | wc -c
+ */
+
+const DEFAULT_URL = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : 'http://localhost:3002';
+
+const BUDGET_BYTES = 50 * 1024; // 50KB
+
+async function checkHomepageSize() {
+  const url = process.env.HOMEPAGE_URL || DEFAULT_URL;
+  const cookie = process.env.COMPASS_COOKIE || 'compass-user=john';
+
+  console.log(`\n🏠 Homepage HTML Budget Check`);
+  console.log(`   URL: ${url}`);
+  console.log(`   Budget: ${(BUDGET_BYTES / 1024).toFixed(0)}KB`);
+
+  try {
+    const res = await fetch(url, {
+      headers: {
+        // Pass user identity via cookie
+        Cookie: cookie,
+      },
+    });
+
+    if (!res.ok) {
+      console.error(`\n❌ Failed to fetch homepage: ${res.status} ${res.statusText}`);
+      process.exit(1);
+    }
+
+    const html = await res.text();
+    const bytes = Buffer.byteLength(html, 'utf8');
+    const kb = bytes / 1024;
+
+    console.log(`   Actual: ${kb.toFixed(1)}KB (${bytes.toLocaleString()} bytes)`);
+
+    if (bytes > BUDGET_BYTES) {
+      const over = kb - (BUDGET_BYTES / 1024);
+      console.error(`\n❌ OVER BUDGET by ${over.toFixed(1)}KB`);
+      console.error(`   Reduce discovery payload or lazy-load non-active contexts.`);
+      process.exit(1);
+    }
+
+    console.log(`\n✅ Under budget`);
+
+  } catch (err) {
+    console.error(`\n❌ Error:`, err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+}
+
+checkHomepageSize();

--- a/tests/homepage-html-budget.spec.ts
+++ b/tests/homepage-html-budget.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+const HOMEPAGE_HTML_BUDGET_BYTES = 50 * 1024;
+
+test('signed-in homepage HTML stays under the mobile SSR budget', async ({ request }) => {
+  const response = await request.get('/', {
+    headers: {
+      Cookie: 'compass-user=john',
+    },
+  });
+
+  expect(response.ok()).toBeTruthy();
+  const html = await response.text();
+  const bytes = Buffer.byteLength(html, 'utf8');
+
+  expect(bytes, `homepage HTML budget exceeded: ${bytes} bytes`).toBeLessThan(HOMEPAGE_HTML_BUDGET_BYTES);
+});

--- a/tests/homepage-html-budget.spec.ts
+++ b/tests/homepage-html-budget.spec.ts
@@ -1,17 +1,35 @@
 import { test, expect } from '@playwright/test';
 
-const HOMEPAGE_HTML_BUDGET_BYTES = 50 * 1024;
+const HTML_BUDGET_BYTES = 50 * 1024;
 
-test('signed-in homepage HTML stays under the mobile SSR budget', async ({ request }) => {
+test('homepage HTML stays under the mobile budget for john', async ({ request, baseURL }) => {
+  test.skip(!baseURL, 'baseURL is required');
+
   const response = await request.get('/', {
     headers: {
-      Cookie: 'compass-user=john',
+      cookie: 'compass-user=john',
     },
   });
 
   expect(response.ok()).toBeTruthy();
+
   const html = await response.text();
   const bytes = Buffer.byteLength(html, 'utf8');
 
-  expect(bytes, `homepage HTML budget exceeded: ${bytes} bytes`).toBeLessThan(HOMEPAGE_HTML_BUDGET_BYTES);
+  expect(bytes, `Homepage HTML was ${bytes} bytes`).toBeLessThan(HTML_BUDGET_BYTES);
+  expect(html).toContain('focused-content');
+  expect(html).toContain('NYC Solo Trip');
+});
+
+test('homepage still loads discovery cards and place-card navigation for john', async ({ page, baseURL }) => {
+  test.skip(!baseURL, 'baseURL is required');
+
+  await page.context().addCookies([{ name: 'compass-user', value: 'john', url: baseURL }]);
+  await page.goto('/', { waitUntil: 'networkidle' });
+
+  const firstCard = page.locator('.place-card').first();
+  await expect(firstCard).toBeVisible();
+
+  await firstCard.click();
+  await expect(page).toHaveURL(/\/placecards\//);
 });


### PR DESCRIPTION
## Summary
- move homepage data assembly into a dedicated server helper and stop SSR-rendering discovery payloads for every context
- lazy-load the active context discovery and monitoring payload from /api/home/context after mount, preserving visible sections and place-card navigation
- add homepage HTML budget coverage with a Playwright assertion and a scriptable size check

## Verification
- npm run build
- PLAYWRIGHT_BASE_URL=http://localhost:3102 npx playwright test tests/homepage-html-budget.spec.ts
- PLAYWRIGHT_BASE_URL=http://localhost:3102 npx playwright test tests/e2e-homepage.spec.ts tests/chat.spec.ts tests/smoke.spec.ts
- HOMEPAGE_URL=http://localhost:3102 COMPASS_COOKIE='compass-user=john' npx tsx scripts/check-homepage-size.ts
- curl -s http://localhost:3102/ -b 'compass-user=john' | wc -c  # 20367 bytes

Fixes #323