### PR TITLE
Tighten homepage clickthrough readiness checks

### DIFF
--- a/smoke-check.mjs
+++ b/smoke-check.mjs
@@ -14,7 +14,7 @@ try {
   result.details.homeStatus = resp?.status();
   await page.waitForTimeout(1500); // let client hydrate
 
-  const cardLinks = page.locator('a[href*="/placecards/"]');
+  const cardLinks = page.locator('a.place-card');
   const cardCount = await cardLinks.count();
   result.details.cardCount = cardCount;
   result.homepage = (resp?.status() === 200) && cardCount > 0;
@@ -31,15 +31,43 @@ try {
   result.details.brokenImages = brokenImages;
   result.imagesOk = imgCount === 0 || brokenImages.length === 0;
 
-  // Place click — cards open /placecards/ route
+  // Place click — verify the live homepage uses the fixed shell structure and real click-through.
   if (cardCount > 0) {
-    const firstHref = await cardLinks.first().getAttribute('href');
+    const firstCard = cardLinks.first();
+    const firstHref = await firstCard.getAttribute('href');
+    const cardShell = firstCard.locator('xpath=..');
+    const mapsControl = cardShell.locator('.place-card-maps').first();
+    const detailLink = cardShell.locator('.place-card-detail-link').first();
+
     result.details.firstHref = firstHref;
-    const cardPage = await context.newPage();
-    const cardResp = await cardPage.goto(base + firstHref, { waitUntil: 'networkidle', timeout: 30000 });
-    result.details.placeUrl = cardPage.url();
-    result.placeClick = (cardResp?.status() || 0) < 400;
-    await cardPage.close();
+    result.details.firstCardShellClass = await cardShell.getAttribute('class');
+    result.details.firstCardHasDetailLink = await detailLink.count().then((count) => count > 0);
+    result.details.firstCardMapsTag = await mapsControl.count().then(async (count) => count > 0 ? mapsControl.evaluate((el) => el.tagName) : null);
+
+    await Promise.all([
+      page.waitForURL(/\/placecards\//, { timeout: 10000 }),
+      firstCard.click({ position: { x: 24, y: 24 } }),
+    ]);
+    result.details.placeUrl = page.url();
+    result.placeClick = /\/placecards\//.test(page.url());
+
+    await page.goBack({ waitUntil: 'networkidle', timeout: 10000 });
+    await page.waitForTimeout(1000);
+
+    const footer = page.locator('a.place-card').first().locator('xpath=..').locator('.place-card-footer');
+    if (await footer.count()) {
+      try {
+        await Promise.all([
+          page.waitForURL(/\/placecards\//, { timeout: 5000 }),
+          footer.click({ position: { x: 6, y: 10 } }),
+        ]);
+        result.details.footerGapClick = true;
+        await page.goBack({ waitUntil: 'networkidle', timeout: 10000 });
+        await page.waitForTimeout(1000);
+      } catch {
+        result.details.footerGapClick = false;
+      }
+    }
   }
 
   // Triage — look for save/dismiss buttons on the homepage

--- a/tests/homepage-readiness.spec.ts
+++ b/tests/homepage-readiness.spec.ts
@@ -1,11 +1,13 @@
 import { test, expect, devices, type Page, type Browser } from '@playwright/test';
 
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3002';
+
 async function seedJohnCookie(page: Page) {
   await page.context().addCookies([
     {
       name: 'compass-user',
       value: 'john',
-      url: 'http://localhost:3002',
+      url: BASE_URL,
     },
   ]);
 }
@@ -19,7 +21,7 @@ async function openHomepageAsJohn(page: Page) {
 async function newJohnMobilePage(browser: Browser) {
   const context = await browser.newContext({
     ...devices['iPhone 14'],
-    baseURL: 'http://localhost:3002',
+    baseURL: BASE_URL,
     storageState: undefined,
   });
   const page = await context.newPage();
@@ -27,6 +29,36 @@ async function newJohnMobilePage(browser: Browser) {
   await page.goto('/', { waitUntil: 'networkidle' });
   await page.waitForTimeout(1000);
   return { context, page };
+}
+
+async function expectCardCenterToNavigate(page: Page, mode: 'mouse' | 'tap' = 'mouse') {
+  const firstCard = page.locator('a.place-card').first();
+  await expect(firstCard).toBeVisible();
+
+  const box = await firstCard.boundingBox();
+  expect(box).not.toBeNull();
+  if (!box) return;
+
+  const x = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+  const topElement = await page.evaluate(([clickX, clickY]) => {
+    const node = document.elementFromPoint(clickX, clickY);
+    if (!node) return null;
+    return {
+      tag: node.tagName,
+      className: node instanceof HTMLElement ? node.className : '',
+    };
+  }, [x, y]);
+
+  expect(topElement?.className ?? '').not.toContain('ChatWidget');
+
+  if (mode === 'tap') {
+    await page.touchscreen.tap(x, y);
+  } else {
+    await page.mouse.click(x, y);
+  }
+  await page.waitForURL(/\/placecards\//);
+  await expect(page).toHaveURL(/\/placecards\//);
 }
 
 test.describe('homepage readiness for john', () => {
@@ -45,52 +77,61 @@ test.describe('homepage readiness for john', () => {
     await expect(page.locator('.ctx-switcher-group-label').first()).toContainText(/Trips|Outings|Radars/);
   });
 
-  test('homepage place cards keep triage, chat, and maps controls visible', async ({ page }) => {
+  test('homepage place cards keep the fixed click-shell structure and controls visible', async ({ page }) => {
     await openHomepageAsJohn(page);
 
     const firstCard = page.locator('a.place-card').first();
     await expect(firstCard).toBeVisible();
 
     const cardShell = firstCard.locator('xpath=..');
+    await expect(cardShell).toHaveClass(/place-card-shell/);
+
     const triageButtons = cardShell.locator('.place-card-triage-overlay .triage-btn');
     await expect(triageButtons).toHaveCount(2);
     await expect(triageButtons.first()).toBeVisible();
     await expect(cardShell.getByRole('button', { name: /chat about/i })).toBeVisible();
 
-    const mapsLink = cardShell.locator('.place-card-maps');
-    await expect(mapsLink).toBeVisible();
-    await expect(mapsLink).toHaveAttribute('href', /google\.com\/maps/);
-    await expect(mapsLink).toHaveAttribute('target', '_blank');
+    const detailLink = cardShell.locator('.place-card-detail-link');
+    await expect(detailLink).toBeVisible();
+    await expect(detailLink).toHaveAttribute('href', /\/placecards\/.+\?context=/);
+
+    const mapsButton = cardShell.locator('.place-card-maps');
+    await expect(mapsButton).toBeVisible();
+    await expect(mapsButton).toHaveText(/maps/i);
+    await expect(mapsButton.evaluate((el) => el.tagName)).resolves.toBe('BUTTON');
   });
 
-  test('clicking the first homepage place card navigates to detail', async ({ page }) => {
+  test('clicking the visible center of the first homepage place card navigates to detail', async ({ page }) => {
+    await openHomepageAsJohn(page);
+    await expectCardCenterToNavigate(page, 'mouse');
+  });
+
+  test('clicking footer whitespace on the first homepage place card still navigates to detail', async ({ page }) => {
     await openHomepageAsJohn(page);
 
     const firstCard = page.locator('a.place-card').first();
     await expect(firstCard).toBeVisible();
 
+    const cardShell = firstCard.locator('xpath=..');
+    await expect(cardShell).toHaveClass(/place-card-shell/);
+
+    const footer = cardShell.locator('.place-card-footer');
+    await expect(footer).toBeVisible();
+
     await Promise.all([
       page.waitForURL(/\/placecards\//),
-      firstCard.click({ position: { x: 24, y: 24 } }),
+      footer.click({ position: { x: 6, y: 10 } }),
     ]);
 
     await expect(page).toHaveURL(/\/placecards\//);
   });
 });
 
-test('homepage readiness for john on mobile: tapping the first place card navigates to detail', async ({ browser }) => {
+test('homepage readiness for john on mobile: tapping the visible center of the first place card navigates to detail', async ({ browser }) => {
   const { context, page } = await newJohnMobilePage(browser);
 
   try {
-    const firstCard = page.locator('a.place-card').first();
-    await expect(firstCard).toBeVisible();
-
-    await Promise.all([
-      page.waitForURL(/\/placecards\//),
-      firstCard.tap({ position: { x: 24, y: 24 } }),
-    ]);
-
-    await expect(page).toHaveURL(/\/placecards\//);
+    await expectCardCenterToNavigate(page, 'tap');
   } finally {
     await context.close();
   }


### PR DESCRIPTION
## Summary
- tighten homepage readiness coverage to assert the fixed clickable card shell structure
- add center-click + footer-gap navigation checks so stale pre-fix card markup is caught
- upgrade `smoke-check.mjs` to inspect live card structure instead of only direct-goto place URLs

## Why
Issue #351 turned out to be a live-build mismatch: `localhost:3002` is still serving the older homepage card markup (no `.place-card-shell`, no `.place-card-detail-link`, maps rendered as an external anchor), so direct anchor clicks can pass while footer-gap clicks stay on `/`.

## Verification
- `npx playwright test tests/homepage-readiness.spec.ts --reporter=line` against `http://localhost:3002` now fails on the stale structure/clickthrough mismatch
- `PLAYWRIGHT_BASE_URL=http://localhost:3003 npx playwright test tests/homepage-readiness.spec.ts --reporter=line --config=playwright.3003.config.ts`
- `node smoke-check.mjs http://localhost:3002`
- manual Playwright verification against `http://localhost:3003` for homepage clickthrough, triage/chat/maps, admin, and review
