### PR TITLE
fix: restore place card maps action (#326)

### DIFF
--- a/app/_components/PlaceCardDetail.tsx
+++ b/app/_components/PlaceCardDetail.tsx
@@ -373,7 +373,30 @@ export default function PlaceCardDetail({ card, userId, contextKey, discovery }:
       {/* ── Body ── */}
       <div className="place-detail-v2-body">
 
-        {/* Google Maps CTA removed — single link lives in the actions row below the map */}
+        {/* Required actions stay above the fold for place cards with place IDs */}
+        <div className="place-detail-actions-row">
+          {googleMapsUrl && card.type !== 'accommodation' && (
+            <a href={googleMapsUrl} target="_blank" rel="noopener noreferrer"
+               className="place-detail-action-btn">
+              📍 View in Maps →
+            </a>
+          )}
+          {googleEarthUrl && (
+            <a href={googleEarthUrl} target="_blank" rel="noopener noreferrer"
+               className="place-detail-action-btn">
+              🌍 Google Earth 3D →
+            </a>
+          )}
+          <ShareButton name={card.name} />
+          {userId && contextKey && card.place_id && (
+            <TriageWidget
+              userId={userId}
+              contextKey={contextKey}
+              contextLabel=""
+              placeId={card.place_id}
+            />
+          )}
+        </div>
 
         {/* ── ABOVE THE FOLD: hours first, then food strip, identity, narrative ── */}
 
@@ -563,26 +586,6 @@ export default function PlaceCardDetail({ card, userId, contextKey, discovery }:
         {contextKey && contextKey.startsWith('trip:') && card.place_id && (
           <TravelIntelWidget placeId={card.place_id} contextKey={contextKey} />
         )}
-
-        {/* ── Compact actions row ── */}
-        <div className="place-detail-actions-row">
-          {/* Maps link moved to address row above */}
-          {googleEarthUrl && (
-            <a href={googleEarthUrl} target="_blank" rel="noopener noreferrer"
-               className="place-detail-action-btn">
-              🌍 Google Earth 3D →
-            </a>
-          )}
-          <ShareButton name={card.name} />
-          {userId && contextKey && card.place_id && (
-            <TriageWidget
-              userId={userId}
-              contextKey={contextKey}
-              contextLabel=""
-              placeId={card.place_id}
-            />
-          )}
-        </div>
 
         {/* Map (compact 200px) */}
         <div className="place-detail-map-compact">

--- a/app/_lib/card-adapter.ts
+++ b/app/_lib/card-adapter.ts
@@ -75,6 +75,40 @@ export function adaptCard(raw: Record<string, unknown>, manifest?: Record<string
     };
   }
 
+  // Flat stub card format used by lightweight/generated place cards.
+  if (typeof raw.name === 'string' && typeof raw.type === 'string') {
+    const flat = raw as Record<string, unknown>;
+    const name = raw.name;
+    const type = raw.type;
+    const heroImage = typeof flat.hero_image === 'string' ? flat.hero_image : undefined;
+    const address = typeof flat.address === 'string' ? flat.address : undefined;
+    const city = typeof flat.city === 'string' ? flat.city : undefined;
+    const rating = typeof flat.rating === 'number' ? flat.rating : undefined;
+    const reviewCount = typeof flat.reviewCount === 'number'
+      ? flat.reviewCount
+      : typeof flat.user_rating_count === 'number'
+        ? flat.user_rating_count
+        : undefined;
+
+    return {
+      place_id: typeof flat.place_id === 'string' ? flat.place_id : '',
+      name,
+      type: normalizeType(type),
+      data: {
+        description: typeof flat.description === 'string' ? flat.description : '',
+        highlights: [],
+        images: mergePlaceCardImages(
+          heroImage ? [{ path: heroImage, category: 'general' }] : [],
+          manifestImages,
+        ),
+        ...(address ? { address } : {}),
+        ...(city ? { city } : {}),
+        ...(rating !== undefined ? { rating } : {}),
+        ...(reviewCount !== undefined ? { reviewCount } : {}),
+      },
+    };
+  }
+
   // V1 format
   const v1 = raw as unknown as V1Card;
   const identity = v1.identity ?? { name: 'Unknown' };

--- a/tests/e2e-homepage.spec.ts
+++ b/tests/e2e-homepage.spec.ts
@@ -15,6 +15,14 @@ async function loginAndGoHome(page: Page) {
 }
 
 test.describe('Homepage Layout', () => {
+  test('place card pages render a visible View in Maps action for place_id-backed cards', async ({ page }) => {
+    await page.goto('/placecards/ChIJW_WGT2BZwokRNpvZ4k3lVcs?context=trip%3Anyc-april-2026', { waitUntil: 'networkidle' });
+
+    const mapsLink = page.getByRole('link', { name: /View in Maps/i }).first();
+    await expect(mapsLink).toBeVisible({ timeout: 8000 });
+    await expect(mapsLink).toHaveAttribute('href', 'https://www.google.com/maps/place/?q=place_id:ChIJW_WGT2BZwokRNpvZ4k3lVcs');
+  });
+
   test('renders single-track focused view with all key elements', async ({ page }) => {
     await loginAndGoHome(page);
 

--- a/tests/placecard-maps-action.test.ts
+++ b/tests/placecard-maps-action.test.ts
@@ -1,0 +1,33 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+async function renderPlaceCardDetail(props: Record<string, unknown>) {
+  const imported = await import('../app/_components/PlaceCardDetail');
+  const PlaceCardDetail = ((imported.default as { default?: unknown })?.default ?? imported.default) as React.ComponentType<Record<string, unknown>>;
+  return renderToStaticMarkup(React.createElement(PlaceCardDetail, props));
+}
+
+describe('place card View in Maps action (issue #326)', () => {
+  test('renders the Maps action even when the card has no address fields', async () => {
+    const html = await renderPlaceCardDetail({
+      card: {
+        place_id: 'ChIJAddresslessPlace123',
+        name: 'Addressless Place',
+        type: 'restaurant',
+        data: {
+          description: 'A place card reached from discovery data without a rendered address.',
+          highlights: [],
+          images: [],
+        },
+      },
+    });
+
+    assert.match(html, /View in Maps/);
+    assert.match(
+      html,
+      /href="https:\/\/www\.google\.com\/maps\/place\/\?q=place_id:ChIJAddresslessPlace123"/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- preserve flat stub place card data in the card adapter so place_id-backed detail pages keep their real place metadata
- move the shared View in Maps action above the fold on place detail pages
- add a regression test covering the required place_id maps link on the reported place card route

## Testing
- npx next build
- npx tsx -e "import { adaptCard } from './app/_lib/card-adapter.ts'; const raw = { place_id: 'ChIJW_WGT2BZwokRNpvZ4k3lVcs', name: 'Maison Premiere', type: 'bar', address: '298 Bedford Ave, Brooklyn, NY 11249', city: '', rating: 4.6, hero_image: null, stub: true }; const manifest = { images: [{ path: 'https://example.com/photo.jpg', category: 'general' }] }; const card = adaptCard(raw, manifest); if (card.place_id !== raw.place_id) throw new Error('place_id missing'); if (card.name !== raw.name) throw new Error('name missing'); if (card.type !== 'bar') throw new Error('type missing'); if (card.data.address !== raw.address) throw new Error('address missing'); if (!Array.isArray(card.data.images) || card.data.images.length !== 1) throw new Error('images missing'); console.log(JSON.stringify({ place_id: card.place_id, name: card.name, type: card.type, address: card.data.address, images: card.data.images.length }));" 
- npx playwright test tests/e2e-homepage.spec.ts --grep "place_id-backed cards" *(fails in local self-hosted run because next start errors without BLOB_READ_WRITE_TOKEN)*

Fixes #326