### PR TITLE
fix: make homepage place card shell reliably clickable

### DIFF
--- a/app/_components/PlaceCard.tsx
+++ b/app/_components/PlaceCard.tsx
@@ -121,32 +121,19 @@ export default function PlaceCard({ discovery, contextKey, contextLabel, context
     window.open(mapsUrl, '_blank', 'noopener,noreferrer');
   }, [mapsUrl]);
 
-  const handleCardClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    const target = e.target as HTMLElement;
-    if (target.closest('a, button, input, textarea, select, summary, [role="button"]')) {
-      return;
-    }
-    router.push(detailHref);
-  }, [detailHref, router]);
-
-  const handleCardKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.target !== e.currentTarget) return;
-    if (e.key !== 'Enter' && e.key !== ' ') return;
-    e.preventDefault();
+  const handleCardSurfaceClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target;
+    if (!(target instanceof Element)) return;
+    if (target.closest('a, button')) return;
     router.push(detailHref);
   }, [detailHref, router]);
 
   return (
     <div
-      style={{ position: 'relative' }}
-      className={isChatTarget ? 'place-card-chat-active' : ''}
-      onClick={handleCardClick}
-      onKeyDown={handleCardKeyDown}
-      role="link"
-      tabIndex={0}
-      aria-label={`Open ${name} in Compass`}
+      className={`place-card-shell${isChatTarget ? ' place-card-chat-active' : ''}`}
+      onClick={handleCardSurfaceClick}
     >
-      <div className="place-card">
+      <Link href={detailHref} className="place-card" aria-label={`Open ${name} in Compass`}>
         <div className="place-card-image" style={gradientStyle as React.CSSProperties}>
           {!finalImageUrl && <span className="place-card-image-fallback" />}
           {/* Hidden img for onError detection - triggers on load failure */}
@@ -187,7 +174,7 @@ export default function PlaceCard({ discovery, contextKey, contextLabel, context
             </div>
           )}
         </div>
-      </div>
+      </Link>
       <div className="place-card-footer">
         <Link href={detailHref} className="place-card-detail-link" aria-label={`View ${name} details in Compass`}>
           View details →
@@ -204,7 +191,7 @@ export default function PlaceCard({ discovery, contextKey, contextLabel, context
         )}
       </div>
       {userId && place_id && (
-        <div className="place-card-triage-overlay" onClick={(e) => e.stopPropagation()}>
+        <div className="place-card-triage-overlay">
           <TriageButtons userId={userId} contextKey={contextKey} placeId={place_id} size="sm" />
         </div>
       )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1052,6 +1052,10 @@ a:hover {
 
 /* ---- 19. Place Card ---- */
 
+.place-card-shell {
+  position: relative;
+}
+
 .place-card {
   display: flex;
   flex-direction: column;

--- a/tests/e2e-homepage.spec.ts
+++ b/tests/e2e-homepage.spec.ts
@@ -30,6 +30,7 @@ test.describe('Homepage Layout', () => {
 
     test.skip(await page.locator('.place-card-detail-link').count() === 0, 'No homepage place cards are seeded for this user in the local fixture');
 
+    const cardShell = page.locator('.place-card-shell').first();
     const detailLink = page.locator('.place-card-detail-link').first();
     await expect(detailLink).toBeVisible({ timeout: 8000 });
     await expect(detailLink).toHaveAttribute('href', /\/placecards\/.+\?context=/);
@@ -42,13 +43,23 @@ test.describe('Homepage Layout', () => {
         .filter((href): href is string => Boolean(href));
     });
 
-    expect(cardHrefs.length).toBeGreaterThanOrEqual(1);
+    expect(cardHrefs.length).toBeGreaterThanOrEqual(2);
     expect(cardHrefs.every((href) => href.startsWith('/placecards/'))).toBe(true);
 
-    const cardShell = page.locator('.place-card').first();
+    const cardLink = page.locator('a.place-card').first();
     await Promise.all([
       page.waitForURL(/\/placecards\//),
-      cardShell.click({ position: { x: 24, y: 24 } }),
+      cardLink.click({ position: { x: 24, y: 24 } }),
+    ]);
+    await expect(page).toHaveURL(/\/placecards\//);
+
+    await page.goBack({ waitUntil: 'networkidle' });
+
+    const footer = cardShell.locator('.place-card-footer');
+    await expect(footer).toBeVisible();
+    await Promise.all([
+      page.waitForURL(/\/placecards\//),
+      footer.click({ position: { x: 6, y: 10 } }),
     ]);
     await expect(page).toHaveURL(/\/placecards\//);
 

--- a/tests/place-card-links.test.tsx
+++ b/tests/place-card-links.test.tsx
@@ -7,10 +7,11 @@ describe('homepage place-card links', () => {
   test('keeps the homepage card click-through app-local and Maps as a button action', () => {
     const source = readFileSync(path.join(process.cwd(), 'app/_components/PlaceCard.tsx'), 'utf8');
 
-    assert.match(source, /role="link"/, 'expected the whole card wrapper to expose link semantics');
-    assert.match(source, /tabIndex=\{0\}/, 'expected the whole card wrapper to remain keyboard-focusable');
-    assert.match(source, /router\.push\(detailHref\)/, 'expected broad card activation to route to the detail page');
-    assert.match(source, /target\.closest\('a, button, input, textarea, select, summary, \[role="button"\]'\)/, 'expected embedded controls to opt out of the broad click handler');
+    assert.match(source, /className=\{`place-card-shell/, 'expected the broad click handler to live on the card shell wrapper');
+    assert.match(source, /<Link href=\{detailHref\} className="place-card"/, 'expected the main card body to remain an app-local link');
+    assert.match(source, /<Link href=\{detailHref\} className="place-card-detail-link"/, 'expected the footer detail CTA to remain an app-local link');
+    assert.match(source, /router\.push\(detailHref\)/, 'expected broad card-surface clicks to route to the detail page');
+    assert.match(source, /target\.closest\('a, button'\)/, 'expected embedded links and buttons to opt out of the broad click handler');
     assert.match(source, /<button[\s\S]*className="place-card-maps"/, 'expected the Maps action to render as a button');
     assert.doesNotMatch(source, /href=\{mapsUrl\}/, 'expected no external Maps anchor in the homepage card');
   });


### PR DESCRIPTION
## Summary
- route non-link clicks on the homepage place-card shell to the app-local detail page
- keep the existing internal card/detail links plus separate Maps, triage, and chat controls
- extend homepage coverage to include broad footer-surface clicks

## Testing
- npx tsx --test tests/place-card-links.test.tsx
- npx eslint app/_components/PlaceCard.tsx tests/e2e-homepage.spec.ts tests/place-card-links.test.tsx *(warnings only: existing no-img + unused-vars in legacy tests)*
- manual Playwright verification on localhost (reproduced footer miss on :3002 before the fix; verified body + footer click-through plus Maps/triage/chat behavior on a temporary local harness after the fix)

Closes #337