### PR TITLE
fix: unblock homepage place card navigation (#329)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6961,8 +6961,8 @@ nextjs-portal { display: none !important; }
 .focused-content {
   display: flex;
   flex-direction: column;
-  gap: var(--space-lg);
-  flex-grow: 0; /* don't stretch to fill viewport — avoid empty space gap */
+  gap: var(--space-md);
+  flex-grow: 0; /* keep the first carousel clear of the pinned chat bar */
 }
 
 /* ---- Focused Hero (context header) ---- */

--- a/tests/e2e-homepage.spec.ts
+++ b/tests/e2e-homepage.spec.ts
@@ -9,7 +9,16 @@ import { test, expect, type Page } from '@playwright/test';
 // Auth is pre-seeded by global-setup.ts (compass-user cookie for qa-test-user)
 
 /** Navigate to homepage (auth already set by global-setup) */
-async function loginAndGoHome(page: Page) {
+async function loginAndGoHome(page: Page, userId?: string) {
+  if (userId) {
+    await page.context().addCookies([
+      {
+        name: 'compass-user',
+        value: userId,
+        url: 'http://localhost:3002',
+      },
+    ]);
+  }
   await page.goto('/', { waitUntil: 'networkidle' });
   await page.waitForTimeout(1000); // let client hydrate
 }
@@ -67,6 +76,23 @@ test.describe('Homepage Layout', () => {
         expect(await prompts.count()).toBeGreaterThanOrEqual(1);
       }
     }
+  });
+
+  test('homepage place cards navigate when their visible center is clicked', async ({ page }) => {
+    await loginAndGoHome(page, 'john');
+
+    const cardLink = page.locator('a.place-card[href*="/placecards/"]').first();
+    await expect(cardLink).toBeVisible({ timeout: 8000 });
+    const href = await cardLink.getAttribute('href');
+    expect(href).toBeTruthy();
+
+    const box = await cardLink.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) return;
+
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    await page.waitForURL((url) => url.pathname.startsWith('/placecards/'), { timeout: 10000 });
+    expect(page.url()).toContain('/placecards/');
   });
 
   test('chat input is accessible without scrolling on mobile', async ({ page }) => {


### PR DESCRIPTION
## Summary
- tighten the focused homepage section spacing so the first homepage place-card row stays clear of the pinned chat bar
- keep the homepage place-card center point clickable instead of letting the fixed chat input intercept it
- update the homepage regression to click the visible center of the first place card and expect place-detail navigation

## Verification
- reproduced on `http://localhost:3002/` signed in as `john`: the first homepage place-card center point resolved to the pinned chat input row and clicking it stayed on `/`
- focused Playwright regression passed against the clean worktree dev server on `http://localhost:3003/`
- manual browser verification on the clean worktree server at `http://localhost:3003/`: place-card center click navigates, Maps still opens Google Maps, chat-about still scopes to the place, and triage buttons still render

Closes #329