### PR TITLE
test: lock homepage readiness interactions for john

### DIFF
--- a/tests/homepage-readiness.spec.ts
+++ b/tests/homepage-readiness.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect, devices, type Page, type Browser } from '@playwright/test';
+
+async function seedJohnCookie(page: Page) {
+  await page.context().addCookies([
+    {
+      name: 'compass-user',
+      value: 'john',
+      url: 'http://localhost:3002',
+    },
+  ]);
+}
+
+async function openHomepageAsJohn(page: Page) {
+  await seedJohnCookie(page);
+  await page.goto('/', { waitUntil: 'networkidle' });
+  await page.waitForTimeout(1000);
+}
+
+async function newJohnMobilePage(browser: Browser) {
+  const context = await browser.newContext({
+    ...devices['iPhone 14'],
+    baseURL: 'http://localhost:3002',
+    storageState: undefined,
+  });
+  const page = await context.newPage();
+  await seedJohnCookie(page);
+  await page.goto('/', { waitUntil: 'networkidle' });
+  await page.waitForTimeout(1000);
+  return { context, page };
+}
+
+test.describe('homepage readiness for john', () => {
+  test('focused homepage still exposes multiple contexts via the switcher', async ({ page }) => {
+    await openHomepageAsJohn(page);
+
+    const switcher = page.locator('.ctx-switcher-trigger');
+    await expect(switcher).toBeVisible();
+    await expect(page.locator('.focused-hero-title').first()).toBeVisible();
+
+    await switcher.click();
+
+    const options = page.locator('.ctx-switcher-option');
+    await expect(options.first()).toBeVisible();
+    expect(await options.count()).toBeGreaterThanOrEqual(5);
+    await expect(page.locator('.ctx-switcher-group-label').first()).toContainText(/Trips|Outings|Radars/);
+  });
+
+  test('homepage place cards keep triage, chat, and maps controls visible', async ({ page }) => {
+    await openHomepageAsJohn(page);
+
+    const firstCard = page.locator('a.place-card').first();
+    await expect(firstCard).toBeVisible();
+
+    const cardShell = firstCard.locator('xpath=..');
+    const triageButtons = cardShell.locator('.place-card-triage-overlay .triage-btn');
+    await expect(triageButtons).toHaveCount(2);
+    await expect(triageButtons.first()).toBeVisible();
+    await expect(cardShell.getByRole('button', { name: /chat about/i })).toBeVisible();
+
+    const mapsLink = cardShell.locator('.place-card-maps');
+    await expect(mapsLink).toBeVisible();
+    await expect(mapsLink).toHaveAttribute('href', /google\.com\/maps/);
+    await expect(mapsLink).toHaveAttribute('target', '_blank');
+  });
+
+  test('clicking the first homepage place card navigates to detail', async ({ page }) => {
+    await openHomepageAsJohn(page);
+
+    const firstCard = page.locator('a.place-card').first();
+    await expect(firstCard).toBeVisible();
+
+    await Promise.all([
+      page.waitForURL(/\/placecards\//),
+      firstCard.click({ position: { x: 24, y: 24 } }),
+    ]);
+
+    await expect(page).toHaveURL(/\/placecards\//);
+  });
+});
+
+test('homepage readiness for john on mobile: tapping the first place card navigates to detail', async ({ browser }) => {
+  const { context, page } = await newJohnMobilePage(browser);
+
+  try {
+    const firstCard = page.locator('a.place-card').first();
+    await expect(firstCard).toBeVisible();
+
+    await Promise.all([
+      page.waitForURL(/\/placecards\//),
+      firstCard.tap({ position: { x: 24, y: 24 } }),
+    ]);
+
+    await expect(page).toHaveURL(/\/placecards\//);
+  } finally {
+    await context.close();
+  }
+});

--- a/tests/place-card-links.test.tsx
+++ b/tests/place-card-links.test.tsx
@@ -1,0 +1,46 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+
+describe('homepage place-card composition', () => {
+  test('keeps the detail route app-local while preserving secondary controls', () => {
+    const source = readFileSync(path.join(process.cwd(), 'app/_components/PlaceCard.tsx'), 'utf8');
+
+    assert.match(
+      source,
+      /<Link href=\{`\/placecards\/\$\{place_id \|\| id\}\?context=\$\{encodeURIComponent\(contextKey\)\}`\} className="place-card">/,
+      'expected the main card body to stay an app-local Next link',
+    );
+    assert.match(
+      source,
+      /className="place-card-maps"/,
+      'expected the Google Maps action to remain present on homepage cards',
+    );
+    assert.match(
+      source,
+      /target="_blank" rel="noopener noreferrer" className="place-card-maps"/,
+      'expected the Maps action to stay external and isolated from Compass navigation',
+    );
+    assert.match(
+      source,
+      /className="place-card-triage-overlay"/,
+      'expected the triage overlay wrapper to stay rendered outside the main card link',
+    );
+    assert.match(
+      source,
+      /<TriageButtons userId=\{userId\} contextKey=\{contextKey\} placeId=\{place_id\} size="sm" \/>/,
+      'expected homepage cards to keep inline triage controls',
+    );
+    assert.match(
+      source,
+      /className=\{`place-card-chat-btn\$\{isChatTarget \? ' place-card-chat-btn-active' : ''\}`\}/,
+      'expected the chat-about affordance to remain wired on homepage cards',
+    );
+    assert.match(
+      source,
+      /onClick=\{handleChatAbout\}/,
+      'expected the chat-about button to preserve its dedicated click handler',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a john-scoped Playwright readiness spec for the focused homepage on localhost:3002
- verify the context switcher still exposes multiple contexts even though the homepage is single-track
- lock in homepage place-card detail navigation plus visible triage/chat/maps controls

## Verification
- node --import tsx --test tests/place-card-links.test.tsx
- npx playwright test tests/homepage-readiness.spec.ts
