### PR TITLE
fix: restore readiness smoke coverage

### DIFF
--- a/app/_lib/effective-user-data.ts
+++ b/app/_lib/effective-user-data.ts
@@ -2,7 +2,7 @@ import { deriveDiscoveryInventory } from './discovery-history';
 import { mergeDiscoveryInventories, mergeManifestInventories, readOwnerLocalDiscoveries, readOwnerLocalManifest } from './owner-local-inventory';
 import type { UserDiscoveries, UserManifest } from './types';
 import { getUserById } from './user';
-import { getUserDiscoveries, getUserManifest } from './user-data';
+import { getUserDiscoveries, getUserManifest, normalizeUserDiscoveries } from './user-data';
 
 function shouldUseOwnerLocalInventory(userId: string): boolean {
   return Boolean(getUserById(userId)?.isOwner);
@@ -24,7 +24,8 @@ export async function getWritableUserManifest(userId: string): Promise<UserManif
 export async function getEffectiveUserDiscoveries(userId: string): Promise<UserDiscoveries | null> {
   const discoveries = await getUserDiscoveries(userId);
   if (!shouldUseOwnerLocalInventory(userId)) return discoveries;
-  return mergeDiscoveryInventories(discoveries, readOwnerLocalDiscoveries());
+  const merged = mergeDiscoveryInventories(discoveries, readOwnerLocalDiscoveries());
+  return merged ? normalizeUserDiscoveries(merged) : null;
 }
 
 export async function getEffectiveDerivedUserDiscoveries(userId: string, historyLimit = 50): Promise<UserDiscoveries | null> {

--- a/app/_lib/user-data.ts
+++ b/app/_lib/user-data.ts
@@ -191,11 +191,14 @@ const TYPE_NORMALIZATION: Record<string, string> = {
   'live-music': 'music-venue',
   'live_music': 'music-venue',
   'live_music_venue': 'music-venue',
+  'live_music_bar': 'music-venue',
   'live music': 'music-venue',
   'live music venue': 'music-venue',
   'venue': 'music-venue',
   'comedy': 'theatre',
   'exhibition': 'gallery',
+  'art_gallery': 'gallery',
+  'art_museum': 'museum',
   'wine-bar': 'bar',
   'wine_bar': 'bar',
   'cocktail-bar': 'bar',
@@ -209,6 +212,7 @@ const TYPE_NORMALIZATION: Record<string, string> = {
   'specialty-shop': 'shop',
   'bookstore': 'shop',
   'bookshop': 'shop',
+  'book_store': 'shop',
   'street_art': 'gallery',
   'outdoor': 'park',
   'hiking trail': 'park',
@@ -219,9 +223,17 @@ const TYPE_NORMALIZATION: Record<string, string> = {
 
 function normalizeType(type: string | undefined | null): string {
   if (!type) return 'restaurant';
-  if (VALID_DISCOVERY_TYPES.has(type)) return type;
-  const mapped = TYPE_NORMALIZATION[type.toLowerCase()];
+  const normalized = type.toLowerCase().trim().replace(/\s+/g, '_');
+  if (VALID_DISCOVERY_TYPES.has(normalized)) return normalized;
+  const mapped = TYPE_NORMALIZATION[normalized];
   if (mapped) return mapped;
+  if (normalized.endsWith('_restaurant')) return 'restaurant';
+  if (normalized.endsWith('_gallery')) return 'gallery';
+  if (normalized.endsWith('_museum')) return 'museum';
+  if (normalized.endsWith('_park')) return 'park';
+  if (normalized.endsWith('_bar') || normalized.endsWith('_pub')) return 'bar';
+  if (normalized.endsWith('_bakery') || normalized.endsWith('_cafe') || normalized.endsWith('_coffee_shop')) return 'cafe';
+  if (normalized.endsWith('_store') || normalized.endsWith('_shop')) return 'shop';
   return 'restaurant'; // ultimate fallback
 }
 
@@ -261,7 +273,147 @@ function normalizeContextKey(key: string | undefined | null): string {
   return k;
 }
 
-function normalizeDiscoveries(raw: UserDiscoveries | Discovery[]): UserDiscoveries {
+function normalizeCityCandidate(city: string | undefined | null): string {
+  if (!city) return '';
+  return city
+    .replace(/^\d{4,6}\s+/, '')
+    .replace(/\s+[A-Z]{2}\s+[A-Z0-9 -]+$/i, '')
+    .replace(/\s+[A-Z]\d[A-Z]\s*\d[A-Z]\d$/i, '')
+    .trim();
+}
+
+function inferCityFromAddress(address: string | undefined | null): string {
+  if (!address) return '';
+
+  const parts = address.split(',').map((part) => part.trim()).filter(Boolean);
+  if (parts.length === 0) return '';
+
+  let candidate = '';
+  if (parts.length >= 4) {
+    candidate = parts[parts.length - 3] || '';
+  } else if (parts.length === 3) {
+    const middle = parts[1] || '';
+    const tail = parts[2] || '';
+    const middleLooksLikeStreet = /^\d/.test(middle) || /\b(st|street|ave|avenue|rd|road|blvd|boulevard|dr|drive|ln|lane|way|pl|place|square)\b/i.test(middle);
+    const tailLooksLikeCountry = /^(usa|canada|france|uk|united kingdom)$/i.test(tail);
+    candidate = middleLooksLikeStreet ? tail : (tailLooksLikeCountry ? middle : middle || tail);
+  } else if (parts.length >= 2) {
+    candidate = parts[1] || '';
+  }
+
+  const cleaned = normalizeCityCandidate(candidate);
+  if (!cleaned) return '';
+  if (/^(usa|canada|france|uk|united kingdom|ontario|quebec|ny|on|qc)$/i.test(cleaned)) {
+    return '';
+  }
+  return cleaned;
+}
+
+function inferCityFromContext(contextKey: string | undefined | null): string {
+  const key = (contextKey || '').toLowerCase();
+  if (!key) return '';
+  if (key.includes('brooklyn')) return 'Brooklyn';
+  if (key.includes('nyc') || key.includes('new-york') || key.includes('manhattan')) return 'New York';
+  if (key.includes('toronto')) return 'Toronto';
+  if (key.includes('paris')) return 'Paris';
+  if (key.includes('montreal')) return 'Montreal';
+  if (key.includes('boston')) return 'Boston';
+  return '';
+}
+
+function normalizeCity(params: {
+  city?: string | null;
+  address?: string | null;
+  contextKey?: string | null;
+}): string {
+  const normalizedContextKey = normalizeContextKey(params.contextKey);
+  const normalizedCity = normalizeCityCandidate(params.city);
+  const inferredFromAddress = inferCityFromAddress(params.address);
+  const inferredFromContext = inferCityFromContext(normalizedContextKey);
+
+  if (!normalizedCity) {
+    return inferredFromAddress || inferredFromContext || '';
+  }
+
+  if (/^toronto$/i.test(normalizedCity) && inferredFromContext && !/^toronto$/i.test(inferredFromContext)) {
+    return inferredFromAddress || inferredFromContext;
+  }
+
+  return normalizedCity;
+}
+
+function inferContextKey(contextKey: string | undefined | null, city: string | undefined | null): string {
+  const normalized = normalizeContextKey(contextKey);
+  if (normalized) return normalized;
+  const normalizedCity = normalizeCityCandidate(city);
+  if (!normalizedCity) return '';
+  const slug = normalizedCity.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return slug ? `radar:${slug}` : '';
+}
+
+function normalizeDiscoveryKey(discovery: Pick<Discovery, 'place_id' | 'contextKey' | 'name'>): string {
+  if (discovery.place_id && discovery.contextKey) return `place:${discovery.place_id}:${discovery.contextKey}`;
+  const normalizedName = (discovery.name || '').toLowerCase().replace(/[^a-z0-9 ]/g, '').replace(/\s+/g, ' ').trim();
+  return `name:${normalizedName}:${discovery.contextKey || ''}`;
+}
+
+function discoveryCompletenessScore(discovery: Partial<Discovery>): number {
+  return [
+    discovery.place_id,
+    discovery.address,
+    discovery.city,
+    discovery.heroImage,
+    discovery.source,
+    discovery.description,
+    discovery.rating,
+    discovery.match,
+  ].filter((value) => value !== undefined && value !== null && value !== '').length;
+}
+
+function mergeDiscoveryRecords(existing: Discovery, incoming: Discovery): Discovery {
+  const existingTime = Date.parse(existing.discoveredAt || '') || 0;
+  const incomingTime = Date.parse(incoming.discoveredAt || '') || 0;
+  const preferred = incomingTime >= existingTime ? incoming : existing;
+  const fallback = preferred === incoming ? existing : incoming;
+
+  return {
+    ...fallback,
+    ...preferred,
+    id: preferred.id || fallback.id,
+    name: preferred.name !== 'Unknown Place' ? preferred.name : fallback.name,
+    address: preferred.address || fallback.address,
+    city: preferred.city || fallback.city,
+    type: preferred.type !== 'restaurant' || !fallback.type ? preferred.type : fallback.type,
+    heroImage: preferred.heroImage || fallback.heroImage,
+    rating: preferred.rating ?? fallback.rating,
+    match: preferred.match ?? fallback.match,
+    source: preferred.source !== 'v1:migrated' ? preferred.source : fallback.source,
+    discoveredAt: existingTime >= incomingTime ? existing.discoveredAt : incoming.discoveredAt,
+  };
+}
+
+function dedupeDiscoveries(discoveries: Discovery[]): Discovery[] {
+  const deduped = new Map<string, Discovery>();
+
+  for (const discovery of discoveries) {
+    const key = normalizeDiscoveryKey(discovery);
+    const existing = deduped.get(key);
+
+    if (!existing) {
+      deduped.set(key, discovery);
+      continue;
+    }
+
+    const merged = mergeDiscoveryRecords(existing, discovery);
+    const existingScore = discoveryCompletenessScore(existing);
+    const incomingScore = discoveryCompletenessScore(discovery);
+    deduped.set(key, incomingScore >= existingScore ? merged : mergeDiscoveryRecords(discovery, existing));
+  }
+
+  return Array.from(deduped.values());
+}
+
+export function normalizeUserDiscoveries(raw: UserDiscoveries | Discovery[]): UserDiscoveries {
   // V1→V2 compatibility: V1 stores as raw array, V2 expects { discoveries: [...] }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const rawAny = raw as any;
@@ -272,29 +424,37 @@ function normalizeDiscoveries(raw: UserDiscoveries | Discovery[]): UserDiscoveri
       : [];
 
   // Normalize all fields for V1→V2 compatibility
-  const normalized = rawArray.map((d, i) => ({
-    ...d,
-    id: (d.id as string) || `v1_${i}`,
-    name: (d.name as string) || 'Unknown Place',
-    city: (d.city as string) || 'Toronto',
-    type: (() => {
-      // Priority: authoritative type from place card index (for cards with place_id)
-      const placeId = d.place_id as string | undefined;
-      const indexed = lookupTypeFromIndex(placeId);
-      if (indexed && VALID_DISCOVERY_TYPES.has(indexed)) return indexed;
-      // Fallback: normalize incoming type or infer from name
-      if (d.type) return normalizeType(d.type as string);
-      return inferTypeFromName(d.name as string);
-    })(),
-    rating: d.rating != null ? Number(d.rating) || undefined : undefined,
-    contextKey: normalizeContextKey(d.contextKey as string),
-    discoveredAt: (d.discoveredAt as string) || new Date().toISOString(),
-    placeIdStatus: (d.placeIdStatus as string) || (d.place_id ? 'verified' : 'missing'),
-    source: (d.source as string) || 'v1:migrated',
-  }));
+  const normalized = rawArray.map((d, i) => {
+    const city = normalizeCity({
+      city: d.city as string | null | undefined,
+      address: d.address as string | null | undefined,
+      contextKey: d.contextKey as string | null | undefined,
+    });
+
+    return {
+      ...d,
+      id: (d.id as string) || `v1_${i}`,
+      name: (d.name as string) || 'Unknown Place',
+      city,
+      type: (() => {
+        // Priority: authoritative type from place card index (for cards with place_id)
+        const placeId = d.place_id as string | undefined;
+        const indexed = lookupTypeFromIndex(placeId);
+        if (indexed && VALID_DISCOVERY_TYPES.has(indexed)) return indexed;
+        // Fallback: normalize incoming type or infer from name
+        if (d.type) return normalizeType(d.type as string);
+        return inferTypeFromName(d.name as string);
+      })(),
+      rating: d.rating != null ? Number(d.rating) || undefined : undefined,
+      contextKey: inferContextKey(d.contextKey as string | null | undefined, city),
+      discoveredAt: (d.discoveredAt as string) || new Date().toISOString(),
+      placeIdStatus: (d.placeIdStatus as string) || (d.place_id ? 'verified' : 'missing'),
+      source: (d.source as string) || 'v1:migrated',
+    };
+  }) as Discovery[];
 
   return {
-    discoveries: normalized,
+    discoveries: dedupeDiscoveries(normalized),
     updatedAt: !Array.isArray(rawAny) && typeof rawAny?.updatedAt === 'string'
       ? rawAny.updatedAt
       : new Date().toISOString(),
@@ -304,7 +464,7 @@ function normalizeDiscoveries(raw: UserDiscoveries | Discovery[]): UserDiscoveri
 export async function getUserDiscoveries(userId: string): Promise<UserDiscoveries | null> {
   const raw = await getUserData(userId, 'discoveries');
   if (!raw) return null;
-  return normalizeDiscoveries(raw as UserDiscoveries | Discovery[]);
+  return normalizeUserDiscoveries(raw as UserDiscoveries | Discovery[]);
 }
 
 export async function getDerivedUserDiscoveries(userId: string, historyLimit = 50): Promise<UserDiscoveries | null> {

--- a/app/api/user/discoveries/route.ts
+++ b/app/api/user/discoveries/route.ts
@@ -4,6 +4,7 @@ import { put, list, del } from '@vercel/blob';
 import { COOKIE_NAME, getUserById } from '../../../_lib/user';
 import type { Discovery, DiscoveryType, PlaceIdStatus } from '../../../_lib/types';
 import { recordDiscoveryHistoryEvent } from '../../../_lib/discovery-history';
+import { getEffectiveUserDiscoveries, getEffectiveUserManifest } from '../../../_lib/effective-user-data';
 
 export const dynamic = 'force-dynamic';
 
@@ -195,7 +196,17 @@ export async function GET() {
   const user = getUserById(userId);
   if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
-  const discoveries = await readRawDiscoveries(userId);
+  const [effective, manifest] = await Promise.all([
+    getEffectiveUserDiscoveries(userId),
+    getEffectiveUserManifest(userId),
+  ]);
+  const fallbackContextKey = manifest?.contexts.find((context) => context.key.startsWith('radar:'))?.key
+    ?? manifest?.contexts[0]?.key
+    ?? 'radar:toronto-experiences';
+  const discoveries = (effective?.discoveries ?? []).map((discovery) => ({
+    ...discovery,
+    contextKey: discovery.contextKey || fallbackContextKey,
+  }));
   return NextResponse.json({ discoveries, count: discoveries.length });
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -7274,6 +7274,7 @@ nextjs-portal { display: none !important; }
   .focused-hero-title-trip {
     font-size: 1.5rem !important;
   }
+}
 
 /* ---- Monitoring tray: change signals ---- */
 

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -78,10 +78,15 @@ async function run() {
     assert(!html.includes('data-next-error'), 'Page has React error');
   });
 
-  await test('Homepage has ≥5 context sections', async () => {
+  await test('Homepage exposes focused context UI with ≥5 contexts in manifest', async () => {
     const html = await fetchHTML('/');
-    const sections = (html.match(/section-header/g) || []).length;
-    assert(sections >= 5, `Only ${sections} sections (need ≥5)`);
+    const hasContextUi = html.includes('focused-hero') || html.includes('section-header') || html.includes('ctx-switcher-label');
+    assert(hasContextUi, 'Homepage has no context hero/switcher UI');
+
+    const data = await fetchJSON('/api/user/manifest');
+    if (data._auth) return;
+    const contexts = data.contexts || [];
+    assert(contexts.length >= 5, `Only ${contexts.length} contexts in manifest (need ≥5)`);
   });
 
   await test('Homepage has ≥10 place cards', async () => {
@@ -152,8 +157,8 @@ async function run() {
   console.log('\n  — Hero Image URLs —');
 
   await test('Hero image URLs return 200', async () => {
-    const blobUrlRe = /https:\/\/[a-z0-9]+\.public\.blob\.vercel-storage\.com\/[^\s"'<>]+/g;
-    const urls = [...new Set((detailHtml.match(blobUrlRe) || []).filter(u => u.match(/\.(jpg|jpeg|png|webp)/i)).slice(0, 3))];
+    const blobUrlRe = /https:\/\/[a-z0-9]+\.public\.blob\.vercel-storage\.com\/[^\s"'<>\)]+/g;
+    const urls = [...new Set((detailHtml.match(blobUrlRe) || []).map(u => u.replace(/[),]+$/, '')).filter(u => u.match(/\.(jpg|jpeg|png|webp)/i)).slice(0, 3))];
     if (urls.length === 0) return; // no images to check on this card — pass
     for (const url of urls) {
       const res = await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(5000) });


### PR DESCRIPTION
## Summary
- normalize signed-in discovery reads so the readiness smoke suite sees valid city/context/type data with duplicate place IDs collapsed
- re-normalize owner-local merged discoveries before returning the effective inventory so owner-local + blob data don't leak raw invalid records
- fix smoke drift for the focused homepage UI and blob hero-image URL parsing from CSS `url(...)`
- close the broken mobile homepage CSS media block so the branch builds cleanly in a fresh checkout

## Root cause
- the homepage "0 context sections" failure was smoke drift: the UI moved to a focused hero/context-switcher layout, so the old `section-header` count no longer matched the product
- the hero-image 404 was also smoke drift: the regex was capturing a trailing `)` from CSS `url(...)`
- the city / duplicate place ID / invalid type failures were real read-model issues in signed-in discoveries, where raw-ish records were exposed without enough normalization/deduping
- during clean-checkout verification, `app/globals.css` also turned out to have an unclosed mobile media block; that had been masked by the original dirty worktree

## Verification
- `node scripts/smoke-test.mjs http://127.0.0.1:3104` ✅ 36/36 passed on a fresh verification worktree
- homepage Playwright spec against the branch-local server with a temporary 3104 baseURL override ✅ 13/13 passed

Closes #343