### PR TITLE
test: tighten homepage place-card click-shell coverage

### DIFF
--- a/app/_lib/card-adapter.ts
+++ b/app/_lib/card-adapter.ts
@@ -63,14 +63,31 @@ function normalizeType(raw?: string): DiscoveryType {
 export function adaptCard(raw: Record<string, unknown>, manifest?: Record<string, unknown>): PlaceCard {
   const manifestImages = manifest?.images as Array<{ path?: string; category?: string }> | undefined;
 
-  // Already V2 format?
-  if (raw.data && typeof raw.data === 'object' && raw.type) {
-    const v2 = raw as unknown as PlaceCard;
+  // Already V2 format, including lightweight stub cards that only have top-level fields.
+  if (raw.type && ('name' in raw || 'data' in raw)) {
+    const v2 = raw as Partial<PlaceCard> & {
+      address?: string;
+      city?: string;
+      rating?: number;
+      hero_image?: string | null;
+      heroImage?: string | null;
+    };
+    const baseImages = Array.isArray(v2.data?.images) ? v2.data.images : [];
+    const mergedImages = mergePlaceCardImages(baseImages, manifestImages);
+
     return {
-      ...v2,
+      place_id: v2.place_id ?? '',
+      name: v2.name ?? 'Unknown',
+      type: normalizeType(v2.type),
       data: {
+        description: typeof v2.data?.description === 'string' ? v2.data.description : '',
+        highlights: Array.isArray(v2.data?.highlights) ? v2.data.highlights : [],
         ...v2.data,
-        images: mergePlaceCardImages(v2.data.images, manifestImages),
+        images: mergedImages,
+        ...(v2.address ? { address: v2.address } : {}),
+        ...(v2.city ? { city: v2.city } : {}),
+        ...(v2.rating !== undefined ? { rating: v2.rating } : {}),
+        ...((v2.heroImage ?? v2.hero_image) ? { heroImage: v2.heroImage ?? v2.hero_image ?? undefined } : {}),
       },
     };
   }

--- a/tests/card-adapter.test.ts
+++ b/tests/card-adapter.test.ts
@@ -1,0 +1,32 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { adaptCard } from '../app/_lib/card-adapter';
+
+describe('adaptCard', () => {
+  test('preserves top-level fields from lightweight stub place cards', () => {
+    const card = adaptCard({
+      place_id: 'ChIJYRqEV39bwokRpz-hF0GXgaA',
+      name: 'Archestratus Books + Foods',
+      type: 'bookshop-cafe',
+      address: '160 Huron St, Brooklyn, NY 11222',
+      city: '',
+      rating: 4.8,
+      hero_image: null,
+      stub: true,
+    }, {
+      images: [
+        { path: 'https://example.com/photo.jpg', category: 'general' },
+      ],
+    });
+
+    assert.equal(card.name, 'Archestratus Books + Foods');
+    assert.equal(card.place_id, 'ChIJYRqEV39bwokRpz-hF0GXgaA');
+    assert.equal(card.type, 'restaurant');
+    assert.equal(card.data.address, '160 Huron St, Brooklyn, NY 11222');
+    assert.equal(card.data.rating, 4.8);
+    assert.deepEqual(card.data.images, [
+      { path: 'https://example.com/photo.jpg', category: 'general' },
+    ]);
+  });
+});

--- a/tests/place-card-links.test.tsx
+++ b/tests/place-card-links.test.tsx
@@ -8,10 +8,12 @@ describe('homepage place-card links', () => {
     const source = readFileSync(path.join(process.cwd(), 'app/_components/PlaceCard.tsx'), 'utf8');
 
     assert.match(source, /className=\{`place-card-shell/, 'expected the broad click handler to live on the card shell wrapper');
+    assert.match(source, /onClick=\{handleCardSurfaceClick\}/, 'expected the card shell wrapper to wire up the broad click handler');
     assert.match(source, /<Link href=\{detailHref\} className="place-card"/, 'expected the main card body to remain an app-local link');
     assert.match(source, /<Link href=\{detailHref\} className="place-card-detail-link"/, 'expected the footer detail CTA to remain an app-local link');
     assert.match(source, /router\.push\(detailHref\)/, 'expected broad card-surface clicks to route to the detail page');
     assert.match(source, /target\.closest\('a, button'\)/, 'expected embedded links and buttons to opt out of the broad click handler');
+    assert.match(source, /e\.preventDefault\(\);\s*e\.stopPropagation\(\);[\s\S]*window\.open\(mapsUrl, '_blank', 'noopener,noreferrer'\)/, 'expected the Maps button to opt out of shell navigation before opening Google Maps');
     assert.match(source, /<button[\s\S]*className="place-card-maps"/, 'expected the Maps action to render as a button');
     assert.doesNotMatch(source, /href=\{mapsUrl\}/, 'expected no external Maps anchor in the homepage card');
   });


### PR DESCRIPTION
## Summary
- confirm the homepage card shell explicitly wires the broad click handler
- assert the Maps button opts out of shell navigation before opening Google Maps
- document that the homepage tap/click fix itself was already present on the stacked base branch

## Verification
- `npx tsx --test tests/place-card-links.test.tsx`
- `npx eslint tests/place-card-links.test.tsx`
- manual Playwright checks on `localhost:3002` signed in as `john`:
  - first homepage `a.place-card` navigates to `/placecards/...`
  - triage buttons stay on `/`
  - chat button stays on `/` and marks the card as chat-targeted
  - Maps opens a separate Google Maps page
- direct navigation to `/placecards/ChIJYRqEV39bwokRpz-hF0GXgaA?context=trip%3Anyc-april-2026` still renders `Unknown`; split to follow-up issue #341

Refs #339
